### PR TITLE
DOC-7394: Remove N1QL auditing and backfill pages

### DIFF
--- a/modules/n1ql/examples/transactions/results.jsonc
+++ b/modules/n1ql/examples/transactions/results.jsonc
@@ -1,4 +1,5 @@
 // tag::extract[]
+// tag::extract-1[]
 [
   {
     "_sequence_num": 1,
@@ -12,6 +13,8 @@
 // end::begin[]
     ]
   },
+// end::extract-1[]
+// tag::extract-2[]
   {
     "_sequence_num": 2,
     "_sequence_query": "\n\n-- Specify transaction settings\nSET TRANSACTION ISOLATION LEVEL READ COMMITTED;",
@@ -64,6 +67,8 @@
       }
     ]
   },
+// end::extract-2[]
+// tag::extract-3[]
   {
     "_sequence_num": 7,
     "_sequence_query": "\n\n-- Set a second savepoint\nSAVEPOINT s2;",
@@ -96,6 +101,8 @@
       }
     ]
   },
+// end::extract-3[]
+// tag::extract-4[]
   {
     "_sequence_num": 10,
     "_sequence_query": "\n\n-- Roll back the transaction to the second savepoint\nROLLBACK TRAN TO SAVEPOINT s2;",
@@ -131,3 +138,4 @@
     }
   }
 ]
+// end::extract-4[]

--- a/modules/n1ql/pages/n1ql-language-reference/n1ql-auditing.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/n1ql-auditing.adoc
@@ -1,7 +1,6 @@
 = {sqlpp} Auditing
 :description: {sqlpp}-related activities can be audited, by Couchbase Server.
 :page-topic-type: reference
-:no-escape-hatch:
 
 [abstract]
 {description}

--- a/modules/n1ql/pages/n1ql-language-reference/n1ql-auditing.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/n1ql-auditing.adoc
@@ -365,7 +365,7 @@ Below is the list of all events that are captured in the audit logs.
 . Enabling auditing, with audit settings written
 . Login, both success and failure
 . Logout, both success and failure
-. Data access operations -- see xref:server:audit-event-reference:audit-event-reference.adoc#query-service-event-list-table[Query and Index Service Events] in the Server documentation
+. Data access operations -- see xref:audit-event-reference:audit-event-reference.adoc#query-service-event-list-table[Query and Index Service Events]
 . Audit archive
 . System backup
 . Data service:

--- a/modules/n1ql/pages/n1ql-language-reference/n1ql-auditing.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/n1ql-auditing.adoc
@@ -11,8 +11,7 @@ include::ROOT:partial$component-signpost.adoc[]
 == Understanding {sqlpp} Auditing
 
 This section provides specific information on Couchbase Server auditing as it relates to {sqlpp}.
-For a general description of configuring auditing with Couchbase Web Console, see
-xref:learn:security/authorization-overview.adoc[Authorization].
+For a general description of auditing with Couchbase Server, see xref:learn:security/auditing.adoc[].
 
 Couchbase Server provides auditing for {sqlpp}-related activities such as the following:
 
@@ -39,9 +38,8 @@ Events available to be audited include ones issued through the SDK, the Query wo
 The audit records are written in JSON format to match the format used for Admin Auditing to allow easy integration with downstream auditing tools for audit log analysis.
 The syslog format will allow for integration with third party SIEM tools, such as QRadar.
 
-Required auditing fields for executed statements:
-
-[cols="1,4,4"]
+.Required auditing fields for executed statements
+[cols="1,4a,4a"]
 |===
 | Field | Description | Example
 
@@ -72,20 +70,20 @@ Required auditing fields for executed statements:
 | `userAgent`
 | To identify the type of user by a combination of the User-Agent and CB-User-Agent headers in one of the four formats:
 
-1) CURL request
+. CURL request
 
-2) Query Workbench
+. Query Workbench
 
-3) CBQ shell
+. CBQ shell
 
-4) SDK
-| 1) `curl/7.43.0`
+. SDK
+| . `curl/7.43.0`
 
-2) `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.100 Safari/537.36 (Couchbase Query Workbench (5.1.0-1434-enterprise))`
+. `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.100 Safari/537.36 (Couchbase Query Workbench (5.1.0-1434-enterprise))`
 
