### PR TITLE
DOC-10645: Document NODE_NAME() and CURRENT_USERS() functions

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/metafun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/metafun.adoc
@@ -595,6 +595,42 @@ For examples showing how to index metadata information, refer to xref:n1ql-langu
 
 For examples showing how to use metadata information in the predicate of an ANSI JOIN clause, refer to xref:n1ql:n1ql-language-reference/join.adoc[JOIN Clause].
 
+[[node-name]]
+== NODE_NAME()
+
+=== Description
+
+Returns the name of the node on which the query is running.
+
+=== Arguments
+
+None.
+
+=== Return Value
+
+A string representing a node name.
+
+=== Example
+
+[[node-name-ex,NODE_NAME() Example]]
+====
+.Query
+[source,sqlpp]
+----
+SELECT NODE_NAME() AS node_name;
+----
+
+.Results
+[source,json]
+----
+[
+  {
+    "node_name": "127.0.0.1:8091"
+  }
+]
+----
+====
+
 [[pairs,PAIRS()]]
 == PAIRS(`obj`)
 

--- a/modules/n1ql/pages/n1ql-language-reference/metafun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/metafun.adoc
@@ -257,6 +257,44 @@ SELECT BASE64_DECODE("WzEsMiwzLDRd") AS `array`,
 ----
 ====
 
+[[current-users]]
+== CURRENT_USERS()
+
+=== Description
+
+Returns the authenticated users for the current statement.
+
+=== Arguments
+
+None.
+
+=== Return Value
+
+An array of strings, each representing a user name.
+
+=== Example
+
+[[current-users-ex,CURRENT_USERS() Example]]
+====
+.Query
+[source,sqlpp]
+----
+SELECT CURRENT_USERS() as current_users;
+----
+
+.Results
+[source,json]
+----
+[
+  {
+    "current_users": [
+      "local:97cdc7bd-f808-458e-9753-7f5119326198"
+    ]
+  }
+]
+----
+====
+
 [[flatten_keys,FLATTEN_KEYS()]]
 == FLATTEN_KEYS(`expr1` [ `modifiers` ], `expr2` [ `modifiers` ], ...)
 


### PR DESCRIPTION
Docs issue: DOC-10645

Documenting as part of release/7.2. Needs porting to Capella and release/7.6.