### PR TITLE
DOC-10800: Migrate how-to guides to docs-devex

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -1,2 +1,2 @@
-name: server
-version: '7.2'
+name: cloud
+version: master


### PR DESCRIPTION
This is a follow-up to #3 and #4, which added the how-to guides to the `docs-devex` repo in the `release/7.2` and `capella` branches, respectively.

This change updates the version coordinates for the `capella` branch, so that the how-to guides can be pulled into the cloud documentation. See also:

* [couchbase/docs-site#655](https://github.com/couchbase/docs-site/pull/655)
* [couchbase/docs-server#3069](https://github.com/couchbase/docs-server/pull/3069)

Docs issue: DOC-10800