### PR TITLE
Improve SQL++ Vector example and make it work

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/searchfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/searchfun.adoc
@@ -381,7 +381,7 @@ Also the supported type identifiers at the moment are "type_field" and "docid_pr
 
 .Search against a Vector Search index for the closest 2 vectors
 ====
-NOTE: This example does not use the travel sample data or query context mentioned before, as it requires documents that contain vector data. 
+NOTE: This example does not use the travel sample data or query context mentioned before, as it requires documents that contain vector data. The query context should be set to vector-sample and color.
 
 .Query
 [source,sqlpp]
@@ -397,8 +397,8 @@ WHERE SEARCH(t1,
     "knn": [ 
       { 
         "k": 2, 
-        "field": "colorvect_dot", 
-        "vector": [ 0.707106781186548, 0, 0.707106781186548 ]
+        "field": "colorvect_l2", 
+        "vector": [ 192, 0, 191 ]
       }
     ]
   }


### PR DESCRIPTION
Set the query context for scope and collection
Use the same dataset that pendo loads (we dropped colorvect_dot)