### PR TITLE
[DOC-11265] Updated Reserved Words list

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/reservedwords.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/reservedwords.adoc
@@ -35,75 +35,82 @@ The following keywords are reserved and cannot be used as unescaped identifiers:
 
 [cols=6*]
 |===
+| _INDEX_CONDITION
+| _INDEX_KEY
 | xref:n1ql-language-reference/advise.adoc[ADVISE]
 | xref:n1ql-language-reference/selectclause.adoc#all[ALL]
 | ALTER
 | ANALYZE
+
 | xref:n1ql-language-reference/logicalops.adoc#logical-op-and[AND]
 | xref:n1ql-language-reference/collectionops.adoc#collection-op-any[ANY]
-
 | xref:n1ql-language-reference/collectionops.adoc#array[ARRAY]
 | xref:n1ql-language-reference/from.adoc#section_ax5_2nx_1db[AS]
 | ASC
 | AT
+
 | BEGIN
 | BETWEEN
-
 | xref:n1ql-language-reference/datatypes.adoc#datatype-binary[BINARY]
 | xref:n1ql-language-reference/datatypes.adoc#datatype-boolean[BOOLEAN]
 | BREAK
 | BUCKET
+
 | BUILD
 | BY
-
+| CACHE
 | CALL
 | CASE
 | CAST
+
 | CLUSTER
 | COLLATE
 | COLLECTION
-
 | COMMIT
 | xref:n1ql:n1ql-language-reference/set-transaction.adoc[COMMITTED]
 | CONNECT
+
 | CONTINUE
 | CORRELATED
 | COVER
-
 | xref:n1ql-language-reference/createindex.adoc[CREATE]
 | xref:n1ql-language-reference/window.adoc#window-frame-extent[CURRENT]
+| CYCLE
+
 | DATABASE
 | DATASET
 | DATASTORE
 | DECLARE
-
 | DECREMENT
-| xref:n1ql-language-reference/delete.adoc[DELETE]
 | DEFAULT
+
+| xref:n1ql-language-reference/delete.adoc[DELETE]
 | DERIVED
 | DESC
 | DESCRIBE
-
 | xref:n1ql-language-reference/selectclause.adoc#distinct[DISTINCT]
 | DO
+
 | xref:n1ql-language-reference/dropindex.adoc[DROP]
 | EACH
 | ELEMENT
 | ELSE
-
 | END
+| ESCAPE
+
 | xref:n1ql-language-reference/collectionops.adoc#collection-op-every[EVERY]
 | xref:n1ql-language-reference/union.adoc[EXCEPT]
 | EXCLUDE
 | EXECUTE
 | xref:n1ql-language-reference/collectionops.adoc#exists[EXISTS]
-
 | xref:n1ql-language-reference/explain.adoc[EXPLAIN]
+
 | FALSE
 | FETCH
 | FILTER
 | FIRST
 | FLATTEN
+| FLATTEN_KEYS
 
 | FLUSH
 | xref:n1ql-language-reference/window.adoc#window-frame-extent[FOLLOWING]
@@ -147,8 +154,8 @@ The following keywords are reserved and cannot be used as unescaped identifiers:
 | KNOWN
 | xref:n1ql-language-reference/createfunction.adoc[LANGUAGE]
 
-| LATERAL
 | LAST
+| LATERAL
 | LEFT
 | xref:n1ql-language-reference/let.adoc[LET]
 | LETTING
@@ -162,60 +169,74 @@ The following keywords are reserved and cannot be used as unescaped identifiers:
 | MATCHED
 
 | MATERIALIZED
+| MAXVALUE
 | xref:n1ql-language-reference/merge.adoc[MERGE]
 | MINUS
+| MINVALUE
 | xref:n1ql-language-reference/comparisonops.adoc#null-and-missing[MISSING]
+
 | NAMESPACE
 | xref:n1ql-language-reference/nest.adoc[NEST]
-
+| NEXT
+| NEXTVAL
 | xref:n1ql-language-reference/join.adoc#use-nl-hint[NL]
 | xref:n1ql-language-reference/window.adoc#window-frame-exclusion[NO]
+
 | xref:n1ql-language-reference/logicalops.adoc#logical-op-not[NOT]
 | xref:n1ql-language-reference/windowfun.adoc#fn-window-nth-value[NTH_VALUE]
 | xref:n1ql-language-reference/comparisonops.adoc#null-and-missing[NULL]
 | xref:n1ql-language-reference/window.adoc#nulls-treatment[NULLS]
