### PR TITLE
[DOC-12106] Hybrid Search + Regular Search Scoring Explainer

### DIFF
--- a/modules/search/pages/geo-search-ui.adoc
+++ b/modules/search/pages/geo-search-ui.adoc
@@ -7,6 +7,8 @@
 [abstract]
 {description}
 
+For more information about how the Search Service scores documents in search results, see xref:run-searches.adoc#scoring[Scoring for Search Queries].
+
 == Prerequisites
 
 * You have the Search Service enabled on a node in your database.

--- a/modules/search/pages/run-searches.adoc
+++ b/modules/search/pages/run-searches.adoc
@@ -46,7 +46,7 @@ hit_score = (query_1_boost * query_1_hit_score) + (knn_boost * knn_distance)
 
 When running a hybrid search with the <<ui,Web Console>> or <<api,REST API>>, the Search Service displays results as a disjunct (`OR`) between your regular Search and Vector Search queries. 
 
-TIP: When running a hybrid Search query, you should add a `boost` value to your regular Search query to level the `tf-idf` score with the knn distance.
+TIP: When running a hybrid Search query, you should add a `boost` value to your regular Search query to level the `tf-idf` score with the `knn` distance.
 Otherwise, you might see unexpected search results.
 This is because of the differences in the scoring algorithms between the 2 query types.
 

--- a/modules/search/pages/run-searches.adoc
+++ b/modules/search/pages/run-searches.adoc
@@ -8,6 +8,8 @@
 [abstract]
 {description}
 
+If you use the default search result xref:search-request-params.adoc#sort[sorting] of `_score`, a documents <<scoring,score>> determines where it appears in your search results. 
+
 NOTE: You need to xref:create-search-indexes.adoc[create a Search index] before you can run a search with the Search Service.
 
 You can run a search against a Search index with: 
@@ -20,6 +22,33 @@ You can run a search against a Search index with:
 include::partial$sdks-fts-links.adoc[]
 
 To run a Search query against multiple Search indexes at once, xref:create-search-index-alias.adoc[].
