### PR TITLE
DOC-10801: Migrate tutorial and JavaScript UDFs to docs-devex

### DIFF
--- a/modules/guides/partials/other-guide.adoc
+++ b/modules/guides/partials/other-guide.adoc
@@ -3,5 +3,5 @@ ifdef::page-topic-type[{page-topic-type}]
 ifndef::page-topic-type[page]
 is for Couchbase Server.
 // tag::link[]
-For Couchbase Capella, see xref:cloud:guides:{docname}.adoc[].
+ifdef::escape-hatch[For Couchbase Capella, see xref:cloud:guides:{docname}.adoc[].]
 // end::link[]

--- a/modules/javascript-udfs/pages/calling-javascript-from-n1ql.adoc
+++ b/modules/javascript-udfs/pages/calling-javascript-from-n1ql.adoc
@@ -3,13 +3,14 @@
 :page-edition: Enterprise Edition
 :page-toclevels: 2
 :keywords: scopes, variadic
+
 [abstract]
 {description}
 
 == Introduction
 
 Before you can call a JavaScript function, you must first create a {sqlpp} User-Defined Function to call it.
-The process to do this is explained in the  xref:guides:create-user-defined-function.adoc#creating-the-n1ql-udf-function[Creating the {sqlpp} User-Defined Function] section of our xref:guides:javascript-udfs.adoc[] guide.
+The process to do this is explained in the xref:guides:create-user-defined-function.adoc#creating-the-n1ql-udf-function[Creating the {sqlpp} User-Defined Function] section of our xref:guides:javascript-udfs.adoc[] guide.
 
 If you are unfamiliar with creating User-Defined Functions to call JavaScript, then the xref:guides:javascript-udfs.adoc[guide] is the best place to start.
 

--- a/modules/javascript-udfs/pages/calling-n1ql-from-javascript.adoc
+++ b/modules/javascript-udfs/pages/calling-n1ql-from-javascript.adoc
@@ -174,7 +174,7 @@ include::example$do-recursion-response.jsonc[]
 ====
 The JavaScript workers are created when the Couchbase server is started up.
 
-latexmath:[Number\:of\:JavaScript\:workers = 4 \times number\:of\:CPUs]
+asciimath:["Number of JavaScript Workers" = 4 xx "Number of CPUs"]
 
 The service will automatically prevent recursive calls if there are less than 50% javascript workers available
 

--- a/modules/javascript-udfs/pages/javascript-functions-with-couchbase.adoc
+++ b/modules/javascript-udfs/pages/javascript-functions-with-couchbase.adoc
@@ -1,5 +1,5 @@
 = JavaScript Functions with Couchbase
-:description: Writing Couchbase Server extension functions in the JavaScript Language.
+:description: Writing Couchbase extension functions in the JavaScript Language.
 :page-edition: Enterprise Edition
 :page-toclevels: 2
 

--- a/modules/tutorials/pages/python-tutorial/install-couchbase-python-sdk.adoc
+++ b/modules/tutorials/pages/python-tutorial/install-couchbase-python-sdk.adoc
@@ -1,5 +1,8 @@
 = Installing the Couchbase Python SDK
 :description: pass:q[In this tutorial, you're going to create a skeleton application for interacting with the student database you created in xref:install-couchbase-server.adoc[]]
+ifndef::python-tutorial[]
+:page-embargo: EMBARGOED
+endif::[]
 :page-pagination: full
 
 include::partial$tutorial-globals.adoc[]


### PR DESCRIPTION
Follow-up to #10. Minor fixes on the server side. In particular, hides "escape hatch" links until the Capella devex docs are published.

Docs issue: DOC-10801