-
 | NUMBER
 | OBJECT
+
 | xref:n1ql-language-reference/offset.adoc[OFFSET]
 | ON
 | OPTION
 | xref:n1ql-language-reference/insert.adoc#insert-values[OPTIONS]
-
 | xref:n1ql-language-reference/logicalops.adoc#or-operator[OR]
 | xref:n1ql-language-reference/orderby.adoc[ORDER]
+
 | xref:n1ql-language-reference/window.adoc#window-frame-exclusion[OTHERS]
 | OUTER
 | xref:n1ql-language-reference/window.adoc[OVER]
 | PARSE
-
 | PARTITION
 | PASSWORD
+
 | PATH
 | POOL
 | xref:n1ql-language-reference/window.adoc#window-frame-extent[PRECEDING]
 | PREPARE
+| PREV
+| PREVIEW
 
+| PREVVAL
 | PRIMARY
 | PRIVATE
 | PRIVILEGE
 | xref:n1ql-language-reference/join.adoc#use-hash-hint[PROBE]
 | PROCEDURE
-| PUBLIC
 
+| PUBLIC
 | xref:n1ql-language-reference/window.adoc#window-frame-clause[RANGE]
 | RAW
 | REALM
 | REDUCE
 | RENAME
-| xref:n1ql-language-reference/window.adoc#nulls-treatment[RESPECT]
 
 | REPLACE
+| xref:n1ql-language-reference/window.adoc#nulls-treatment[RESPECT]
+| RESTART
+| RESTRICT
+| READ
+| RECURSIVE
+
 | RETURN
 | RETURNING
 | REVOKE
 | RIGHT
 | ROLE
+| ROLES
 
 | xref:n1ql:n1ql-language-reference/rollback-transaction.adoc[ROLLBACK]
 | xref:n1ql-language-reference/window.adoc#window-frame-extent[ROW]
@@ -227,7 +248,7 @@ The following keywords are reserved and cannot be used as unescaped identifiers:
 | SCOPE
 | xref:n1ql-language-reference/selectclause.adoc[SELECT]
 | SELF
-| SEMI
+| SEQUENCE
 | SET
 | SHOW
 
@@ -259,24 +280,24 @@ The following keywords are reserved and cannot be used as unescaped identifiers:
 | xref:n1ql-language-reference/hints.adoc[USE]
 | USER
 
+| USERS
 | USING
 | VALIDATE
 | VALUE
 | VALUED
 | VALUES
-| VECTOR
 
+| VECTOR
 | VIA
 | VIEW
 | WHEN
 | xref:n1ql-language-reference/where.adoc[WHERE]
 | WHILE
-| WINDOW
 
+| WINDOW
 | WITH
 | xref:n1ql-language-reference/collectionops.adoc#collection-op-within[WITHIN]
 | xref:n1ql:n1ql-language-reference/begin-transaction.adoc[WORK]
 | XOR
-|
 |
 |===

--- a/modules/n1ql/pages/n1ql-language-reference/reservedwords.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/reservedwords.adoc
@@ -79,197 +79,204 @@ The following keywords are reserved and cannot be used as unescaped identifiers:
 
 | DECREMENT
 | xref:n1ql-language-reference/delete.adoc[DELETE]
+| DEFAULT
 | DERIVED
 | DESC
 | DESCRIBE
-| xref:n1ql-language-reference/selectclause.adoc#distinct[DISTINCT]
 
+| xref:n1ql-language-reference/selectclause.adoc#distinct[DISTINCT]
 | DO
 | xref:n1ql-language-reference/dropindex.adoc[DROP]
 | EACH
 | ELEMENT
 | ELSE
-| END
 
+| END
 | xref:n1ql-language-reference/collectionops.adoc#collection-op-every[EVERY]
 | xref:n1ql-language-reference/union.adoc[EXCEPT]
 | EXCLUDE
 | EXECUTE
 | xref:n1ql-language-reference/collectionops.adoc#exists[EXISTS]
-| xref:n1ql-language-reference/explain.adoc[EXPLAIN]
 
+| xref:n1ql-language-reference/explain.adoc[EXPLAIN]
 | FALSE
 | FETCH
 | FILTER
 | FIRST
 | FLATTEN
-| FLUSH
 
