### PR TITLE
Updated Terminology page for style and structure

### DIFF
--- a/modules/eventing/pages/eventing-Terminologies.adoc
+++ b/modules/eventing/pages/eventing-Terminologies.adoc
@@ -1,253 +1,420 @@
-= Terminology
-:description: While using Eventing Service, the following terminologies are used.
-:page-edition: Enterprise Edition
+= Eventing Terminology
+:description: The following terminology is used by the Eventing Service.
+:page-toclevels: 2
 
 [abstract]
 {description}
 
 == Eventing Service
 
-The Eventing Service can run one or more Eventing Functions that offer a computing paradigm by which developers can react to mutations (or data changes) via the user code, specifically JavaScript entry points (or handlers) of *OnUpdate*, *OnDelete*, or a user defined *Timer callback*.  System resources are managed at or above the Eventing Function level, and the containing Eventing Function scopes the state of all user code.
+The Eventing Service executes user-defined code and responds in real time whenever applications interact and cause your data to change.
 
-== Eventing Function
+The Eventing Service can run one or more Eventing Functions.
 
-An Eventing Function is a collection of JavaScript functions and settings (or configuration) together react to a class of events. An Eventing Function is a stateless short running piece of a self-contained program that must execute from start to end prior to a specified timeout duration.
 
-Eventing Functions can interact with the Data Service (KV), the Query Service ({sqlpp}), and external REST services via a built-in cURL function call.  Eventing Functions can also schedule a callback to an internal JavaScript function sometime in the future by creating a Timer.
+== Eventing Functions
 
-The Eventing Service routes mutations to the entry points *OnUpdate* or *OnDelete* and fired Timers to a user defined *Timer callback*.
+Eventing Functions handle data changes in the Eventing Service. 
+They're standalone JavaScript fragments that trigger in real time as a response to document mutations and that must execute from start to finish before a specified timeout is reached.
 
-NOTE: Since the 6.5 release, the JavaScript code in the Eventing Function is compressed (with the compressed size limited to 128KB) in the Couchbase Server.
+Eventing Functions allow you to:
 
-=== Handler
+* Integrate with the Data Service to:
+** Read, write, and delete documents
+** Work with Atomic Counters, CAS, and TTLS
+* Integrate with the Query Service to use inline {sqlpp} queries or statements
+* Enable a Timer to schedule functions to run in the future
+* Interact with external REST endpoints through cURL functionality
+* Route mutations to the entry points `OnUpdate` and `OnDelete`
+* Route fired timers to a user-defined Timer callback
 
-The Eventing Service calls the following entry points or JavaScript functions on events (mutations or fired timers).
+NOTE: The JavaScript code in an Eventing Function is compressed in Couchbase Server versions 6.5.0 and later.
+The compressed size is limited to 128KB.
 
-==== Insert/Update Handler
 
-The *OnUpdate* handler gets called when a document is created or modified. Two major limitations exist. First, if a document is modified several times in a short duration, the calls may be coalesced into a single event due to deduplication. Second, it is not possible to discern between Create and Update operations.
+=== Handlers
 
-The entry point OnUpdate(doc,meta) passes both `doc`, the document, and `meta`, additional data containing useful information such as the document's id, CAS, expiration, and datatype ("json" or "binary").
+The Eventing Service calls the `OnUpdate`, `OnDelete`, and Timer Callback handlers on mutations and fired timers.
 
-NOTE: Unless the _Language compatibility_ in the settings of the Function is at least 6.6.2 binary documents will be suppressed.
+==== `OnUpdate`
 
-==== Delete Handler
+The `OnUpdate` handler is called when you create or modify a document.
 
-The *OnDelete* handler gets called when a document is deleted (or expired).
+The entry point `OnUpdate(doc,meta)` passes `doc`, the document, and `meta`, which contains additional data like the document ID, CAS, expiration date, and data type. 
 
-The entry point OnDelete(meta,options) passes both `meta` which contains useful information such as the document (see above) and also `options` which has one boolean parameter `options.expired` to indicate if the removal was due to a deletion or an expiration.
+There are two limitations to the `OnUpdate` handler:
 
-One major limitation exists - it is not possible to get the value of the document that was just deleted or expired.
+* If you modify a document several times in a short period of time, the handler calls can merge into a single event due to deduplication
+* It is not possible to distinguish between Create and Update operations
 
-==== Timer Callback Handler
+NOTE: To prevent the suppression of binary documents, you must set the language compatibility of your Function to Couchbase Server version 6.6.2 or later.
 
-Timer callbacks are user defined JavaScript functions passed as the callback argument to the built-in createTimer(callback, date, reference, context) function call.
+==== `OnDelete`
 