-3) `Go-http-client/1.1 (CBQ/2.0)`
+. `Go-http-client/1.1 (CBQ/2.0)`
 
-4) `+couchbase-java-client/2.5.2 (git: 2.5.2, core: 1.5.2) (Mac OS X/10.11.6 x86_64; Java HotSpot(TM) 64-Bit Server VM 1.8.0_101-b13)+`
+. `+couchbase-java-client/2.5.2 (git: 2.5.2, core: 1.5.2) (Mac OS X/10.11.6 x86_64; Java HotSpot(TM) 64-Bit Server VM 1.8.0_101-b13)+`
 
 | `node`
 | Assigned name (IP address) of the server where the request ran.
@@ -120,8 +118,7 @@ Required auditing fields for executed statements:
 | `A {sqlpp} SELECT statement was executed`
 |===
 
-Optional auditing fields for statements:
-
+.Optional auditing fields for statements
 [cols="2,5,5"]
 |===
 | Field | Description | Example
@@ -147,8 +144,7 @@ The parameter can be set by any user in any request and is not verified in the s
 |
 |===
 
-Required auditing fields for API requests:
-
+.Required auditing fields for API requests
 [cols="2,5,5"]
 |===
 | Field | Description | Example
@@ -190,15 +186,7 @@ Required auditing fields for API requests:
 
 To reduce disk usage and improve performance, the log files are as compact as possible.
 
-To make the log entry easier-to-read, use a formatting utility such as https://stedolan.github.io/jq/[jq^], or reformat the log entry through the Query Workbench:
-
-. Copy the log entry to the clipboard
-. Open Query Workbench
-. Type `SELECT`
-. Paste the query from the clipboard
-. Click the btn:[Execute] button
-
-When viewed through Query Workbench, the logs are formatted and indented for easier reading.
+To make the log entry easier-to-read, use a formatting utility such as https://stedolan.github.io/jq/[jq^].
 
 .{blank}
 ====

--- a/modules/n1ql/pages/n1ql-language-reference/n1ql-auditing.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/n1ql-auditing.adoc
@@ -67,18 +67,18 @@ The syslog format will allow for integration with third party SIEM tools, such a
 | `TRUE`
 
 | `userAgent`
-| To identify the type of user by a combination of the User-Agent and CB-User-Agent headers in one of the four formats:
-
-. CURL request
+| To identify the type of user by a combination of the User-Agent and CB-User-Agent headers in one of the following formats:
 
 . Query Workbench
+
+. CURL request
 
 . CBQ shell
 
 . SDK
-| . `curl/7.43.0`
+| . `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.100 Safari/537.36 (Couchbase Query Workbench (5.1.0-1434-enterprise))`
 
-. `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.100 Safari/537.36 (Couchbase Query Workbench (5.1.0-1434-enterprise))`
+. `curl/7.43.0`
 
 . `Go-http-client/1.1 (CBQ/2.0)`
 
@@ -132,16 +132,16 @@ The syslog format will allow for integration with third party SIEM tools, such a
 
 | `clientContextId`
 a|
-Captured from the `client_context_id` parameter of the {sqlpp} query API.
+Captured from the `client_context_id` parameter of the {sqlpp} query.
 
 May be used to distinguish between user-generated queries and UI-generated queries from the Query WorkBench.
 
 UI-generated queries have the prefix `INTERNAL-` in this field.
+|
+|===
 
 NOTE: The client context ID has no security guarantees.
 The parameter can be set by any user in any request and is not verified in the server, so it should not be relied upon for security purposes.
-|
-|===
 
 .Required auditing fields for API requests
 [cols="2,5,5"]
@@ -330,106 +330,7 @@ Below is the list of all events that are captured in the audit logs.
 . Enabling Auditing, with audit settings written
 . Login, both Success and Failure
 . Logout, both Success and Failure