+| FLUSH
 | xref:n1ql-language-reference/window.adoc#window-frame-extent[FOLLOWING]
 | FOR
 | FORCE
 | xref:n1ql-language-reference/from.adoc[FROM]
 | xref:n1ql-language-reference/hints.adoc#index-type[FTS]
-| xref:n1ql-language-reference/createfunction.adoc[FUNCTION]
 
+| xref:n1ql-language-reference/createfunction.adoc[FUNCTION]
 | GOLANG
 | GRANT
 | xref:n1ql-language-reference/groupby.adoc[GROUP]
 | xref:n1ql-language-reference/window.adoc#window-frame-clause[GROUPS]
 | xref:n1ql-language-reference/hints.adoc#index-type[GSI]
-| xref:n1ql-language-reference/join.adoc#use-hash-hint[HASH]
 
+| xref:n1ql-language-reference/join.adoc#use-hash-hint[HASH]
 | HAVING
 | IF
 | xref:n1ql:n1ql-language-reference/set-transaction.adoc[ISOLATION]
 | IGNORE
 | ILIKE
-| xref:n1ql-language-reference/collectionops.adoc#collection-op-in[IN]
 
+| xref:n1ql-language-reference/collectionops.adoc#collection-op-in[IN]
 | INCLUDE
 | INCREMENT
 | INDEX
 | INFER
 | INLINE
-| INNER
 
+| INNER
 | xref:n1ql-language-reference/insert.adoc[INSERT]
 | xref:n1ql-language-reference/union.adoc[INTERSECT]
 | INTO
 | IS
 | xref:n1ql-language-reference/createfunction.adoc[JAVASCRIPT]
-| xref:n1ql-language-reference/join.adoc[JOIN]
 
+| xref:n1ql-language-reference/join.adoc[JOIN]
 | KEY
 | KEYS
 | KEYSPACE
 | KNOWN
 | xref:n1ql-language-reference/createfunction.adoc[LANGUAGE]
-| LAST
 
+| LATERAL
+| LAST
 | LEFT
 | xref:n1ql-language-reference/let.adoc[LET]
 | LETTING
 | xref:n1ql:n1ql-language-reference/set-transaction.adoc[LEVEL]
+
 | LIKE
 | xref:n1ql-language-reference/limit.adoc[LIMIT]
-
 | LSM
 | MAP
 | MAPPING
 | MATCHED
+
 | MATERIALIZED
 | xref:n1ql-language-reference/merge.adoc[MERGE]
-
 | MINUS
 | xref:n1ql-language-reference/comparisonops.adoc#null-and-missing[MISSING]
 | NAMESPACE
 | xref:n1ql-language-reference/nest.adoc[NEST]
+
 | xref:n1ql-language-reference/join.adoc#use-nl-hint[NL]
 | xref:n1ql-language-reference/window.adoc#window-frame-exclusion[NO]
-
 | xref:n1ql-language-reference/logicalops.adoc#logical-op-not[NOT]
 | xref:n1ql-language-reference/windowfun.adoc#fn-window-nth-value[NTH_VALUE]
 | xref:n1ql-language-reference/comparisonops.adoc#null-and-missing[NULL]
 | xref:n1ql-language-reference/window.adoc#nulls-treatment[NULLS]
+
 | NUMBER
 | OBJECT
-
 | xref:n1ql-language-reference/offset.adoc[OFFSET]
 | ON
 | OPTION
 | xref:n1ql-language-reference/insert.adoc#insert-values[OPTIONS]
+
 | xref:n1ql-language-reference/logicalops.adoc#or-operator[OR]
 | xref:n1ql-language-reference/orderby.adoc[ORDER]
-
 | xref:n1ql-language-reference/window.adoc#window-frame-exclusion[OTHERS]
 | OUTER
 | xref:n1ql-language-reference/window.adoc[OVER]
 | PARSE
+
 | PARTITION
 | PASSWORD
-
 | PATH
 | POOL
 | xref:n1ql-language-reference/window.adoc#window-frame-extent[PRECEDING]
 | PREPARE
+
 | PRIMARY
 | PRIVATE
-
 | PRIVILEGE
 | xref:n1ql-language-reference/join.adoc#use-hash-hint[PROBE]
 | PROCEDURE
 | PUBLIC
+
 | xref:n1ql-language-reference/window.adoc#window-frame-clause[RANGE]
 | RAW
-
 | REALM
 | REDUCE
 | RENAME
 | xref:n1ql-language-reference/window.adoc#nulls-treatment[RESPECT]
+
+| REPLACE
 | RETURN
 | RETURNING
