### PR TITLE
[DOC-11960] Tiny Eventing doc fixes for 7.6

### DIFF
--- a/modules/eventing/pages/eventing-handler-advancedMutateInArray.adoc
+++ b/modules/eventing/pages/eventing-handler-advancedMutateInArray.adoc
@@ -15,7 +15,7 @@ The `advancedMutateInArray` function:
 For example, you can generate an input document with the KEY `combine_landmark_names` and the DATA `{ "id": "combine_landmark_names", "landmark_names": [] }`, then set the number of workers in the Eventing Function's setting to 18.
 Running the Function adds 4,495 landmark names to an array without conflict and in no particular order.
 
-For more information about the Advanced Self-Recursion Parameter, see xref:eventing-advanced-keyspace-accessors.adoc#sub-document-mutatein-operation[Sub-Document MUTATEIN Operation].
+For more information about the Advanced Sub-Document MUTATEIN operation, see xref:eventing-advanced-keyspace-accessors.adoc#advanced-subdoc-array-op[Sub-Document MUTATEIN Operation].
 
 [{tabs}]
 ====

--- a/modules/eventing/pages/eventing-handler-advancedMutateInField.adoc
+++ b/modules/eventing/pages/eventing-handler-advancedMutateInField.adoc
@@ -12,7 +12,7 @@ The `advancedMutateInField` function:
 * Requires a binding of type `bucket alias`
 * Operates on any mutation where the `meta.id` or KEY starts with `mutateinfield:`
 
-For more information about the Advanced Self-Recursion Parameter, see xref:eventing-advanced-keyspace-accessors.adoc#sub-document-mutatein-operation[Sub-Document MUTATEIN Operation].
+For more information about the Advanced Sub-Document MUTATEIN operation , see xref:eventing-advanced-keyspace-accessors.adoc#advanced-subdoc-array-op[Sub-Document MUTATEIN Operation].
 
 [{tabs}]
 ====

--- a/modules/eventing/pages/eventing-handler-advancedSelfRecursion.adoc
+++ b/modules/eventing/pages/eventing-handler-advancedSelfRecursion.adoc
@@ -12,7 +12,7 @@ The `advancedSelfRecursion` function:
 * Requires a binding of type `bucket alias`
 * Operates on any mutation where the `meta.id` or KEY starts with `doquery:`
 
-For more information about the Advanced Self-Recursion Parameter, see xref:eventing-advanced-keyspace-accessors.adoc#optional-params-recursion[Optional { "self_recursion": true }` Parameter].
+For more information about the Advanced Self-Recursion parameter, see xref:eventing-advanced-keyspace-accessors.adoc#optional-params-recursion[Optional { "self_recursion": true }` Parameter].
 
 The following example shows you how to stop and restart a long-running process like a N1QL query.
 It counts the number of hotels that start with a particular letter.

--- a/modules/eventing/pages/eventing-handler-advancedTouchOp.adoc
+++ b/modules/eventing/pages/eventing-handler-advancedTouchOp.adoc
@@ -13,7 +13,7 @@ The `advancedTouchOp` function:
 * Operates on any mutation where the `meta.id` or KEY starts with `ten_seconds:`
 * Does not require that you send the document back to the Data Service to update the TTL
 
-For more information about the Advanced TOUCH operation, see xref:eventing-advanced-keyspace-accessors.adoc#advanced-touch-op[Advanced Keyspace Accessors].
+For more information about the Advanced TOUCH operation, see xref:eventing-advanced-keyspace-accessors.adoc#advanced-touch-op[Advanced TOUCH Operation].
 
 [{tabs}]
 ====


### PR DESCRIPTION
Changes in this PR:

- Updated links in "Function: Advanced Sub-Document MUTATEIN Array Operation" and "Function: Advanced Sub-Document MUTATEIN Operation" to direct to the right section of "Advanced Keyspace Accessors"
- Updated a word or two in "Function: Advanced TOUCH Operation" and "Function: Advanced Self-Recursion Parameter"

I don't believe this PR need a review as the changes are very tiny fixes that don't change the information on or the structure of the page. I'm merging it into the release branch without a review.