### PR TITLE
DOC-11680: Add section on sequential scans

### DIFF
--- a/modules/learn/pages/services-and-indexes/indexes/query-without-index.adoc
+++ b/modules/learn/pages/services-and-indexes/indexes/query-without-index.adoc
@@ -279,9 +279,9 @@ The period after `phaseCounts` is a separator between nested property names, whe
   },
   // ...
 ]
-
-The query returns details of completed requests using sequential scan, if any are logged.
 ----
+
+The query returns details of completed requests using a sequential scan, if any are logged.
 ====
 
 == Manage Sequential Scans

--- a/modules/learn/pages/services-and-indexes/indexes/query-without-index.adoc
+++ b/modules/learn/pages/services-and-indexes/indexes/query-without-index.adoc
@@ -192,14 +192,35 @@ This name is a placeholder -- in reality there is no index.
 
 == Monitor Sequential Scans
 
-You can monitor sequential scans using the `completed_requests` catalog.
+You can monitor sequential scans using the `system:completed_requests` catalog.
 
+* Completed requests which used sequential scan include a `primaryScan.Seq` property within the request's `phaseCounts`, `phaseOperators`, and `phaseTimes`, in addition to the `primaryScan` property.
+
+* In contrast, queries which used a primary index include a `primaryScan.GSI` property within the request's `phaseCounts`, `phaseOperators`, and `phaseTimes`, in addition to the `primaryScan` property.
+
+The `system:completed_requests` catalog also includes a `~qualifier` field, which indicates the reason why any request was captured.
+A completed requests qualifier automatically captures any requests where more than 10000 keys have been returned by sequential scans.
+In most cases, this indicates that you should create an index to support the request.
+
+Statistics on sequential scan usage are also available in request profiling information.
+
+For more details, see xref:manage:monitor/monitoring-n1ql-query.adoc[].
+
+=== Examples
+
+.Get completed requests which used sequential scan
+====
+.Query
 [source,sqlpp]
 ----
 SELECT * FROM system:completed_requests
 WHERE phaseCounts.`primaryScan.Seq` IS NOT MISSING;
 ----
 
+You must wrap the property name `primaryScan.Seq` in backquotes, because the property name contains a period.
+The period after `phaseCounts` is a separator between nested property names, whereas the period within `primaryScan.Seq` is actually part of the property name.
+
+.Result
 [source,json]
 ----
 [
@@ -256,63 +277,10 @@ WHERE phaseCounts.`primaryScan.Seq` IS NOT MISSING;
       "~qualifier": "threshold"
     }
   },
-  {
-    "completed_requests": {
-      "clientContextID": "04a32d09-028d-48a5-88e5-c927f574190c",
-      "cpuTime": "47.303832ms",
-      "elapsedTime": "904.030735ms",
-      "errorCount": 0,
-      "errors": [],
-      "n1qlFeatCtrl": 76,
-      "node": "127.0.0.1:8091",
-      "phaseCounts": {
-        "fetch": 4495,
-        "primaryScan": 4495,
-        "primaryScan.GSI": 4495
-      },
-      "phaseOperators": {
-        "authorize": 1,
-        "fetch": 1,
-        "primaryScan": 1,
-        "primaryScan.GSI": 1,
-        "project": 1,
-        "stream": 1
-      },
-      "phaseTimes": {
-        "authorize": "9.074µs",
-        "fetch": "873.153484ms",
-        "instantiate": "24.38µs",
-        "parse": "400.687µs",
-        "plan": "281.728µs",
-        "plan.index.metadata": "24.149µs",
-        "plan.keyspace.metadata": "9.682µs",
-        "primaryScan": "28.154968ms",
-        "primaryScan.GSI": "28.154968ms",
-        "project": "17.0392ms",
-        "run": "903.212145ms",
-        "stream": "5.641339ms"
-      },
-      "queryContext": "default:travel-sample.inventory",
-      "remoteAddr": "127.0.0.1:43164",
-      "requestId": "15d4bc72-3fec-4cf6-b525-8d7ddc1f131f",
-      "requestTime": "2024-02-09T15:58:48.711Z",
-      "resultCount": 4495,
-      "resultSize": 45781,
-      "scanConsistency": "unbounded",
-      "serviceTime": "903.935582ms",
-      "state": "completed",
-      "statement": "SELECT image_direct_url FROM landmark;",
-      "statementType": "SELECT",
-      "useCBO": true,
-      "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:122.0) Gecko/20100101 Firefox/122.0",
-      "users": "builtin:Administrator",
-      "~qualifier": "threshold"
-    }
-  }
+  // ...
 ]