-
 | REVOKE
 | RIGHT
 | ROLE
+
 | xref:n1ql:n1ql-language-reference/rollback-transaction.adoc[ROLLBACK]
 | xref:n1ql-language-reference/window.adoc#window-frame-extent[ROW]
 | xref:n1ql-language-reference/window.adoc#window-frame-clause[ROWS]
-
 | SATISFIES
 | xref:n1ql:n1ql-language-reference/savepoint.adoc[SAVEPOINT]
 | SCHEMA
+
 | SCOPE
 | xref:n1ql-language-reference/selectclause.adoc[SELECT]
 | SELF
-
 | SEMI
 | SET
 | SHOW
+
 | SOME
 | START
 | STATISTICS
-
 | STRING
 | SYSTEM
 | THEN
+
 | xref:n1ql-language-reference/window.adoc#window-frame-exclusion[TIES]
 | TO
 | xref:n1ql:n1ql-language-reference/begin-transaction.adoc[TRAN]
-
 | xref:n1ql:n1ql-language-reference/begin-transaction.adoc[TRANSACTION]
 | TRIGGER
 | TRUE
+
 | TRUNCATE
 | xref:n1ql-language-reference/window.adoc#window-frame-extent[UNBOUNDED]
 | UNDER
-
 | xref:n1ql-language-reference/union.adoc[UNION]
 | UNIQUE
 | UNKNOWN
+
 | xref:n1ql-language-reference/unnest.adoc[UNNEST]
 | UNSET
 | xref:n1ql-language-reference/update.adoc[UPDATE]
-
 | xref:n1ql-language-reference/upsert.adoc[UPSERT]
 | xref:n1ql-language-reference/hints.adoc[USE]
 | USER
+
 | USING
 | VALIDATE
 | VALUE
-
 | VALUED
 | VALUES
+| VECTOR
+
 | VIA
 | VIEW
 | WHEN
 | xref:n1ql-language-reference/where.adoc[WHERE]
-
 | WHILE
 | WINDOW
+
 | WITH
 | xref:n1ql-language-reference/collectionops.adoc#collection-op-within[WITHIN]
 | xref:n1ql:n1ql-language-reference/begin-transaction.adoc[WORK]
 | XOR
+|
+|
 |===

--- a/modules/n1ql/pages/n1ql-language-reference/reservedwords.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/reservedwords.adoc
@@ -122,22 +122,22 @@ The following keywords are reserved and cannot be used as unescaped identifiers:
 | xref:n1ql-language-reference/join.adoc#use-hash-hint[HASH]
 | HAVING
 | IF
-| xref:n1ql:n1ql-language-reference/set-transaction.adoc[ISOLATION]
 | IGNORE
 | ILIKE
-
 | xref:n1ql-language-reference/collectionops.adoc#collection-op-in[IN]
+
 | INCLUDE
 | INCREMENT
 | INDEX
 | INFER
 | INLINE
-
 | INNER
+
 | xref:n1ql-language-reference/insert.adoc[INSERT]
 | xref:n1ql-language-reference/union.adoc[INTERSECT]
 | INTO
 | IS
+| xref:n1ql:n1ql-language-reference/set-transaction.adoc[ISOLATION]
 | xref:n1ql-language-reference/createfunction.adoc[JAVASCRIPT]
 
 | xref:n1ql-language-reference/join.adoc[JOIN]

--- a/modules/n1ql/pages/n1ql-language-reference/reservedwords.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/reservedwords.adoc
@@ -171,133 +171,133 @@ The following keywords are reserved and cannot be used as unescaped identifiers:
 | MATERIALIZED
 | MAXVALUE
 | xref:n1ql-language-reference/merge.adoc[MERGE]
-| MINUS
 | MINVALUE
 | xref:n1ql-language-reference/comparisonops.adoc#null-and-missing[MISSING]
-
 | NAMESPACE
+
 | xref:n1ql-language-reference/nest.adoc[NEST]
 | NEXT
 | NEXTVAL
 | xref:n1ql-language-reference/join.adoc#use-nl-hint[NL]
 | xref:n1ql-language-reference/window.adoc#window-frame-exclusion[NO]
-
 | xref:n1ql-language-reference/logicalops.adoc#logical-op-not[NOT]
+
 | xref:n1ql-language-reference/windowfun.adoc#fn-window-nth-value[NTH_VALUE]
 | xref:n1ql-language-reference/comparisonops.adoc#null-and-missing[NULL]
 | xref:n1ql-language-reference/window.adoc#nulls-treatment[NULLS]
 | NUMBER
 | OBJECT
