### PR TITLE
[DOC-11960] Another tiny fix!

### DIFF
--- a/modules/eventing/pages/eventing-language-constructs.adoc
+++ b/modules/eventing/pages/eventing-language-constructs.adoc
@@ -264,14 +264,14 @@ The Eventing Service does not support importing libraries into Eventing Function
 
 Eventing Functions support the following built-in functions:
 
-* <<n1ql_call,`N1QL()` Function Call>>
-* <<analytics_call,`ANALYTICS()` Function Call>>
-* <<crc64_call,`crc64()` Function Call>>
-* <<timers_general,`createTimer()` and `cancelTimer()` Function Calls>>
-* <<curl_call,`curl()` Function Call>>
+* <<n1ql_call,`N1QL()`>>
+* <<analytics_call,`ANALYTICS()`>>
+* <<crc64_call,`crc64()`>>
+* <<timers_general,`createTimer()` and `cancelTimer()`>>
+* <<curl_call,`curl()`>>
 
 [#n1ql_call]
-=== `N1QL()` Function Call
+=== `N1QL()`
 
 You cannot use the `N1QL()` function call directly because it bypasses the semantic and syntactic checks of the transpiler.
 
@@ -374,7 +374,7 @@ The `close()` method on the iterable handle can throw an exception if the underl
 |===
 
 [#analytics_call]
-=== `ANALYTICS()` Function Call
+=== `ANALYTICS()`
 
 ifeval::['{page-component-version}' == '7.6'] 
 _(Introduced in Couchbase Server 7.6)_ 
@@ -422,7 +422,7 @@ function OnUpdate(doc, meta) {
 For more information about {sqlpp} Analytics, see xref:server:analytics:1_intro.adoc[What’s SQL++ for Analytics?].
 
 [#crc64_call]
-=== `crc64()` Function Call
+=== `crc64()`
 
 The `crc64()` function:
 
@@ -468,9 +468,8 @@ function OnUpdate(doc, meta) {
 }
 ----
 
-
 [#timers_general]
-=== `createTimer()` and `cancelTimer()` Function Calls
+=== `createTimer()` and `cancelTimer()`
 
 Timers are asynchronous compute.
 They allow Eventing Functions to execute in reference to wall-clock events.
@@ -491,7 +490,7 @@ To cancel a Timer, you can do one of the following:
 For more information about Timers, see xref:eventing-timers.adoc[Timers].
 
 [#curl_call]
-=== `curl()` Function Call
+=== `curl()`
 
 The `curl()` function lets you interact with external entities through a REST endpoint from Eventing Functions, using either HTTP or HTTPS.
 


### PR DESCRIPTION
Changes in this PR:
- Removed "Function Call" from function headings as they were redundant

Merging right away as it's a very small fix that I don't believe needs reviewing.