### PR TITLE
[DOC-11979] LlamaIndex Integration Docs

### DIFF
--- a/modules/third-party/pages/integrations.adoc
+++ b/modules/third-party/pages/integrations.adoc
@@ -37,7 +37,7 @@ a| * https://docs.llamaindex.ai/en/stable/api_reference/storage/vector_store/cou
 | Community Supported
 
 | LangChain
-a| Use the Couchbase LangChain integrations to quickly start developing AI applications with your Couchbase database:  
+a| Use the Couchbase LangChain integrations to quickly start developing AI applications with your Couchbase database.  
 
 Use the document loader to get documents from a Couchbase database.
 

--- a/modules/third-party/pages/integrations.adoc
+++ b/modules/third-party/pages/integrations.adoc
@@ -24,6 +24,18 @@ These are examples of integrations that Couchbase or partners have developed to 
 |===
 | Integration | Summary | Links | Capella | Self-managed |  <<#support-model,Support Model>>
 
+| LlamaIndex
+a| Use the Couchbase LlamaIndex integrations to quickly start developing AI applications with your Couchbase database and Python.
+
+You can use the Couchbase LlamaIndex Readers Integration to load documents from a Couchbase database, and use the other documentation and samples to get started. 
+a| * https://docs.llamaindex.ai/en/stable/api_reference/storage/vector_store/couchbase/[CouchbaseVectorStore - LlamaIndex API Reference]
+* https://docs.llamaindex.ai/en/stable/examples/vector_stores/CouchbaseVectorStoreDemo/[CouchbaseVectorStoreDemo Documentation]
+* https://github.com/couchbase-examples/rag-demo-llama-index[Couchbase RAG Demo Application with Streamlit, LlamaIndex, and OpenAI]
+* https://llamahub.ai/l/readers/llama-index-readers-couchbase?from=readers[LlamaIndex Readers Integration: Couchbase]
+| ✔
+| ✔
+| Community Supported
+
 | LangChain
 a| Use the Couchbase LangChain integrations to quickly start developing AI applications with your Couchbase database:  
 


### PR DESCRIPTION
Since we're single sourcing this page now, this single PR should also take care of https://couchbasecloud.atlassian.net/browse/AV-75077 

Just adding the links to documentation on the LlamaIndex side for the Couchbase x LlamaIndex integration. 