### PR TITLE
[DOC-12029] Customer Issue: Importing a Search Index Guidance Did Not Match Capella UI

### DIFF
--- a/modules/search/examples/search-index-alias.jsonc
+++ b/modules/search/examples/search-index-alias.jsonc
@@ -1,0 +1,17 @@
+{
+    "name": "travel-color-index",
+    "type": "fulltext-alias",
+    "params": {
+      "targets": {
+        "travel-sample.inventory.travel-index": {},
+        "vector-sample.color.color-index": {}
+      }
+    },
+    "sourceType": "nil",
+    "sourceName": "",
+    "sourceUUID": "",
+    "sourceParams": null,
+    "planParams": {},
+    "uuid": "",
+    "id": ""
+  }

--- a/modules/search/examples/short-search-index.jsonc
+++ b/modules/search/examples/short-search-index.jsonc
@@ -1,0 +1,47 @@
+{
+    "type": "fulltext-index",
+    "name": "travel-sample.inventory.travel-index",
+    "uuid": "2c4b22c60b59c524",
+    "sourceType": "gocbcore",
+    "sourceName": "travel-sample",
+    "sourceUUID": "76a82f1f3471d9fae3b483f9ee75459d",
+    "planParams": {
+      "maxPartitionsPerPIndex": 1024,
+      "indexPartitions": 1
+    },
+    "params": {
+      "doc_config": {
+        "docid_prefix_delim": "",
+        "docid_regexp": "",
+        "mode": "scope.collection.type_field",
+        "type_field": "type"
+      },
+      "mapping": {
+        "analysis": {},
+        "default_analyzer": "standard",
+        "default_datetime_parser": "dateTimeOptional",
+        "default_field": "_all",
+        "default_mapping": {
+          "dynamic": false,
+          "enabled": false
+        },
+        "default_type": "_default",
+        "docvalues_dynamic": false,
+        "index_dynamic": false,
+        "store_dynamic": false,
+        "type_field": "_type",
+        "types": {
+          "inventory.airline": {
+            "dynamic": false,
+            "enabled": true,
+            "properties": {}
+          }
+        }
+      },
+      "store": {
+        "indexType": "scorch",
+        "segmentVersion": 15
+      }
+    },
+    "sourceParams": {}
+  }

--- a/modules/search/pages/import-search-index.adoc
+++ b/modules/search/pages/import-search-index.adoc
@@ -14,25 +14,57 @@ For more information about how to change Services on your database, see xref:clo
 
 * You have a bucket with scopes and collections in your database. 
 For more information, see xref:cloud:clusters:data-service/manage-buckets.adoc[].
+
+* You have a Search index or Search index alias definition saved as a JSON file.
+For more information about the properties you can include in a Search index or index alias definition, see xref:search-index-params.adoc[].
  
 * You have logged in to the Couchbase {page-ui-name}. 
 
-== Procedure
 
-To import a xref:create-search-indexes.adoc[Search index definition] or xref:index-aliases.adoc[Search alias] with the {page-ui-name}:
+== Import a Search Index Definition 
 
-. On the *Databases* page, select the database where you want to import a Search index or index alias.
+To import a full xref:search-index-params.adoc[Search index definition] with the {page-ui-name}: 
+
+. On the *Databases* page, select the database where you want to import a JSON Search index definition.
 . Go to menu:Data Tools[Search].
-. Do one of the following:
-.. To import a Search index definition, click btn:[Import Search Index].
-.. To import a Search index alias definition, click btn:[Import Search Alias].
-. In the *Index Name* or *Alias Name* field, enter a name for your new Search index or alias. 
-. Upload a JSON file smaller than 40 MB that contains your Search index or alias definition.
-. Click btn:[Import Search Index] or btn:[Import Search Alias].
-//. (Optional) Make any changes to your Search index or index alias settings. 
-//+
-//For more information, see xref:customize-index.adoc[] or xref:create-search-index-alias.adoc[].
-//. Click btn:[Create Index] or btn:[Create Index Alias].
+. Click btn:[Create Search Index].
+. Click btn:[Advanced Mode].
+. Click btn:[Index Definition].
+. Click btn:[Import from File].
+. Upload a JSON file smaller than 40 MB that contains your Search index definition.
++
+For example:
++
+[source,json]
+----
+include::example$short-search-index.jsonc[]
+----
+. (Optional) Make changes to your Search index settings. 
++
+For more information, see xref:customize-index.adoc[] or xref:create-search-index-ui.adoc[].
+. Click btn:[Create Index].
+
+== Import a Search Index Alias Definition 
+
+To import a xref:index-aliases.adoc[Search alias] with the {page-ui-name}:
+
+. On the *Databases* page, select the database where you want to import a JSON Search index alias.
+. Go to menu:Data Tools[Search].
+. Click btn:[Create Search Alias].
+. Click btn:[Alias Definition].
+. Click btn:[Import from File]. 
+. Upload a JSON file smaller than 40 MB that contains your Search alias definition.
++
+For example:
++
+[source,json]
+----
+include::example$search-index-alias.jsonc[]
+----
+. (Optional) Make changes to your Search index alias settings. 
++
+For more information, see xref:create-search-index-alias.adoc[].
+. Click btn:[Create Alias].
 
 == Next Steps
 