-After creating a timer the argument "callback" or JavaScript function will be executed at or close to the desired "date" argument. The "reference" argument is an identifier for the timer scoped to an Eventing function and callback. The "context" argument must be serializable data that is available to the callback when the timer is fired.
-For more information see xref:eventing-timers.adoc#createtimer-function[createTimer function].
+The `OnDelete` handler is called when you delete a document or when the document expires.
+
+The entry point `OnDelete(meta,options)` passes `meta`, which contains information like the document, and `options`, which contains the boolean parameter `options.expired` that indicates if the document was removed because of a deletion or an expiration.
+
+It is not possible to get the value of a document that has been deleted or expired.
+
+==== Timer Callback
+
+Timer callbacks are user-defined JavaScript functions passed as the `callback` argument to the built-in function call `createTimer(callback,date,reference,context)`.
+
+When you create a Timer, the `callback` argument is executed at or close to the `date` argument.
+The `reference` argument works as an identifier for the Timer scoped to an Eventing Function and callback.
+The `context` argument must be serializable data that is available to the callback when the Timer is fired.
+
+For more information about Timer callbacks, see xref:eventing-timers.adoc#createtimer-function[`createTimer()` and `cancelTimer()`].
+
 
 === Statelessness
 
-The persistent state of an Eventing Function is captured in the below external elements, and all states that appears on the execution stack are ephemeral
+The persistent state of an Eventing Function is captured in the following external elements:
 
-* The Listen To Location (the Eventing source) a collection that is the source of the mutations sent to the Function via the Database Change Protocol (DCP).
-* The Eventing Storage (the Eventing metadata) a collection used as a scratch pad for the Function's state (this can be shared across all a tenant's Functions).
-* The documents or mutations being observed along with their extended attributes.
-* Optional Bindings for Function. There are three distinct types of bindings:
-** Bucket alias, an alias and access mode used by the Function to access a collection.
-** URL alias, an alias and HTTP/S settings used by the Function to access external REST APIs.
-** Constant alias, an alias to an integer, decimal number, string, boolean, or a JSON object used as a global variable within the Function.
+* Documents or mutations and their extended attributes
+* Listen to Location, or the Eventing source: a collection that is the source of mutations sent to the Function through the Database Change Protocol (DCP)
+* Eventing Storage, or the Eventing metadata: a collection used as a scratchpad for the state of the Function
+* Optional bindings for the Function:
+** Bucket alias: an alias and access mode used by the Function to access a collection
+** URL alias: an alias and HTTP/S setting used by the Function to access external REST APIs
+** Constant alias: an alias to an integer, decimal number, string, boolean, or a JSON object used as a global variable within the Function
+
+All states in the execution stack are short-lived.
+
 
 === Deduplication
 
-Couchbase does not store every version of a document permanently. Hence, when a handler receives the mutation history of documents from the Eventing source, it sees a truncated history of each document. However, the final state of a document is always present in all such histories (as the current state is always available in the database).
+Couchbase does not store every version a document permanently.
+When a handler receives the mutation history of documents from Eventing, it sees a truncated history of each document.
 
-Similarly, the KV data engine deduplicates multiple mutations made to any individual document rapidly in succession, to ensure  highest possible performance. So, when a document mutates rapidly, handlers may not see all intermediate states, but in all cases, will see the final state of the document.
+NOTE: Because the current state of a document is always available in the database, the final state of a document is always present in the mutation history.
+
+To ensure high performance, the KV data engine deduplicates multiple mutations made to an individual document in succession.
+Handlers might not see all intermediate states of a document when it mutates quickly, but they do see its final state.
+
 
 === Recursive Mutation
 
-An abbreviation of convenience of the term Potentially Recursive Mutation. When a handler manipulates documents in a keyspace that also serves as the source of mutations to this or any other handler, a write originated by a handler will cause a mutation to be seen by itself or another handler. These are called potentially recursive mutations.
+A potentially recursive mutation happens when a handler manipulates documents in a keyspace that also serves as the mutation source for this or another handler.
+The write originated by the handler causes a mutation to be seen by itself or by another handler.
 
