### PR TITLE
[DOC-12098] Added back ticks to create index example in WITH RECURSIVE page

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/with-recursive.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/with-recursive.adoc
@@ -257,7 +257,7 @@ SELECT * FROM similar_items;
 ====
 [source,sqlpp]
 ----
-CREATE INDEX srcdestidx ON travel-sample.inventory.route( sourceairport, destinationairport );
+CREATE INDEX srcdestidx ON `travel-sample`.inventory.route( sourceairport, destinationairport );
 
 WITH RECURSIVE recroute AS (
     SELECT sourceairport, destinationairport, 0 as depth,


### PR DESCRIPTION
Small fix to add back ticks to "travel-sample" in the create index example 4 on the [WITH RECURSIVE page](https://docs.couchbase.com/server/current/n1ql/n1ql-language-reference/with-recursive.html).

Fix version on the doc ticket is 7.6.2 but since this is a fix and the code example doesn't run without the back ticks, should we just merge it right now?

Jira ticket: [DOC-12098](https://issues.couchbase.com/browse/DOC-12098)