--- a/modules/search/pages/import-search-index.adoc
+++ b/modules/search/pages/import-search-index.adoc
@@ -17,6 +17,8 @@ For more information, see xref:cloud:clusters:data-service/manage-buckets.adoc[]
 
 * You have a Search index or Search index alias definition saved as a JSON file.
 For more information about the properties you can include in a Search index or index alias definition, see xref:search-index-params.adoc[].
++
+NOTE: Your JSON file must be smaller than 40 MB. 
  
 * You have logged in to the Couchbase {page-ui-name}. 
 
@@ -31,7 +33,7 @@ To import a full xref:search-index-params.adoc[Search index definition] with the
 . Click btn:[Advanced Mode].
 . Click btn:[Index Definition].
 . Click btn:[Import from File].
-. Upload a JSON file smaller than 40 MB that contains your Search index definition.
+. Upload a JSON file that contains your Search index definition.
 +
 For example:
 +
@@ -53,7 +55,7 @@ To import a xref:index-aliases.adoc[Search alias] with the {page-ui-name}:
 . Click btn:[Create Search Alias].
 . Click btn:[Alias Definition].
 . Click btn:[Import from File]. 
-. Upload a JSON file smaller than 40 MB that contains your Search alias definition.
+. Upload a JSON file that contains your Search alias definition.
 +
 For example:
 +

--- a/modules/search/pages/search-index-params.adoc
+++ b/modules/search/pages/search-index-params.adoc
@@ -13,6 +13,8 @@ This JSON payload sets all the settings for your new Search index.
 
 Your JSON payload must contain the properties described in <<initial,>>, including the <<params,>>.
 
+xref:index-aliases.adoc[Search index aliases] only need to include the properties described in <<initial,>>.
+
 [#initial]
 == Initial Settings 
 
@@ -41,7 +43,7 @@ The type of index you want to create:
 
 * `fulltext-index`: Create a Search index.
 * `fulltext-alias`: Create an alias for a Search index. 
-For more information about Search index aliases, see xref:server:fts:fts-creating-full-text-aliases.adoc[].
+For more information about Search index aliases, see xref:index-aliases.adoc[].
 
 |[[uuid]]uuid |String |No a|
 
@@ -55,9 +57,11 @@ Do not include the `uuid` property when you want to copy an index to a different
 View the UUID for an existing index from the {page-ui-name} by selecting an existing index and clicking btn:[Index Definition].
 The UUID displays in the Index Definition on the Update Index page.
 
-|sourceType |String |Yes |The `sourceType` is always `"gocbcore"`.
+|sourceType |String |Yes |The `sourceType` is always `"gocbcore"` for a Search index.
+For a xref:index-aliases.adoc[Search index alias], it's `"nil"`.
 
-|sourceName |String |Yes |The name of the bucket where you want to create the Search index. 
+|sourceName |String |Yes |The name of the bucket where you want to create the Search index.
+Do not include a `sourceName` for a Search index alias. 
 
 |[[sourceuuid]]sourceUUID |String |No a|
 
@@ -73,16 +77,24 @@ This object contains advanced settings for index behavior.
 
 Do not add content into this object unless instructed by Couchbase Support.
 
-|planParams |Object |Yes |An object that sets the Search index's partitions and replications. 
+|planParams |Object |Yes a|An object that sets the Search index's partitions and replications. 
 For more information, see <<planparams,>>.
 
-|params |Object |Yes |An object that sets the Search index's type identifier, type mappings, and analyzers. 
+Do not include any of the properties in a `planParams` object for a xref:index-aliases.adoc[Search index alias].
+
+|params |Object |Yes a|
+
+An object that sets the Search index's type identifier, type mappings, and analyzers. 
 For more information, see <<params,>>.
+
+For a xref:index-aliases.adoc[Search index alias], this object contains the <<targets,targets object>>.
 
 |====
 
 [#planparams]
 == planParams Object 
+
+NOTE: Do not include any of the properties in a `planParams` object for a xref:index-aliases.adoc[Search index alias].
 
 The `planParams` object sets a Search index's partition and replication settings:
 
@@ -121,6 +133,8 @@ The number of replicas you can create depends on the number of nodes you have av
 
 The `params` object sets a Search index's xref:customize-index.adoc#type-identifiers[type identifier], xref:customize-index.adoc#type-mappings[type mappings], and xref:customize-index.adoc#analyzers[analyzers].
 
+For a xref:index-aliases.adoc[Search index alias], it includes a JSON object for each Search index to include in the alias. 
+
 It contains the following properties:
 
 [cols="1,1,1,2"]
@@ -132,6 +146,19 @@ For more information, see <<doc-config,>>.
 
 |mapping |Object |Yes |An object that sets the analyzers and type mappings for a Search index. 
 For more information, see <<mapping,>>.
+
+|[[targets]]targets |Object |Index Alias Only a| An object that contains JSON objects for each Search index to add to the alias definition. 
+
+The key for each JSON object must be the fully qualified name of each Search index. 
+
+For example: 
+
+----
+"targets": {
+
+    "vector-sample.color.color-index": {}
+}
+----
 
 |====
 


### PR DESCRIPTION
Making updates to import-search-index and search-index-params since the UI did not change as expected.

Guidance now reflects the UI for how to import search indexes.

Added two new examples to support the page.