-----
 
-In most environments, sequential scans that produce a large number of keys are an indication of a missing index.
-To help identify such cases, a completed requests qualifier is automatically added that captures requests where more than 10000 keys have been returned by sequential scans.
-The `~qualifier` field in `completed_requests` indicates the reason the request was captured.
-Statistics on sequential scan usage are also available in request profiling information.
+The query returns details of completed requests using sequential scan, if any are logged.
+----
+====
+

--- a/modules/learn/pages/services-and-indexes/indexes/query-without-index.adoc
+++ b/modules/learn/pages/services-and-indexes/indexes/query-without-index.adoc
@@ -308,7 +308,7 @@ You can get or set the N1QL Feature Controller setting in any of the following w
 
 |Cluster-level
 |CLI
-|xref:cli:cbcli/couchbase-cli-setting-query.adoc[]
+|xref:cli:cbcli/couchbase-cli-setting-query.adoc[couchbase-cli setting-query]
 |`--n1ql-feature-control`
 
 |Cluster-level
@@ -354,7 +354,7 @@ echo $(( 76 | 16384 ))
 ----
 
 .Result
-[source,none]
+[source,console]
 ----
 16460
 ----
@@ -373,7 +373,7 @@ echo $(( 16460 ^ 16384 ))
 ----
 
 .Result
-[source,none]
+[source,console]
 ----
 76
 ----