+
+[#scoring]
+== Scoring for Search Queries 
+
+To determine a document's score in search results, the Search Service uses the https://en.wikipedia.org/wiki/Tf%E2%80%93idf[tf-idf^] algorithm. 
+`tf-idf` increases the score of a document based on term frequency, or the number of times a term appears in a document divided by the total number of terms in the document. 
+It penalizes document frequency, or how often a term appears across all documents. 
+
+The `tf-idf` score is calculated at a partition level in a Search index. 
+
+The Search Service uses `tf-idf` to calculate the hit score for a document, multiplied by any xref:search-request-params.adoc#boost[boost] parameters applied to each query inside the xref:search-request-params.adoc#query-object[query object]: 
+
+----
+hit_score = (query_1_boost * query_1_hit_score) + (query_2_boost * query_2_hit_score)
+----
+
+If one of your Search queries is a xref:vector-search:vector-search.adoc[Vector Search query], the calculation changes to: 
+
+----
+hit_score = (query_1_boost * query_1_hit_score) + (knn_boost * knn_distance)
+----
+
+When running a hybrid search with the <<ui,Web Console>> or <<api,REST API>>, the Search Service displays results as a disjunct (`OR`) between your regular Search and Vector Search queries. 
+
+TIP: When running a hybrid Search query, you should add a `boost` value to your regular Search query to level the `tf-idf` score with the knn distance.
+Otherwise, you might see unexpected search results.
+This is because of the differences in the scoring algorithms between the 2 query types.
 
 [#ui]
 == Run a Search with the {page-ui-name}
@@ -47,6 +76,57 @@ For more information about how to configure a Search index and search for geospa
 == Run a Search with a {sqlpp} Query 
 
 Use the xref:clusters:query-service/query-workbench.adoc[Query tab] to search using natural-language search and {sqlpp} features in the same query. 
+
+When using {sqlpp} with a hybrid xref:vector-search:vector-search.adoc[Vector Search] query, you have more flexibility in how you choose to display your search results. 
+When running a hybrid search with the <<ui,Web Console>> or <<api,REST API>>, the Search Service displays results as a disjunct (`OR`) between your 2 search queries. 
+For example: 
+
+----
+
+{ 
+    "query": 
+    {
+        "match_phrase": "my regular query"
+    } 
+}
+
+OR 
+
+{
+    "knn": [
+        "k": 5,
+        "field": "vector_field",
+        "vector": [0, 0, 128]
+    ]
+}
+----
+
+{sqlpp} allows you to choose whether to return search results as a conjunct (`AND`) or a disjunct (`OR`) between for hybrid search queries.
+
+As a conjunct, the Search Service returns matches that score highly for both the regular Search query and the Vector Search query. 
+The Search Service would exclude matches that only match the Vector Search query.
+For example: 
+
+[source,sqlpp]
+----
+
+SELECT meta().id FROM <key_space>
+WHERE text = "content"
+AND SEARCH(<key_space>, {"query": {"match": "content", "field": "text"}, "knn": {"vector": <vector_embedding>", "field": "vector_field", "k": 5}});
+
+----
+
+As a disjunct, the Search Service returns matches for the regular Search query, followed by matches for the Vector Search query.
+As a result, you could see matches for the Vector Search query that do not contain matches for the regular Search query. 
+For example: 
+
+[source,sqlpp]
+----
+
+SELECT meta().id FROM <key_space>
+WHERE SEARCH (<key_space>, {"query": {"match": "content", "field": "text"}, "knn": {"vector": <vector_embedding>", "field": "vector_field", "k": 5}});
+
+----
 
 For more information about how to use the Search Service from a {sqlpp} query, see xref:n1ql:n1ql-language-reference/searchfun.adoc[].
 

--- a/modules/search/pages/run-searches.adoc
+++ b/modules/search/pages/run-searches.adoc
@@ -10,7 +10,7 @@
 
 If you use the default search result xref:search-request-params.adoc#sort[sorting] of `_score`, a documents <<scoring,score>> determines where it appears in your search results. 
 
-NOTE: You need to xref:create-search-indexes.adoc[create a Search index] before you can run a search with the Search Service.
+NOTE: You must xref:create-search-indexes.adoc[create a Search index] before you can run a search with the Search Service.
 
 You can run a search against a Search index with: 
 
@@ -103,8 +103,10 @@ OR
 
 {sqlpp} allows you to choose whether to return search results as a conjunct (`AND`) or a disjunct (`OR`) between for hybrid search queries.
 
-As a conjunct, the Search Service returns matches that score highly for both the regular Search query and the Vector Search query. 
-The Search Service would exclude matches that only match the Vector Search query.
+As a conjunct, the Search Service:
+
+* Returns matches that score highly for both the regular Search query and the Vector Search query. 
+* Excludes matches that only match the Vector Search query.
 For example: 
 
 [source,sqlpp]
@@ -116,8 +118,12 @@ AND SEARCH(<key_space>, {"query": {"match": "content", "field": "text"}, "knn": 
 
 ----
 
-As a disjunct, the Search Service returns matches for the regular Search query, followed by matches for the Vector Search query.
+As a disjunct, the Search Service: 
+
+* Returns matches for the regular Search query, followed by matches for the Vector Search query.
+
 As a result, you could see matches for the Vector Search query that do not contain matches for the regular Search query. 
+
 For example: 
 
 [source,sqlpp]

--- a/modules/search/pages/run-searches.adoc
+++ b/modules/search/pages/run-searches.adoc
@@ -8,7 +8,7 @@
 [abstract]
 {description}
 
-If you use the default search result xref:search-request-params.adoc#sort[sorting] of `_score`, a documents <<scoring,score>> determines where it appears in your search results. 
+If you use the default search result xref:search-request-params.adoc#sort[sorting] of `_score`, a document's <<scoring,score>> determines where it appears in your search results. 
 
 NOTE: You must xref:create-search-indexes.adoc[create a Search index] before you can run a search with the Search Service.
 

--- a/modules/search/pages/run-searches.adoc
+++ b/modules/search/pages/run-searches.adoc
@@ -101,7 +101,7 @@ OR
 }
 ----
 
-{sqlpp} allows you to choose whether to return search results as a conjunct (`AND`) or a disjunct (`OR`) between for hybrid search queries.
+{sqlpp} allows you to choose whether to return search results as a conjunct (`AND`) or a disjunct (`OR`) for hybrid search queries.
 
 As a conjunct, the Search Service returns matches that score highly for both the regular Search query and the Vector Search query. 
 The Search Service would exclude matches that only match the Vector Search query.

--- a/modules/search/pages/simple-search-ui.adoc
+++ b/modules/search/pages/simple-search-ui.adoc
@@ -7,6 +7,8 @@
 [abstract]
 {description}
 
+For more information about how the Search Service scores documents in search results, see xref:run-searches.adoc#scoring[Scoring for Search Queries].
+
 == Prerequisites 
 
 * You have the Search Service enabled on a node in your database.

--- a/modules/vector-search/pages/run-vector-search-sdk.adoc
+++ b/modules/vector-search/pages/run-vector-search-sdk.adoc
@@ -9,6 +9,8 @@
 [abstract]
 {description}
 
+For more information about how the Search Service scores documents in search results, see xref:run-searches.adoc#scoring[Scoring for Search Queries].
+
 
 == Prerequisites
 

--- a/modules/vector-search/pages/run-vector-search-ui.adoc
+++ b/modules/vector-search/pages/run-vector-search-ui.adoc
@@ -7,6 +7,8 @@
 [abstract]
 {description}
 
+For more information about how the Search Service scores documents in search results, see xref:run-searches.adoc#scoring[Scoring for Search Queries].
+
 == Prerequisites 
 
 * You have the Search Service enabled on a node in your database.


### PR DESCRIPTION
Ticket was logged in response to a partner needing more clarity around how the Search Service scores documents in searches/hybrid searches using Vector Search.

I updated all of the "run a search" pages to point back to this basic explainer page on running Searches, and specifically point to the section on scoring - since the default sort for searches is by score.

Equivalent Server PR: https://github.com/couchbaselabs/docs-devex/pull/181

Preview site: https://preview.docs-test.couchbase.com/sarah-DOC-12106/server/current/search/run-searches.html 