-
 | xref:n1ql-language-reference/offset.adoc[OFFSET]
+
 | ON
 | OPTION
 | xref:n1ql-language-reference/insert.adoc#insert-values[OPTIONS]
 | xref:n1ql-language-reference/logicalops.adoc#or-operator[OR]
 | xref:n1ql-language-reference/orderby.adoc[ORDER]
-
 | xref:n1ql-language-reference/window.adoc#window-frame-exclusion[OTHERS]
+
 | OUTER
 | xref:n1ql-language-reference/window.adoc[OVER]
 | PARSE
 | PARTITION
 | PASSWORD
-
 | PATH
+
 | POOL
 | xref:n1ql-language-reference/window.adoc#window-frame-extent[PRECEDING]
 | PREPARE
 | PREV
-| PREVIEW
-
+| PREVIOUS
 | PREVVAL
+
 | PRIMARY
 | PRIVATE
 | PRIVILEGE
 | xref:n1ql-language-reference/join.adoc#use-hash-hint[PROBE]
 | PROCEDURE
-
 | PUBLIC
+
 | xref:n1ql-language-reference/window.adoc#window-frame-clause[RANGE]
 | RAW
+| READ
 | REALM
+| RECURSIVE
 | REDUCE
-| RENAME
 
+| RENAME
 | REPLACE
 | xref:n1ql-language-reference/window.adoc#nulls-treatment[RESPECT]
 | RESTART
 | RESTRICT
-| READ
-| RECURSIVE
-
 | RETURN
+
 | RETURNING
 | REVOKE
 | RIGHT
 | ROLE
-| ROLES
-
 | xref:n1ql:n1ql-language-reference/rollback-transaction.adoc[ROLLBACK]
 | xref:n1ql-language-reference/window.adoc#window-frame-extent[ROW]
+
 | xref:n1ql-language-reference/window.adoc#window-frame-clause[ROWS]
 | SATISFIES
 | xref:n1ql:n1ql-language-reference/savepoint.adoc[SAVEPOINT]
 | SCHEMA
-
 | SCOPE
 | xref:n1ql-language-reference/selectclause.adoc[SELECT]
+
 | SELF
 | SEQUENCE
 | SET
 | SHOW
-
 | SOME
 | START
+
 | STATISTICS
 | STRING
 | SYSTEM
 | THEN
-
 | xref:n1ql-language-reference/window.adoc#window-frame-exclusion[TIES]
 | TO
+
 | xref:n1ql:n1ql-language-reference/begin-transaction.adoc[TRAN]
 | xref:n1ql:n1ql-language-reference/begin-transaction.adoc[TRANSACTION]
 | TRIGGER
 | TRUE
-
 | TRUNCATE
 | xref:n1ql-language-reference/window.adoc#window-frame-extent[UNBOUNDED]
+
 | UNDER
 | xref:n1ql-language-reference/union.adoc[UNION]
 | UNIQUE
 | UNKNOWN
-
 | xref:n1ql-language-reference/unnest.adoc[UNNEST]
 | UNSET
+
 | xref:n1ql-language-reference/update.adoc[UPDATE]
 | xref:n1ql-language-reference/upsert.adoc[UPSERT]
 | xref:n1ql-language-reference/hints.adoc[USE]
 | USER
-
 | USERS
 | USING
+
 | VALIDATE
 | VALUE
 | VALUED
 | VALUES
-
 | VECTOR
 | VIA
+
 | VIEW
 | WHEN
 | xref:n1ql-language-reference/where.adoc[WHERE]
 | WHILE
-
 | WINDOW
 | WITH
+
 | xref:n1ql-language-reference/collectionops.adoc#collection-op-within[WITHIN]
 | xref:n1ql:n1ql-language-reference/begin-transaction.adoc[WORK]
 | XOR
+|
+|
 |
 |===


### PR DESCRIPTION
Changes in this PR:

- Added the following to the reserved words list:
   - DEFAULT
   - LATERAL
   - REPLACE
   - VECTOR
- Moved the word ISOLATION to the correct spot on the table

Also had to move other words around to keep the table from breaking.

Jira ticket: https://issues.couchbase.com/browse/DOC-11265
Updated page: https://docs.couchbase.com/server/current/n1ql/n1ql-language-reference/reservedwords.html