-[#json_number_percision]
+
+[#json_number_precision]
 === JSON Number Precision
 
-JSON does not have specialized types for integral and floating-point numbers. So many JavaScript runtimes utilize floating-point numbers to hold JSON numbers. This means that JavaScript numbers have a very large range but lesser precision when compared to traditional integers of the same size.
+JSON does not have specialized types for integral and floating-point numbers, so many JavaScript runtimes use floating-point numbers to hold JSON numbers.
+This means that JavaScript numbers have a large range but less precision when it comes to traditional integers of the same size.
 
-v8 utilizes 64-bit floating-point numbers which yields a 53-bit precision. So, only integers up to +/- 253 can safely be handled in Eventing JavaScript. When handling very large integers, that is, numbers having 15 or more digits, one should utilize JavaScript BigInt types to safely handle them. The exact numbers where integral precision is lost is defined by JavaScript in the constants `Number.MAX_SAFE_INTEGER` and `Number.MIN_SAFE_INTEGER`.
+The JavaScript and WebAssembly engine V8 uses 64-bit floating-point numbers that yield a 53-bit precision.
+Only integers up to +/- 253 can be safely handled by Eventing JavaScript.
 
-Often, such large integers are really only tokens, and it is not necessary to perform arithmetic on them, and only comparison for equality is necessary. Examples of this in Eventing are CAS values generated by Advanced Bucket Operations, or the result of the crc64() function. In these cases, it is appropriate to hold these large integers as strings, as it ensures full fidelity while retaining the ability to do equality comparisons.
+To handle large integers of 15 or more digits, you can use JavaScript `BigInt` types.
+The constants `Number.MAX_SAFE_INTEGER` and `Number.MIN_SAFE_INTERGER` show the exact numbers where integral precision is defined and lost by JavaScript.
 
-=== Feed Boundary
+Large integers are usually tokens that require equality comparisons.
+In Eventing, this can be seen in the CAS values generated by Advanced Keyspace Operations and in the results generated by the `crc64()` Function.
+In these cases, you can hold the large integers as strings. 
+The strings ensure full fidelity and retain the ability to do equality comparisons.
 
-Feed Boundary is a time or progress milestone used during an Eventing Function configuration. The Feed Boundary is a persistent setting in the Function's definition and can only be set or altered when a Function is created, undeployed or paused.
+For more information about the `crc64()` Function, see xref:eventing-language-constructs.adoc#crc64_call[`crc64()` Function Call].
 
-Based on the `Feed Boundary` setting, when an Eventing Function is deployed it can either process all data mutations available in the cluster (`Everything`) or  process only future data mutations (`From now`) that occur post deployment. However, once deployed you may Pause/Resume an Eventing Function in this case; the Feed Boundary is a checkpoint of the Function's actual progress such that no mutations or timers are reprocessed or lost.
 
+[#function-scope]
 === Function Scope
 
-A bucket.scope combination is used for identifying functions belonging to the same group.
+You can use a `bucket.scope` to identify Functions that belong to the same group.
 
-Only the "Eventing Full Admin" role and also the "Full Admin" role can set the bucket.scope to  *+*+.+*+*; all other Eventing non-privileged users need to define a *Function Scope* for their Eventing functions that references an existing resource of bucket.scope.
-This provides role based isolation of Eventing functions between non-privileged users
+As a best practice, you should set your Function scope to the `bucket.scope` that contains the collection that's the source of your Eventing Function mutations.
+This makes sure that your Function does not undeploy by removing a scope that points to a resource that's not required for the Function to run.
 
-Typically you should set Function Scope to the bucket.scope that holds the collection that is the source of your mutations to your Eventing Function.  This best practice ensures that you _*do not*_  inadvertently cause an Eventing Function to undeploy by removing a *Function Scope* pointing to a resource that is not required for the function to run.
+NOTE: To set the `bucket.scope` to `+`.`+`, you must have the `Eventing Full Admin` or the `Full Admin` role.
+All other users must use a scope that references an existing resource of their `bucket.scope`.
 
-=== Keyspaces
-
-A keyspace is a fully qualified path to a collection of the form "bucket-name.scope-name.collection-name". For backward compatibility a keyspace can also be of the form "bucket-name._default._default" which is the form of a 6.6 bucket upgraded to 7.0.  The two terms keyspace and collection can be considered equivalent.
-
-[#eventing-keyspaces]
-=== Eventing Keyspaces
-
-There are two keyspaces used by every Eventing Function: the Listen To Location (the Eventing source) collection and the Eventing Storage (the Eventing metadata) collection.
-
-*Listen To Location (the Eventing source)*
-
-Couchbase Eventing Functions use a collection as the source of data mutations. This collection is referred to as the Eventing source. This source collection can be either Couchbase or Ephemeral keyspace type. However, memcached keyspace types are not supported.
-
-When you are creating an Eventing Function, you need to specify a source collection. The handler(s) of *OnUpdate* and/or *OnDelete* are the entry points that receive events from this collection via DCP to both receive and track data mutations.
-
-NOTE: You can have multiple Eventing Functions running different code listening to the same source collection.  However it is less resource intensive to use just one Eventing Function and merely code an if-then-else or switch statement in your handler’s JavaScript.
-
-When a source collection is deleted, all deployed (or paused) Eventing Functions associated with this source collection are undeployed.
-
-The `Listen To` can listen to multiple collections via a wildcard of `{asterisk}` for the scope and/or the collection.
-For these functions, if the bucket binding used by the JavaScript code also contains a wildcard of `{asterisk}` for the scope and/or the collection only the Advanced Keyspace Accessors will be able to read or write the Data Service (or KV).
-
-In the course of processing the JavaScript code of an Eventing Function, documents can be mutated in different collections. For understanding purposes, these keyspaces can be termed as destination collections which are bound to the Function via Bucket aliases.
-
-At times, the Eventing Function's JavaScript code can trigger data mutations on documents via the Data Service (KV) via either Basic Keyspace Accessors or Advanced Keyspace Accessors.
-If the Eventing Function code directly modifies documents in the source collection, the Eventing Service will suppress the mutation back to the Eventing Function making the mutation.
-When implementing multiple Functions it is possible to create infinite recursions, however the Eventing Service by default will prevent deploying Functions that would result in recursion loops.  It should be noted that not all recursion loops can be detected nor are all recursion loops wrong -- the default recursion checks can be disabled. For more detail on cyclic generation of data changes, refer to xref:troubleshooting-best-practices.adoc#cyclicredun[Bucket Allocation Considerations].
-
-At times, the Eventing Function's JavaScript code can trigger data mutations on documents via the Query Service ({sqlpp}) via inline {sqlpp} statements or N1QL() function calls. In this case the Eventing Function will see the mutation it just generated and additional business logic may be needed to terminate  or protect against possible recursion.
-
-*Eventing Storage (the Eventing metadata)*
-
-The Eventing Storage (or Metadata) collection, stores artifacts (or configuration documents) that contain information about DCP streams, worker allocations, timer information/state, and internal checkpoints.
-
-When you are creating an Eventing Function, ensure that a separate collection is designated as an Eventing metadata and reserved solely for the internal use of the Eventing Service. You can use a common Eventing metadata collection across multiple Eventing Functions for the same tenant.
-
-NOTE: The Eventing Storage keyspace must be in a Bucket of type Couchbase.  If this keyspace is not persistent the Data Service, or KV, will evict timer and checkpoint documents on hitting quota and Eventing can lose track of both timers and mutations processed. Furthermore at any point, refrain from deleting the Eventing metadata collection. Also, ensure that your Eventing Function's JavaScript code or other services do not perform a write or delete operation on the Eventing metadata collection.
-
-If an Eventing metadata collection gets accidentally deleted, then all deployed Eventing Function are undeployed and associated indexes and constructs get dropped.
-
-*Function Name*
-
-All Eventing Functions must have a unique name in a Couchbase cluster. A Function name can only start with characters in range A-Z, a-z, 0-9, and can only contain characters in range A-Z, a-z, 0-9, underscore, and hyphen.
-
-*Deployment Feed Boundary*
-
-Using the `Feed Boundary` drop down, you can either set an Eventing Function to deploy for all data mutations available in the cluster (`Everything`) or choose to deploy the Eventing Function to process only future data mutations, post deployment (`From now`). However, once deployed you may Pause/Resume an Eventing Function in the Resume case; the Feed Boundary is a checkpoint of the Function's actual progress when the Function was paused such that no mutations are reprocessed or lost upon a subsequent Resume.
-
-*Description*
-
-The Description is an optional text that can be added to the Function, typically to describe the purpose of the particular business logic.
-
-[#function-settings]
-=== Eventing Function Settings
-
-There are several advanced settings (by default hidden within a collapsible panel) that can be adjusted. The System Log Level, {sqlpp} Consistency, Workers, Language compatibility, Script Timeout, and Timer Context Max Size are additional options available during the Eventing Function definition process.
-
-* *System Log Level*: Determines the granularity at which messages are logged to the common system log messages across all Eventing Functions. The available choices are: `Info` (the default), `Error`, `Debug`, `Warning`, and `Trace`.
-+
-Typically you will never need to adjust this from the default setting of `Info`, the data in this file is generally only used by support.
-
-* *Application log location* The directory path to the log file for the application or the Function specific log messages named <<function_name>>.log.
-The Function designer uses log() statements to write to this file in addition it will also record some Function specific system level errors.
-In the UI when "Log" is selected these files are combined across all Eventing nodes and displayed.  This value is read-only and set at system initialization time and cannot be subsequently changed.
-
-* *{sqlpp} Consistency*: The default consistency level of {sqlpp} statements in the Eventing Function.
-This controls the consistency level for {sqlpp} statements, but can be set on a per statement basis. The valid values are `None` (the default) and `Request`.
-
-* *Workers*: Workers the number of worker processes to be started for the Eventing Function.
-Allows the Eventing Function to be scaled up (or vertical scaling). Each worker process supports two fixed threads of execution, however this setting is limited to a maximum of 64 for system optimization purposes.
-The system automatically generates a warning message if the number of workers exceeds a set threshold based upon cluster resources, however, in this case the handler can still be deployed.
-The minimum value is 1 (the default) and the recommended maximum is 64.  In most cases the maximum should be the number of vCPUs.
-
-* *Language compatibility*: The language version of the Eventing Function for backward compatibility.
-+
-If the semantics of a language construct change in any given release the “Language compatibility” setting will ensure an older Eventing Function will continue to see the runtime behavior that existed at the time it was authored, until such behavior is deprecated and removed. Note 6.0.0, 6.5.0, and 6.6.2 are the only currently defined versions and for newly authored Functions the default is the highest compatibility version available, currently 6.6.2.
-+
-For example, accessing non-existent items from a keyspace returns undefined in 6.5.0, while in 6.0.0 an exception is thrown. In addition, only a Function with “language compatibility” of 6.6.2 in its settings will pass binary documents to the OnUpdate(doc,meta) handler. In addition, values of 6.0.0 and 6.5.0 will filter all binary documents out of the DCP mutation stream, only 6.6.2 will pass binary documents to the Eventing Function handlers.
-
-* *Script Timeout*: Script Timeout provides a timeout option to terminate a non-responsive Function.
-+
-The entry points into the handler, e.g. OnUpdate and OnDelete, processing for each mutation must complete from start to finish prior to this specified timeout duration. The default is 60 seconds.
-
-* *Timer Context Max Size*: Timer Context Max Size limits the size of the context for any Timer created by the Function.
-+
-Eventing Timers can store and access a context which can be any JSON document, the context is used to store state when the timer is created and retrieve state when the timer fires.  By default the size is 1024 bytes, but this can be adjusted on a per Function basis.
 
 [#section_mzd_l1p_m2b]
 === Bindings
 
-A binding is a construct that allows separating environment specific variables (example: keyspace names, external endpoint URLs plus credentials, or global constants) from the Eventing Function's source code. It provides a level of indirection between environment specific artifacts to symbolic names, to help moving an Eventing Function definition from development to production environments without changing code. Binding names must be valid JavaScript identifiers and must not conflict with any built-in types.
+A binding is a construct that lets you separate environment-specific variables, like keyspace names, external endpoint URLS and credentials, and global constrains, from the source code of the Eventing Function.
 
-An Eventing Function can have no binding, one binding, or several bindings.  There are three distinct types of bindings:
+A binding provides indirection between environment-specific artifacts and symbolic names, and helps move a Function definition from development to a production environment without changing your code.
+Binding names must be valid JavaScript identifiers, and cannot conflict with built-in types.
 
-*Bucket alias*
+Your Eventing Function can have no binding, one binding, or several bindings.
 
-Bucket aliases allow the JavaScript in an Eventing Function to access Couchbase KV collections from the Data Service or KV. The keyspaces (bucket.scope.collection) are then accessible by the bound name as a JavaScript map in the global space of the Eventing Function.
+==== Bucket alias
 
-An Eventing Function can listen to multiple collections via a wildcard of `{asterisk}` for the scope and/or the collection.
-For these functions, the bucket alias (or binding) used by the JavaScript code can also contain a wildcard of `{asterisk}` for the scope and/or the collection.
-If bucket alias contains a wildcard of `{asterisk}` only the Advanced Keyspace Accessors will be able to read or write the Data Service (or KV).
+A bucket alias binding gives the JavaScript of a Function access to the Couchbase KV collections from the Data Service or KV.
+The keyspaces `bucket.scope.collection` are accessible by the bound name as a JavaScript map in the global space of the Function.
 
-You can add bucket aliases via the 'Bucket alias' choice then entering a tuple of: alias-name, keyspace, and an access level. Where the alias-name that you can use to refer to the keyspace or collection from your Eventing Function code; the keyspace is the full path to a collection in the cluster; and the access level to the keyspace is either 'read only' or 'read and write'.
+You can add bucket aliases by selecting *Bucket alias* and entering an alias-name, a keyspace, and the access level.
+This sequence of values does the following:
 
-NOTE: One or more Bucket alias bindings (or Bucket aliases) are mandatory when your Eventing Function code performs any collection related operations directly against the Data Service.
+* alias-name is the name you can use to refer to the keyspace or collection from your Eventing Function code
+* keyspace is the full path to a collection in the cluster
+* the access level provides access to the keyspace as `read only` or `read and write`
+** `read only` lets you read documents from the collection but not write (create, update, or delete) documents in the collection
+** `read and write` lets you read and write documents in the collection
 
-* Read Only Bindings: A binding with access level of "Read Only" allows reading documents from the collection, but cannot be used to write (create, update or delete) documents in such a collection. Attempting to do so will throw a runtime exception.
+NOTE: You must have one or more bucket alias bindings for your Eventing Function to perform operations directly against the Data Service.
 
-* Read-Write Bindings: A binding with access level of "Read Write" allows both reading and writing (create, update, delete) of documents in the collection.  If you wish to modify the document passed to the OnUpdate entry point (or any other document in the source collection) you will need to provide a Read-Write binding alias to the Function's source collection.
+An Eventing Function can listen to multiple collections when you use the `{asterisk}` wildcard in its scope or collection.
+You can also use the `{asterisk}` wildcard in the scope or collection of the bucket alias code.
+If the bucket alias has a `{asterisk}` wildcard, only the Advanced Keyspace Accessors can read or write the Data Service.
 
-*URL alias*
+==== URL alias
 
-These bindings are utilized by the cURL language construct to access external resources. The binding specifies the endpoint, the protocol (http/https), and credentials if necessary. Cookie support can be enabled via the binding if desired when accessing trusted remote nodes. When a URL binding limits access through to be the URL specified or descendants of it. The target of a URL binding should not be a node that belongs to the Couchbase cluster.
+A URL alias binding is used by the cURL language construct to access external resources.
+The URL alias specifies the endpoint, the HTTP/S protocol, and the credentials.
 
-You can add URL bindings via the 'URL alias' choice then entering the following: alias-name, URL, allow cookies setting, security settings of validate SSL certificate and an auth type of (no auth, basic, bearer, and digest).  For more details refer to xref:eventing-curl-spec.adoc#bindings[cURL Bindings].
+You can enable cookie support through the binding when you access trusted remote nodes.
+The target of a URL alias should not be a node that belongs to the Couchbase cluster.
 
-*Constant alias*
+You can add URL aliases by selecting *URL alias* and entering an alias-name, a URL, settings to allow cookies, security settings to validate SSL certificate, and an authorization type of `no auth`, `basic`, `bearer`, and `digest`.
 
-These bindings are utilized by the Eventing Function's JavaScript code as global variables.
+For more information about URL aliases, see xref:eventing-curl-spec.adoc#bindings[cURL Bindings].
 
-You can add URL bindings via the 'Constant alias' choice then entering an alias-name and value. The value can be either an integer, decimal number, string, boolean, or a JSON object.  For example you might have an alias of _debug_ with a value of _true_ (or _false_) to control verbose logging this would act just like adding a statement `const debug = true;` at the beginning of your JavaScript code (_although the Eventing syntax wouldn't allow this global to be added to the actual JavaScript_).
+==== Constant alias
+
+A constant alias is used by the JavaScript code of the Eventing Function as a global variable.
+
+You can add constant aliases by selecting *Constant alias* and entering an alias-name and a value.
+The valuje can be an integer, a decimal number, a string, a boolean, or a JSON object.
+
+For example, you can have an alias of `debug` with a value of `true` or `false` that controls logging.
+This alias acts in the same way as adding a `const debug = true` statement at the beginning of your JavaScript code.
+
+
+[#eventing-keyspaces]
+=== Eventing Keyspaces
+
+A keyspace is a path to a collection in the format `bucket-name.scope-name.collection-name`.
+
+For backward compatibility, you can also use the format `bucket-name._default._default`.
+This is the format of a bucket from Couchbase Server version 6.6 that has been upgraded to version 7.0.
+
+The following are the two keyspaces used by Eventing Functions:
+
+* <<listen-to-location,Listen to Location>>, which represents the Eventing source
+* <<eventing-storage,Eventing Storage>>, which represents the Eventing metadata
+
+[#listen-to-location]
+==== Listen to Location
+
+Eventing Functions use a collection as the source for their data mutations.
+This collection is called the Eventing source, and can be made up of Couchbase or Ephemeral keyspace types.
+Memcached keyspace types are not supported.
+
+When you create an Eventing Function, you must specify a source collection.
+The `OnUpdate` and `OnDelete` handlers are the entry points for this collection; they receive events and receive and track data mutations.
+
+When you delete a source collection, all deployed and paused Functions associated with the collection are undeployed.
+
+While a Function is processing its JavaScript code, the Function's documents can be mutated in different collections.
+You can set keyspaces as destination collections, which are then bound to the Function through bucket aliases.
+
+The Function's JavaScript code triggers data mutations on documents through Basic Keyspace Accessors or Advanced Keyspace Accessors in the Data Service.
+If the code directly modifies documents in the source collection, the Eventing Service suppresses the mutation back to the Function performing the mutation.
+
+The Function's JavaScript code can also trigger mutations on documents through inline {sqlpp} statements in the Query Service or `N1QL()` function calls.
+You might need to add additional business logic to terminate or protect the Function against possible recursion.
+
+NOTE: When you implement multiple Functions, you can create infinite recursions.
+The Eventing Service prevents the deployment of Functions that might result in recursion loops.
+For more information abotu cyclic generation of data changes, see xref:troubleshooting-best-practices.adoc#cyclicredun[Bucket Allocation Considerations].
+
+To get the `Listen To` keyspace to listen to multiple collections, you can use a `{asterisk}` wildcard for the scope or collection.
+If the bucket binding used by the JavaScript code also has a `{asterisk}` wildcard for its scope or collection, you must use Advanced Keyspace Accessors to read or write the Data Service. For more information about Advanced Keyspace Accessors, see xref:eventing-advanced-keyspace-accessors.adoc#multiple-collection-functions[Eventing Functions that Listen to Multiple Collections].
+
+TIP: You can have multiple Functions listening to the same collection while running different code.
+To use less resources, though, you can use only one Function and code an if-then-else or switch statement in your handler's JavaScript.
+
+[#eventing-storage]
+=== Eventing Storage
+
+The Eventing Storage is the Eventing Function's metadata bucket. 
+The metadata bucket stores artifacts, or configuration documents, that contain information about DCP streams, worker allocations, Timer information and state, and internal checkpoints. 
+
+When you create an Eventing Function, you must make sure that a separate collection has been designated as an Eventing metadata and reserved for the Eventing Service's internal use.
+You can use a common Eventing metadata collection across multiple Eventing Functions for the same tenant.
+
+The Eventing Storage keyspace must be in a Couchbase-type bucket.
+If this keyspace is not persistent, the Data Service evicts Timer and checkpoint documents when it hits quota, and loses track of Timers and mutations that have been processed.
+
+NOTE: Do not delete the Eventing metadata collection.
+Make sure that your Function's JavaScript code does not perform a write or delete operation on the Eventing metadata collection.
+If you delete the metadata collection, all deployed Eventing Functions are undeployed and all associated indexes and constructs are dropped.
+
+
+[#function-settings]
+=== Eventing Function Settings
+
+[cols="1,2",options="header"]
+
+|===
+
+|Function setting 
+|Description
+
+|Function Name
+a|A unique name for your Eventing Function.
+The Function name must:
+
+* Start with an uppercase character (A-Z), lowercase character (a-z), or number (0-9)
+* Contain only uppercase characters (A-Z), lowercase characters (a-z), numbers (0-9), underscores (_), and hyphens (-)
+
+|Description
+|An optional description that describes the purpose of your Eventing Function.
+
+|Deployment Feed Boundary
+|The Feed Boundary determines if the Eventing Function's activities need to include documents that already exist.
+
+When you set the Feed Boundary to `Everything`, the Function deploys all mutations available in your database.
+When you set the Feed Boundary to `From Now`, the Function only processes instances of data mutation that happen after the Function's deployment.
+
+The Feed Boundary also works as a checkpoint for paused Functions.
+When you resume a paused Function, the Feed Boundary makes sure that no mutations are lost or processed again.
+
+You can only modify the Feed Boundary when you create a Function or when a Function is undeployed or paused.
+
+|System Log Level
+|Determines the granularity of messages logged across the Eventing Function.
+Can be one of `Info` (the default), `Error`, `Debug`, `Warning`, or `Trace`.
+
+|Application Log Location
+|The directory path to the log file for the Eventing Function.
+The format is `<function_name>.log`.
+The Function uses `log()` statements to write to this file.
+
+When you select the *Log* value on the UI, all log files are combined across Eventing nodes and displayed.
+The log value is read-only and cannot be changed.
+
+|{sqlpp} Consistency
+|The default consistency level of {sqlpp} statements in the Eventing Function.
+
+You can set the consistency level by statement.
+Can be one of `None` (the default) or `Request`.
+
+|Workers
+|The number of worker threads per node to be allocated to the Eventing Function to process events. 
+Allows the Function to scale up.
+
+The minimum number of workers is `1` (the default) and the maximum is `64`.
+
+|Language Compatibility
+|The language version of the Eventing Function for backward compatibility.
+
+If the semantics of a language construct change during a release, the Language Compatibility setting makes sure that an older Eventing Function continues to produce the runtime behavior from when the Function was initially created.
+The older Function only stops this behavior when the behavior is deprecated and removed.
+
+Couchbase versions 6.0.0, 6.5.0, and 6.6.2 are the only versions that are currently defined.
+New Functions default to the highest compatibility version available of 6.6.2.
+
+In version 6.5.0, trying to access a non-existing item from a keyspace returns an undefined value.
+In version 6.0.0, it throws an exception.
+
+Only a Function with a language compability setting of version 6.6.2 passes binary documents to Eventing Function handlers.
+Versions 6.0.0 and 6.5.0 filter all binary documents out of the DCP mutation stream.
+
+|Script Timeout
+|The number of seconds to elapse before the script times out and is terminated.
+
+The entry points into the handler processing for each mutation must run from start to finish before the specified timeout duration.
+The default number of seconds is `60`.
+
+|Time Context Max Size
+|The size limit of the context for any Timer created by the Eventing Function.
+
+A context can be any JSON document. Timers can store and access a context, which is then used to store the state of when a Timer is created and to retrieve the state of when a Timer is fired.
+
+The default is `1024`.
+
+|===
+
 
 == Operations
 
-The following operations are exposed through the UI, couchbase-cli and REST APIs.
+Operations exposed through the UI, couchbase-cli, and REST APIs.
 
 === Deploy
 
 The deploy operation activates an Eventing Function in a cluster.
+It performs validations and allows only valid Eventing Functions to be deployed.
 
-This operation activates an Eventing Function. Source validations are performed, and only valid Eventing Function can be deployed. Deployment transpiles the code and creates the executable artifacts. The source code of an activated (or deployed and running) Eventing Function cannot be edited. Unless an Eventing Function is in deployed state, it will not receive or process any events (mutations or Timer callbacks). Deployment of an Eventing Function creates necessary metadata, spawns worker processes, calculates initial partitions, and initiates check-pointing of DCP stream to processes.
+Deploying an Eventing Function:
 
-Deployment for DCP observer (or Feed Boundary) has two variations controlled by the setting of the Eventing Function's "Deployment Feed Boundary":
+* Creates necessary metadata
+* Spawns worker processes
+* Calculates initial partitions
+* Initiates check-pointing of DCP streams to process
+* Allows the Function to receive and process mutations and Timer callbacks
 
-* Everything: The Eventing Function will see a deduplicated history of all documents, ending with the current value of each document. Hence, the Eventing Function will see every document in the keyspace at least once.
+You cannot edit the source code of a deployed Eventing Function.
 
-* From now: The Eventing Function will see mutations from current time. In other words, the Eventing Function will see only documents that mutate after it is deployed.
+During deployment, you must choose one of the following *Deployment Feed Boundary* settings:
+
+* *Everything*, which provides the Eventing Function with a deduplicated history of all documents, ending with the current value of each document. This means the Function sees every document in the keyspace at least once.
+* *From now*, which provides the Eventing Function with mutations starting at deployment. This means the Function only sees documents that have mutated after the Function's deployment.
 
 === Undeploy
 
-This operation causes the Eventing Function to stop processing events of all types and shuts down the worker processes associated with the Eventing Function. It deletes all timers created by the Eventing Function being undeployed and their context documents. It releases any runtime resources acquired by the Eventing Function.  An Eventing Function in the Undeployed state can have its code edited and settings altered. Newly created Eventing Functions start in Undeployed state.
+The undeploy operation causes the Eventing Function to stop processing events of all types.
+It also shuts down the worker processes associated with the Function.
+
+Undeploying an Eventing Function:
+
+* Deletes all Timers and context documents created by the Function
+* Releases any runtime resources acquired by the Function
+
+You can edit the code and change the settings of an undeployed Eventing Function.
+
+When you create a new Eventing Function, the Function's state is undeployed.
 
 === Pause
 
-This action stops all processing associated with an Eventing Function including timer callbacks and performs a checkpoint (to be used for a subsequent resume). An Eventing Function in the Paused state can have its code edited and settings altered. Eventing Functions in Paused state can be either Resumed or Undeployed.
+The pause operation causes the Eventing Function to pause all mutations and Timer callbacks.
+It also performs a checkpoint to be used for resuming the Function.
+
+You can edit the code and change the settings of a paused Eventing Function.
+
+A paused Function can be resumed or undeployed.
 
 === Resume
 
-This action continues processing of an Eventing Function that was previously Paused. The Resume process is akin to a Deploy but utilizes a progress checkpoint (made when the Eventing Function was paused) to restart such that no mutations are reprocessed or lost. The backlog of mutations that occurred when the Eventing Function was paused will now be processed. The backlog of timers that came due when the Eventing Function was paused will now fire even if that timer is now in the past. Depending on the system capacity and how long the Eventing Function was paused, clearing the backlog may take some time before Eventing Function moves on to current mutations and timers.
+The resume operation continues processing mutations and Timer callbacks of an Eventing Function that was previously paused.
+
+The resume operation is similar to the deploy operation, but it uses a progress checkpoint to restart the Function. This means no mutations are lost or processed again.
+
+When you resume a Function, the backlog of mutations that occurred when the Function was in a paused state is processed. The backlog of Timers also fires, even if the time of the Timers has already passed.
+
+Depending on the system capacity and on how long the Function was paused, clearing the backlog can take some time. After the backlog is cleared, the Function goes on to process current mutations and Timers.
 
 === Delete
 
-When an Eventing Function is deleted, the source code implementing the Eventing Function, all timers and timer contexts, all processing checkpoints, application logs and other artifacts in the metadata provider are purged. A future Eventing Function by the same name has no relation to a prior deleted Eventing Function of the same name. Only undeployed Eventing Function can be deleted.
+The delete operation deletes the following in the Eventing Function:
+
+* The source code implementing the Function
+* All Timers and Timer contexts
+* All processing checkpoints
+* Application logs
+* Any other artifacts in the metadata provider
+
+You can only delete an undeployed Eventing Function.
 
 === Debug
 
-Debug is a special flag on an Eventing Function that causes the next event instance received by the Eventing Function to be trapped and sent to a separate v8 worker with debugging enabled. The debug worker pauses the trapped event processing and opens a TCP port and generates a Chrome Developer Tools URL with a session cookie that can be used to control the debug worker. All other events, except the trapped event instance, continue unencumbered. If the debugged event instance completes execution, another event instance is trapped for debugging, and this continues till debugging is stopped, at which point any trapped instance runs to completion and the debugging worker becomes passive.
+The debug operation traps and sends the next event instance received by the Eventing Function to a separate v8 worker with debugging enabled. Debug is a special flag that can be attach to a Function.
 
-Debugging is convenience feature intended to help during Eventing Function development and should not be used in production environments. It also be noted that using the debugger does not provide correctness or functionality guarantees.
+The debug operation pauses the trapped event, opens a TCP port, and generates a Chrome Developer Tools URL with a session cookie that can be used to control the debug worker.
+With the exception of the trapped event instance, all other Eventing Function events continue processing.
+
+When the trapped event finishes debugging, the debug operation traps another event instance.
+This continues until you stop the operation.
+
+
+== See Also
+
+* xref:eventing-advanced-keyspace-accessors.adoc[Advanced Keyspace Accessors]
+* xref:eventing-language-constructs.adoc#basic_bucket_accessors[Basic Keyspace Accessors]
+* xref:eventing-curl-spec.adoc[cURL]
+* xref:troubleshooting-best-practices.adoc[Troubleshooting and Best Practices]


### PR DESCRIPTION
Changes in this PR:

- Updated structure and style of Terminology page to be consistent with the rest of our docs

The content of the page hasn't been changed, just reorganized and rewritten with clarity and style in mind.