### PR TITLE
DOC-10801: Migrate tutorial and JavaScript UDFs to docs-devex

### DIFF
--- a/modules/develop/pages/intro.adoc
+++ b/modules/develop/pages/intro.adoc
@@ -23,6 +23,8 @@ endif::[]
 {description}
 It also provides links to the documentation for software development kits and starter kits.
 
+include::partial$escape-hatch.adoc[]
+
 == Developer Tutorial
 
 This tutorial provides an introductory worked example for developers, showing how to use a software development kit with a simple database.

--- a/modules/develop/partials/escape-hatch.adoc
+++ b/modules/develop/partials/escape-hatch.adoc
@@ -1,0 +1,7 @@
+This
+ifdef::page-topic-type[{page-topic-type}]
+ifndef::page-topic-type[page]
+is for Couchbase Server.
+// tag::link[]
+ifdef::escape-hatch[For Couchbase Capella, see xref:cloud:develop:{docname}.adoc[].]
+// end::link[]


### PR DESCRIPTION
Follow-up to #11. Adds escape hatch for developer landing page. This will be hidden behind a feature flag until the Capella devex docs are published.

Docs issue: [DOC-10801](https://issues.couchbase.com/browse/DOC-10801)