### PR TITLE
Doc 11187 gsi faster rebalance documentation (Devex content)

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/alterindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/alterindex.adoc
@@ -296,6 +296,8 @@ nodes;;
 If `action` is set to `move`, the node list determines the new destination nodes for the index and its replicas.
 If `action` is set to `replica_count` and you are _increasing_ the number of replicas, the node list restricts the set of nodes available for placement of the index and its replicas.
 However, if `action` is set to `replica_count` and you are _decreasing_ the number of replicas, the `nodes` property is ignored.
++
+include::partial$n1ql-language-reference/file-based-index-rebalance-note.adoc[]
 
 replicaId;;
 [Required if `action` is set to `drop_replica`] An integer, specifying a replica ID.

--- a/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
@@ -17,7 +17,6 @@ Secondary indexes contain a filtered or a full set of keys in a given keyspace.
 :index-partitioning: xref:n1ql-language-reference/index-partitioning.adoc
 :indexing-meta-info: xref:n1ql-language-reference/indexing-meta-info.adoc
 :operator-pushdowns: xref:learn:services-and-indexes/indexes/index_pushdowns.adoc#operator-pushdowns
-:file-based-index-rebalancing: xref:learn:clusters-and-availability/rebalance.adoc#index-rebalance-methods
 :sysinfo: xref:n1ql-intro/sysinfo.adoc
 :logical-hierarchy: {sysinfo}#logical-hierarchy
 :querying-indexes: {sysinfo}#querying-indexes
@@ -313,8 +312,7 @@ An object with the following properties:
 nodes;;
 [Optional] An array of strings, each of which represents a node name.
 +
-NOTE: You cannot use this property if you have enabled file-based index rebalancing. 
-See {file-based-index-rebalancing}[Index Rebalance Methods]. 
+include::partial$n1ql-language-reference/file-based-index-rebalance-note.adoc[]
 +
 ****
 [.edition]#{community}#

--- a/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
@@ -17,7 +17,7 @@ Secondary indexes contain a filtered or a full set of keys in a given keyspace.
 :index-partitioning: xref:n1ql-language-reference/index-partitioning.adoc
 :indexing-meta-info: xref:n1ql-language-reference/indexing-meta-info.adoc
 :operator-pushdowns: xref:learn:services-and-indexes/indexes/index_pushdowns.adoc#operator-pushdowns
-
+:file-based-index-rebalancing: xref:learn:clusters-and-availability/rebalance.adoc#index-rebalance-methods
 :sysinfo: xref:n1ql-intro/sysinfo.adoc
 :logical-hierarchy: {sysinfo}#logical-hierarchy
 :querying-indexes: {sysinfo}#querying-indexes
@@ -312,6 +312,9 @@ An object with the following properties:
 
 nodes;;
 [Optional] An array of strings, each of which represents a node name.
++
+NOTE: You cannot use this property if you have enabled file-based index rebalancing. 
+See {file-based-index-rebalancing}[Index Rebalance Methods]. 
 +
 ****
 [.edition]#{community}#

--- a/modules/n1ql/partials/n1ql-language-reference/file-based-index-rebalance-note.adoc
+++ b/modules/n1ql/partials/n1ql-language-reference/file-based-index-rebalance-note.adoc
@@ -1,0 +1,2 @@
+NOTE: You cannot use this property if you have enabled file-based index rebalancing. 
+See xref:learn:clusters-and-availability/rebalance.adoc#index-rebalance-methods[Index Rebalance Methods]. 


### PR DESCRIPTION
See [main PR](https://github.com/couchbase/docs-server/pull/3385) that explains this feature. 

Changed in this PR are minor additions to two pages:

* In [ALTER INDEX](https://preview.docs-test.couchbase.com/DOC-11187_gsi_faster_rebalance/server/7.6/n1ql/n1ql-language-reference/alterindex.html) under [WITH Clause](https://preview.docs-test.couchbase.com/DOC-11187_gsi_faster_rebalance/server/7.6/n1ql/n1ql-language-reference/alterindex.html#index-with) added note that the nodes property does not work when file-based index rebalance is enabled.
* In [CREATE INDEX](https://preview.docs-test.couchbase.com/DOC-11187_gsi_faster_rebalance/server/7.6/n1ql/n1ql-language-reference/createindex.html) under the [WITH Clause](https://preview.docs-test.couchbase.com/DOC-11187_gsi_faster_rebalance/server/7.6/n1ql/n1ql-language-reference/createindex.html#index-with) added note that the nodes property does not work when file-based index rebalance is enabled.