### PR TITLE
AV-55075: add Tab Sync Group

### DIFF
--- a/modules/guides/pages/bulk-operations.adoc
+++ b/modules/guides/pages/bulk-operations.adoc
@@ -138,7 +138,7 @@ To read multiple documents in Couchbase perform a bulk `get` operation.
 
 [{tabs}]
 ====
-cbc::
+CLI::
 +
 --
 Use the `cbc cat` command to retrieve multiple documents by their IDs. 

--- a/modules/guides/pages/connect.adoc
+++ b/modules/guides/pages/connect.adoc
@@ -53,7 +53,7 @@ To connect to a standalone or Docker installation with _unencrypted_ network acc
 
 [{tabs}]
 ====
-cbc::
+CLI::
 + 
 -- 
 Most `cbc` sub-commands will require some form of authentication to access a cluster or perform operations on data within a bucket.
@@ -189,7 +189,7 @@ Before using X.509 certificate based authentication, you should run through the 
 
 [{tabs}]
 ====
-cbc::
+CLI::
 + 
 -- 
 . To securely connect to Couchbase Server using `cbc`, pass `-U` for the connection URL immediately after a sub-command.

--- a/modules/guides/pages/creating-data.adoc
+++ b/modules/guides/pages/creating-data.adoc
@@ -31,7 +31,7 @@ To create a single document in Couchbase, perform an insert operation.
 
 [{tabs}]
 ====
-cbc::
+CLI::
 +
 --
 . Create a structured JSON document to insert in the database.
@@ -185,7 +185,7 @@ To specify further parameters for the inserted document, such as expiry, add the
 
 [{tabs}]
 ====
-cbc::
+CLI::
 +
 --
 . Create a structured document object containing your data.

--- a/modules/guides/pages/deleting-data.adoc
+++ b/modules/guides/pages/deleting-data.adoc
@@ -27,7 +27,7 @@ To delete a specific field within a document, perform a _Sub-Document_ remove op
 
 [{tabs}]
 ====
-cbc::
+CLI::
 +
 --
 Use the `cbc rm` command to delete a document from the database.
@@ -141,7 +141,7 @@ To delete a specific field within a document you can perform a _Sub-Document_ re
 
 [{tabs}]
 ====
-cbc-subdoc::
+CLI::
 +
 --
 . Connect to the `cbc-subdoc` interactive shell.

--- a/modules/guides/pages/reading-data.adoc
+++ b/modules/guides/pages/reading-data.adoc
@@ -30,7 +30,7 @@ To read a single document in Couchbase, perform a get operation.
 
 [{tabs}]
 ====
-cbc::
+CLI::
 +
 --
 Use the `cbc cat` command to retrieve a document by ID and output its data.
@@ -180,7 +180,7 @@ To specify further parameters, such as expiry, add options to the get operation.
 
 [{tabs}]
 ====
-cbc::
+CLI::
 +
 --
 Use the `cbc cat` command to retrieve a document by ID and pass options as required.
@@ -325,7 +325,7 @@ To fetch a specific field inside a document, you can perform a sub-document get 
 
 [{tabs}]
 ====
-cbc-subdoc::
+CLI::
 +
 --
 . Connect to the `cbc-subdoc` interactive shell.

--- a/modules/guides/pages/updating-data.adoc
+++ b/modules/guides/pages/updating-data.adoc
@@ -27,9 +27,9 @@ include::partial$data-warning.adoc[]
 
 To update a document, or create the document if it doesn't exist, perform an upsert operation.
 
-[{tabs},sync-group-id=cbc]
+[{tabs}]
 ====
-cbc::
+CLI::
 +
 --
 . Create a JSON document containing the updated data.
@@ -161,9 +161,9 @@ For further details, refer to {python-api-url}#collection-object[Collection^].
 
 To update a document that already exists, perform a replace operation.
 
-[{tabs},sync-group-id=cbc]
+[{tabs}]
 ====
-cbc::
+CLI::
 +
 --
 . Update a JSON document with some new data.
@@ -339,9 +339,9 @@ For further details, refer to {python-api-url}#collection-object[Collection^].
 To change a specific field inside a document, you can perform a _Sub-Document_ operation.
 You can use either a Sub-Document upsert or replace operation depending on what is required for your application.
 
-[{tabs},sync-group-id=cbc]
+[{tabs}]
 ====
-cbc-subdoc::
+CLI::
 +
 --
 . Connect to the `cbc-subdoc` interactive shell.

--- a/modules/guides/pages/updating-data.adoc
+++ b/modules/guides/pages/updating-data.adoc
@@ -27,7 +27,7 @@ include::partial$data-warning.adoc[]
 
 To update a document, or create the document if it doesn't exist, perform an upsert operation.
 
-[{tabs}]
+[{tabs},sync-group-id=cbc]
 ====
 cbc::
 +
@@ -161,7 +161,7 @@ For further details, refer to {python-api-url}#collection-object[Collection^].
 
 To update a document that already exists, perform a replace operation.
 
-[{tabs}]
+[{tabs},sync-group-id=cbc]
 ====
 cbc::
 +
@@ -339,7 +339,7 @@ For further details, refer to {python-api-url}#collection-object[Collection^].
 To change a specific field inside a document, you can perform a _Sub-Document_ operation.
 You can use either a Sub-Document upsert or replace operation depending on what is required for your application.
 
-[{tabs}]
+[{tabs},sync-group-id=cbc]
 ====
 cbc-subdoc::
 +


### PR DESCRIPTION
Noticed that on https://docs-staging.couchbase.com/server/current/guides/updating-data.html the 3rd set of tabs don't synchronise, because `cbc-subdoc` is a different string than `cbc`

This commit sets them all in the same "sync group" so they match for e.g. .NET, Java, etc.

(cbc and cbc-subdoc still won't synchronize though. That doesn't seem to be customizable from https://github.com/asciidoctor/asciidoctor-tabs#tabs-sync Consider rewording both to `cbc` or `CLI` or similar if that would be desirable.)