--- a/modules/learn/pages/services-and-indexes/indexes/query-without-index.adoc
+++ b/modules/learn/pages/services-and-indexes/indexes/query-without-index.adoc
@@ -18,7 +18,7 @@ For instructions on how to install the sample bucket, see {install-sample-bucket
 == Sequential Scans
 
 If a keyspace does not have any suitable primary or secondary indexes for a query, the Query service can fall back on a sequential scan of the data to retrieve the document keys.
-(A sequential scan is also known as a K/V range scan.)
+A sequential scan uses an underlying mechanism known as a K/V range scan.
 
 Sequential scans are intended for simple, ready access to data, and are not intended as a high performance solution.
 
@@ -28,7 +28,13 @@ For ordered document key operations, a primary index provides the same functiona
 
 NOTE: Sequential scans are unavailable on ephemeral buckets.
 
-== Prerequisites
+== Use Sequential Scans
+
+To query an index using sequential scan, run the query as usual.
+
+If there is a primary index or any suitable secondary index available for the keyspace, the Query service uses that in preference to sequential scan.
+
+=== Prerequisites
 
 [discrete]
 ===== RBAC Privileges
@@ -37,12 +43,14 @@ Users must have the *Query Use Sequential Scans* role on the keyspace to be able
 For more details about user roles, see
 {authorization-overview}[].
 
-== Examples
+=== Examples
 
-For this example, set the query context to the `tenant_agent_01` scope in the travel sample dataset.
+To try the examples in this section, set the query context to the `tenant_agent_01` scope in the travel sample dataset.
 For more information, see xref:n1ql:n1ql-intro/queriesandresults.adoc#query-context[Query Context].
 
+.Check that a collection has no indexes
 ====
+.Query
 [source,sqlpp]
 ----
 SELECT * FROM system:indexes
@@ -50,6 +58,7 @@ WHERE scope_id = "tenant_agent_01"
   AND keyspace_id = "users";
 ----
 
+.Result
 [source,json]
 ----
 {
@@ -57,15 +66,18 @@ WHERE scope_id = "tenant_agent_01"
 }
 ----
 
-The collection has no indexes.
+You should see that collection has no primary or secondary indexes.
 ====
 
+.Run a query without indexes
 ====
+.Query
 [source,sqlpp]
 ----
 SELECT name FROM users;
 ----
 
+.Result
 [source,json]
 ----
 [
@@ -106,14 +118,18 @@ SELECT name FROM users;
 ----
 
 The query returns 11 documents.
+Notice that the query takes one or more seconds.
 ====
 
+.Check explain plan for query without index
 ====
+.Query
 [source,sqlpp]
 ----
 EXPLAIN SELECT name FROM users;
 ----
 
+.Result
 [source,json]
 ----
 [
@@ -168,7 +184,10 @@ EXPLAIN SELECT name FROM users;
 ]
 ----
 
-The query uses a Primary Scan called `sequentialscan`.
+The explain plan includes a primary scan operator, using `sequentialscan` rather than `gsi.`
+
+The explain plan reports that the primary scan operator uses an index called `#sequentialscan`.
+This name is a placeholder -- in reality there is no index.
 ====
 
 == Monitor Sequential Scans

--- a/modules/learn/pages/services-and-indexes/indexes/query-without-index.adoc
+++ b/modules/learn/pages/services-and-indexes/indexes/query-without-index.adoc
@@ -284,3 +284,96 @@ The query returns details of completed requests using sequential scan, if any ar
 ----
 ====
 
+== Manage Sequential Scans
+
+In Couchbase Server, sequential scans are switched on globally by default.
+(Administrators need to grant the *Query Use Sequential Scans* role to users before users can access the feature, as described above.)
+
+To turn sequential scans off or on globally, use the {sqlpp} Feature Controller setting.
+You must have administrator privileges to change this setting.
+
+You can get or set the {sqlpp} Feature Controller setting in any of the following ways:
+
+[options="header", cols="~a,~a,~a,~a"]
+|===
+|At|Method|See|Name of option
+
+|Cluster-level
+|Couchbase Web Console
+|xref:manage:manage-settings/general-settings.adoc#query-settings[Configure General Settings with the UI: Query Settings]
+|**{sqlpp} Feature Controller**
+
+|Cluster-level
+|CLI
+|xref:cli:cbcli/couchbase-cli-setting-query.adoc[]
+|`--n1ql-feature-control`
+
+|Cluster-level
+|REST API
+|xref:rest-api:rest-cluster-query-settings.adoc[]
+|`queryN1qlFeatCtrl`
+
+|Node-level
+|REST API
+|xref:n1ql:n1ql-rest-api/admin.adoc#_settings_resource[Query Admin REST API: Settings Endpoint]
+|`n1ql-feat-ctrl`
+|===
+
+To switch off sequential scans globally:
+
+. Get the current value of {sqlpp} Feature Controller.
+
+. Find the result of a bitwise OR operation on the current value and the sequential scan control bit `16384` (hex `0x4000`).
+
+. Set {sqlpp} Feature Controller to the resulting value.
+
+To switch on sequential scans globally:
+
+. Get the current value of {sqlpp} Feature Controller.
+
+. Find the result of a bitwise XOR operation on the current value and the sequential scan control bit `16384` (hex `0x4000`).
+
+. Set {sqlpp} Feature Controller to the resulting value.
+
+Note that the xref:n1ql:n1ql-language-reference/infer.adoc[INFER] command also uses K/V range scan, the mechanism that underlies sequential scan.
+If you turn off sequential scan globally, then INFER can no longer use sequential scan either.
+
+=== Examples
+
+.Switch Off Sequential Scan Globally
+====
+Assuming that the current value of the {sqlpp} Feature Controller is `76`:
+
+.OR operation
+[source,sh]
+----
+echo $(( 76 | 16384 ))
+----
+
+.Result
+[source,none]
+----
+16460
+----
+
+Set the {sqlpp} Feature Controller to `16460`.
+====
+
+.Switch On Sequential Scan Globally
+====
+Assuming that the current value of the {sqlpp} Feature Controller is `16460`:
+
+.XOR operation
+[source,sh]
+----
+echo $(( 16460 ^ 16384 ))
+----
+
+.Result
+[source,none]
+----
+76
+----
+
+Set the {sqlpp} Feature Controller to `76`.
+====

--- a/modules/learn/pages/services-and-indexes/indexes/query-without-index.adoc
+++ b/modules/learn/pages/services-and-indexes/indexes/query-without-index.adoc
@@ -1,0 +1,299 @@
+= Query without Indexes
+:page-topic-type: concept
+:page-status: Couchbase Server 7.6
+:description: Sequential scans enable you to query a keyspace, even if the keyspace has no indexes.
+
+:authorization-overview: xref:learn:security/authorization-overview.adoc
+:install-sample-buckets: xref:manage:manage-settings/install-sample-buckets.adoc
+
+[abstract]
+{description}
+
+.Examples on this Page
+****
+The examples in this topic use the travel-sample dataset which is shipped with Couchbase Server.
+For instructions on how to install the sample bucket, see {install-sample-buckets}[].
+****
+
+== Sequential Scans
+
+If a keyspace does not have any suitable primary or secondary indexes for a query, the Query service can fall back on a sequential scan of the data to retrieve the document keys.
+(A sequential scan is also known as a K/V range scan.)
+
+Sequential scans are intended for simple, ready access to data, and are not intended as a high performance solution.
+
+Sequential scans are best suited to small collections where key order is unimportant, or where the overhead of maintaining an index can't be justified.
+For larger collections and greater performance, define the appropriate indexes to speed up your queries.
+For ordered document key operations, a primary index provides the same functionality, and will outperform a sequential scan.
+
+NOTE: Sequential scans are unavailable on ephemeral buckets.
+
+== Prerequisites
+
+[discrete]
+===== RBAC Privileges
+
+Users must have the *Query Use Sequential Scans* role on the keyspace to be able to execute a request with a sequential scan.
+For more details about user roles, see
+{authorization-overview}[].
+
+== Examples
+
+For this example, set the query context to the `tenant_agent_01` scope in the travel sample dataset.
+For more information, see xref:n1ql:n1ql-intro/queriesandresults.adoc#query-context[Query Context].
+
+====
+[source,sqlpp]
+----
+SELECT * FROM system:indexes
+WHERE scope_id = "tenant_agent_01"
+  AND keyspace_id = "users";
+----
+
+[source,json]
+----
+{
+  "results": []
+}
+----
+
+The collection has no indexes.
+====
+
+====
+[source,sqlpp]
+----
+SELECT name FROM users;
+----
+
+[source,json]
+----
+[
+  {
+    "name": "Haley Rohan"
+  },
+  {
+    "name": "Johnnie Lind"
+  },
+  {
+    "name": "Verdie Jaskolski"
+  },
+  {
+    "name": "Marc Mills"
+  },
+  {
+    "name": "Valentine Funk"
+  },
+  {
+    "name": "Jocelyn Wuckert"
+  },
+  {
+    "name": "Gretchen Auer"
+  },
+  {
+    "name": "Meghan Homenick"
+  },
+  {
+    "name": "Kraig Hilll"
+  },
+  {
+    "name": "Destini Turcotte"
+  },
+  {
+    "name": "Sienna Cummerata"
+  }
+]
+----
+
+The query returns 11 documents.
+====
+
+====
+[source,sqlpp]
+----
+EXPLAIN SELECT name FROM users;
+----
+
+[source,json]
+----
+[
+  {
+    "plan": {
+      "#operator": "Sequence",
+      "~children": [
+        {
+          "#operator": "PrimaryScan3",
+          "bucket": "travel-sample",
+          "index": "#sequentialscan",
+          "index_projection": {
+            "primary_key": true
+          },
+          "keyspace": "users",
+          "namespace": "default",
+          "scope": "tenant_agent_01",
+          "using": "sequentialscan"
+        },
+        {
+          "#operator": "Fetch",
+          "bucket": "travel-sample",
+          "early_projection": [
+            "name"
+          ],
+          "keyspace": "users",
+          "namespace": "default",
+          "scope": "tenant_agent_01"
+        },
+        {
+          "#operator": "Parallel",
+          "~child": {
+            "#operator": "Sequence",
+            "~children": [
+              {
+                "#operator": "InitialProject",
+                "discard_original": true,
+                "preserve_order": true,
+                "result_terms": [
+                  {
+                    "expr": "(`users`.`name`)"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "text": "SELECT name FROM users;"
+  }
+]
+----
+
+The query uses a Primary Scan called `sequentialscan`.
+====
+
+== Monitor Sequential Scans
+
+You can monitor sequential scans using the `completed_requests` catalog.
+
+[source,sqlpp]
+----
+SELECT * FROM system:completed_requests
+WHERE phaseCounts.`primaryScan.Seq` IS NOT MISSING;
+----
+
+[source,json]
+----
+[
+  {
+    "completed_requests": {
+      "clientContextID": "4eb44ea6-170a-4700-ae79-e22f57100e43",
+      "cpuTime": "820.464µs",
+      "elapsedTime": "4.728840089s",
+      "errorCount": 0,
+      "errors": [],
+      "n1qlFeatCtrl": 76,
+      "node": "127.0.0.1:8091",
+      "phaseCounts": {
+        "fetch": 11,
+        "primaryScan": 11,
+        "primaryScan.Seq": 11
+      },
+      "phaseOperators": {
+        "authorize": 1,
+        "fetch": 1,
+        "primaryScan": 1,
+        "primaryScan.Seq": 1,
+        "project": 1,
+        "stream": 1
+      },
+      "phaseTimes": {
+        "authorize": "8.471µs",
+        "fetch": "107.915507ms",
+        "instantiate": "19.769µs",
+        "parse": "870.813µs",
+        "plan": "293.479µs",
+        "plan.index.metadata": "17.998µs",
+        "plan.keyspace.metadata": "7.601µs",
+        "primaryScan": "4.72730895s",
+        "primaryScan.Seq": "4.72730895s",
+        "project": "161.687µs",
+        "run": "4.727550611s",
+        "stream": "234.174µs"
+      },
+      "queryContext": "default:travel-sample.tenant_agent_01",
+      "remoteAddr": "127.0.0.1:43164",
+      "requestId": "d80b0d08-1794-4932-8188-af7e7e57b7b3",
+      "requestTime": "2024-02-09T15:05:09.343Z",
+      "resultCount": 11,
+      "resultSize": 435,
+      "scanConsistency": "unbounded",
+      "serviceTime": "4.728754078s",
+      "state": "completed",
+      "statement": "SELECT name FROM users;",
+      "statementType": "SELECT",
+      "useCBO": true,
+      "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:122.0) Gecko/20100101 Firefox/122.0",
+      "users": "builtin:Administrator",
+      "~qualifier": "threshold"
+    }
+  },
+  {
+    "completed_requests": {
+      "clientContextID": "04a32d09-028d-48a5-88e5-c927f574190c",
+      "cpuTime": "47.303832ms",
+      "elapsedTime": "904.030735ms",
+      "errorCount": 0,
+      "errors": [],
+      "n1qlFeatCtrl": 76,
+      "node": "127.0.0.1:8091",
+      "phaseCounts": {
+        "fetch": 4495,
+        "primaryScan": 4495,
+        "primaryScan.GSI": 4495
+      },
+      "phaseOperators": {
+        "authorize": 1,
+        "fetch": 1,
+        "primaryScan": 1,
+        "primaryScan.GSI": 1,
+        "project": 1,
+        "stream": 1
+      },
+      "phaseTimes": {
+        "authorize": "9.074µs",
+        "fetch": "873.153484ms",
+        "instantiate": "24.38µs",
+        "parse": "400.687µs",
+        "plan": "281.728µs",
+        "plan.index.metadata": "24.149µs",
+        "plan.keyspace.metadata": "9.682µs",
+        "primaryScan": "28.154968ms",
+        "primaryScan.GSI": "28.154968ms",
+        "project": "17.0392ms",
+        "run": "903.212145ms",
+        "stream": "5.641339ms"
+      },
+      "queryContext": "default:travel-sample.inventory",
+      "remoteAddr": "127.0.0.1:43164",
+      "requestId": "15d4bc72-3fec-4cf6-b525-8d7ddc1f131f",
+      "requestTime": "2024-02-09T15:58:48.711Z",
+      "resultCount": 4495,
+      "resultSize": 45781,
+      "scanConsistency": "unbounded",
+      "serviceTime": "903.935582ms",
+      "state": "completed",
+      "statement": "SELECT image_direct_url FROM landmark;",
+      "statementType": "SELECT",
+      "useCBO": true,
+      "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:122.0) Gecko/20100101 Firefox/122.0",
+      "users": "builtin:Administrator",
+      "~qualifier": "threshold"
+    }
+  }
+]
+----
+
+In most environments, sequential scans that produce a large number of keys are an indication of a missing index.
+To help identify such cases, a completed requests qualifier is automatically added that captures requests where more than 10000 keys have been returned by sequential scans.
+The `~qualifier` field in `completed_requests` indicates the reason the request was captured.
+Statistics on sequential scan usage are also available in request profiling information.

--- a/modules/learn/pages/services-and-indexes/indexes/query-without-index.adoc
+++ b/modules/learn/pages/services-and-indexes/indexes/query-without-index.adoc
@@ -286,13 +286,16 @@ The query returns details of completed requests using sequential scan, if any ar
 
 == Manage Sequential Scans
 
+// NOTE: It really is called the N1QL Feature Controller.
+// Don't change it to {sqlpp} until the name of the feature changes.
+
 In Couchbase Server, sequential scans are switched on globally by default.
 (Administrators need to grant the *Query Use Sequential Scans* role to users before users can access the feature, as described above.)
 
-To turn sequential scans off or on globally, use the {sqlpp} Feature Controller setting.
+To turn sequential scans off or on globally, use the N1QL Feature Controller setting.
 You must have administrator privileges to change this setting.
 
-You can get or set the {sqlpp} Feature Controller setting in any of the following ways:
+You can get or set the N1QL Feature Controller setting in any of the following ways:
 
 [options="header", cols="~a,~a,~a,~a"]
 |===
@@ -301,7 +304,7 @@ You can get or set the {sqlpp} Feature Controller setting in any of the followin
 |Cluster-level
 |Couchbase Web Console
 |xref:manage:manage-settings/general-settings.adoc#query-settings[Configure General Settings with the UI: Query Settings]
-|**{sqlpp} Feature Controller**
+|**N1QL Feature Controller**
 
 |Cluster-level
 |CLI
@@ -321,19 +324,19 @@ You can get or set the {sqlpp} Feature Controller setting in any of the followin
 
 To switch off sequential scans globally:
 
-. Get the current value of {sqlpp} Feature Controller.
+. Get the current value of N1QL Feature Controller.
 
 . Find the result of a bitwise OR operation on the current value and the sequential scan control bit `16384` (hex `0x4000`).
 
-. Set {sqlpp} Feature Controller to the resulting value.
+. Set N1QL Feature Controller to the resulting value.
 
 To switch on sequential scans globally:
 
-. Get the current value of {sqlpp} Feature Controller.
+. Get the current value of N1QL Feature Controller.
 
 . Find the result of a bitwise XOR operation on the current value and the sequential scan control bit `16384` (hex `0x4000`).
 
-. Set {sqlpp} Feature Controller to the resulting value.
+. Set N1QL Feature Controller to the resulting value.
 
 Note that the xref:n1ql:n1ql-language-reference/infer.adoc[INFER] command also uses K/V range scan, the mechanism that underlies sequential scan.
 If you turn off sequential scan globally, then INFER can no longer use sequential scan either.
@@ -342,7 +345,7 @@ If you turn off sequential scan globally, then INFER can no longer use sequentia
 
 .Switch Off Sequential Scan Globally
 ====
-Assuming that the current value of the {sqlpp} Feature Controller is `76`:
+Assuming that the current value of the N1QL Feature Controller is `76`:
 
 .OR operation
 [source,sh]
@@ -356,12 +359,12 @@ echo $(( 76 | 16384 ))
 16460
 ----
 
-Set the {sqlpp} Feature Controller to `16460`.
+Set the N1QL Feature Controller to `16460`.
 ====
 
 .Switch On Sequential Scan Globally
 ====
-Assuming that the current value of the {sqlpp} Feature Controller is `16460`:
+Assuming that the current value of the N1QL Feature Controller is `16460`:
 
 .XOR operation
 [source,sh]
@@ -375,5 +378,5 @@ echo $(( 16460 ^ 16384 ))
 76
 ----
 
-Set the {sqlpp} Feature Controller to `76`.
+Set the N1QL Feature Controller to `76`.
 ====

--- a/modules/n1ql/pages/n1ql-intro/queriesandresults.adoc
+++ b/modules/n1ql/pages/n1ql-intro/queriesandresults.adoc
@@ -169,7 +169,7 @@ Secondary indexes, often referred to as Global Secondary Indexes or GSIs, consti
 For example, creating a secondary index on the `name` and `email` fields in the `users` keyspace would allow you to query the keyspace regarding a document's `name` or `email` properties.
 
 Note that you do not need to create an index on a keyspace to be able to query that keyspace.
-If no indexes exist on a keyspace, Couchbase Capella uses a key range scan to query that index.
+If no indexes exist on a keyspace, Couchbase Server uses a sequential scan to query that index.
 
 For more information, refer to xref:learn:services-and-indexes/indexes/global-secondary-indexes.adoc[Using Indexes].
 

--- a/modules/n1ql/partials/nav.adoc
+++ b/modules/n1ql/partials/nav.adoc
@@ -13,6 +13,7 @@
   *** xref:n1ql:n1ql-language-reference/backfill.adoc[]
  ** xref:settings:query-settings.adoc[]
  ** xref:learn:services-and-indexes/indexes/global-secondary-indexes.adoc[]
+  *** xref:learn:services-and-indexes/indexes/query-without-index.adoc[]
   *** xref:learn:services-and-indexes/indexes/index-lifecycle.adoc[]
   *** xref:learn:services-and-indexes/indexes/indexing-and-query-perf.adoc[]
   *** xref:n1ql:n1ql-language-reference/covering-indexes.adoc[]


### PR DESCRIPTION
Docs issue: DOC-11680

Documentation preview:

* [Query without Indexes](https://preview.docs-test.couchbase.com/DOC-11680/server/current/learn/services-and-indexes/indexes/query-without-index.html) &mdash; includes sections on monitoring and managing sequential scans, covering DOC-11171.
* [SQL++ Queries and Results › Indexes](https://preview.docs-test.couchbase.com/DOC-11680/server/current/n1ql/n1ql-intro/queriesandresults.html#indexes) &mdash; mentions sequential scans.

Password for preview docs: [Docs Team demo site passwords](https://couchbasecloud.atlassian.net/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords#Preview-docs-for-internal-review)

Note that pages which previously asserted that indexes were necessary in order to query a keyspace were updated as part of AV-45747. SDK docs for query without index  will be updated as part of DOC-10559.