-. Data access operations
-+
-|===
-| a. Query Service | Event ID
-
-| `ALTER INDEX`
-| 28683
-
-| `BUILD INDEX`
-| 28684
-
-| `CREATE INDEX`
-| 28681
-
-| `CREATE PRIMARY INDEX`
-| 28688
-
-| `DELETE`
-| 28678
-
-| `DROP INDEX`
-| 28682
-
-| `EXPLAIN`
-| 28673
-
-| `GRANT`
-| 28685
-
-| `INFER`
-| 28675
-
-| `INSERT`
-| 28676
-
-| `MERGE`
-| 28680
-
-| `PREPARE`
-| 28674
-
-| `REVOKE`
-| 28686
-
-| `SELECT`
-| 28672
-
-| `UNRECOGNIZED`
-| 28687
-
-| `UPDATE`
-| 28679
-
-| `UPSERT`
-| 28677
-|===
-+
-|===
-| b. API Request | Event ID
-
-| `/admin/active_requests`
-| 28692
-
-| `/admin/clusters`
-| 28701
-
-| `/admin/completed_requests`
-| 28702
-
-| `/admin/config`
-| 28698
-
-| `/admin/indexes/active_requests`
-| 28694
-
-| `/admin/indexes/completed_requests`
-| 28702
-
-| `/admin/indexes/prepareds`
-| 28693
-
-| `/admin/ping`
-| 28697
-
-| `/admin/prepareds`
-| 28691
-
-| `/admin/settings`
-| 28700
-
-| `/admin/ssl_cert`
-| 28699
-
-| `/admin/stats`
-| 28689
-
-| `/admin/vitals`
-| 28690
-|===
-
+. Data access operations -- see xref:server:audit-event-reference:audit-event-reference.adoc#query-service-event-list-table[Query and Index Service Events] in the Server documentation
 . Audit-Archive
 . System-Backup
 . Data service
@@ -440,7 +341,7 @@ Below is the list of all events that are captured in the audit logs.
 . FTS Service
  .. FTS-Read
 . Analytics audit events
-+
+
 Items that will not be captured in the audit logs:
 
  ** API calls that are not statements

--- a/modules/n1ql/pages/n1ql-language-reference/n1ql-auditing.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/n1ql-auditing.adoc
@@ -2,6 +2,41 @@
 :description: {sqlpp}-related activities can be audited, by Couchbase Server.
 :page-topic-type: reference
 
+// Pass through HTML table styles for this page
+
+ifdef::basebackend-html[]
+++++
+<style type="text/css">
+  /* No maximum width for table cells */
+  .doc table.spread > tbody > tr > *,
+  .doc table.stretch > tbody > tr > * {
+    max-width: none !important;
+  }
+
+  /* Wrap code listings in table cells */
+  td .listingblock .content pre code {
+    white-space: pre-wrap !important;
+  }
+
+  /* Ignore fixed column widths */
+  table:not(.fixed-width) col{
+    width: auto !important;
+  }
+
+  /* Do not hyphenate words in the table */
+  td.tableblock p,
+  p.tableblock{
+    hyphens: manual !important;
+  }
+
+  /* Vertical alignment */
+  td.tableblock{
+    vertical-align: top !important;
+  }
+</style>
+++++
+endif::[]
+
 [abstract]
 {description}
 

--- a/modules/n1ql/pages/n1ql-language-reference/n1ql-auditing.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/n1ql-auditing.adoc
@@ -360,20 +360,20 @@ The xref:cli:cbcollect-info-tool.adoc[cbcollect_info] utility does not collect a
 
 Below is the list of all events that are captured in the audit logs.
 
-. System clock modifications as captured in the operating system audit log
-. Disabling Auditing
-. Enabling Auditing, with audit settings written
-. Login, both Success and Failure
-. Logout, both Success and Failure
+. System clock modifications, as captured in the operating system audit log
+. Disabling auditing
+. Enabling auditing, with audit settings written
+. Login, both success and failure
+. Logout, both success and failure
 . Data access operations -- see xref:server:audit-event-reference:audit-event-reference.adoc#query-service-event-list-table[Query and Index Service Events] in the Server documentation
-. Audit-Archive
-. System-Backup
-. Data service
+. Audit archive
+. System backup
+. Data service:
  .. Read
  .. Write
  .. DCP-Read
  .. DCP-Write
-. FTS Service
+. Search service:
  .. FTS-Read
 . Analytics audit events
 


### PR DESCRIPTION
Docs issue: DOC-7394

This PR merges the following minor fixes from Capella forward to Server 7.6:

* https://github.com/couchbaselabs/docs-devex/pull/191