### PR TITLE
[AV-75839] Add Page Aliases to Support FTS File Removal on Capella Docs

### DIFF
--- a/modules/search/pages/create-search-indexes.adoc
+++ b/modules/search/pages/create-search-indexes.adoc
@@ -2,6 +2,7 @@
 :page-topic-type: concept 
 :page-ui-name: {ui-name}
 :page-product-name: {product-name}
+:page-aliases: clusters:search-service/create-full-text-indexes.adoc, clusters:search-service/manage-full-text-indexes.adoc
 :description: Create a Search index to get started with the Search Service in your database. 
 
 [abstract]

--- a/modules/search/pages/run-searches.adoc
+++ b/modules/search/pages/run-searches.adoc
@@ -2,6 +2,7 @@
 :page-topic-type: concept
 :page-ui-name: {ui-name}
 :page-product-name: {product-name}
+:page-aliases: clusters:search-service/perform-full-text-searches.adoc
 :description: Run a Search query to search and return the contents of a Search index.
 
 [abstract]

--- a/modules/search/pages/search.adoc
+++ b/modules/search/pages/search.adoc
@@ -2,6 +2,7 @@
 :page-topic-type: concept
 :page-ui-name: {ui-name}
 :page-product-name: {product-name}
+:page-aliases: clusters:search-service/search-service.adoc
 :description: Use the Search Service to create a customizable search experience for your database and your end-user applications. 
 
 [abstract]


### PR DESCRIPTION
Adding some aliases on the Capella side for deleted content from old FTS docs.

There is a related PR on couchbase-cloud for removing those files - this just makes sure that the links to those files don't just end up at a 404. 