### PR TITLE
[DOC-12168] Copy Changes from AV-75759

### DIFF
--- a/modules/vector-search/examples/run-hybrid-search-payload-ui.jsonc
+++ b/modules/vector-search/examples/run-hybrid-search-payload-ui.jsonc
@@ -1,0 +1,17 @@
+{
+    "fields": ["*"], 
+    "query": { 
+      "min": 70,
+      "max": 80,
+      "inclusive_min": false,
+      "inclusive_max": true,
+      "field": "brightness"
+    }, 
+    "knn": [
+      {
+        "k": 1, 
+        "field": "colorvect_l2", 
+        "vector": [ 0, 0, 128 ]
+      }
+    ]
+}

--- a/modules/vector-search/examples/sample-vector-search-index-payload.json
+++ b/modules/vector-search/examples/sample-vector-search-index-payload.json
@@ -1,0 +1,102 @@
+{
+    "name": "color-test",
+    "type": "fulltext-index",
+    "params": {
+     "doc_config": {
+      "docid_prefix_delim": "",
+      "docid_regexp": "",
+      "mode": "scope.collection.type_field",
+      "type_field": "type"
+     },
+     "mapping": {
+      "default_analyzer": "standard",
+      "default_datetime_parser": "dateTimeOptional",
+      "default_field": "_all",
+      "default_mapping": {
+       "dynamic": true,
+       "enabled": false
+      },
+      "default_type": "_default",
+      "docvalues_dynamic": false,
+      "index_dynamic": true,
+      "store_dynamic": false,
+      "type_field": "_type",
+      "types": {
+       "color.rgb": {
+        "dynamic": false,
+        "enabled": true,
+        "properties": {
+         "brightness": {
+          "enabled": true,
+          "dynamic": false,
+          "fields": [
+           {
+            "docvalues": true,
+            "index": true,
+            "name": "brightness",
+            "store": true,
+            "type": "number"
+           }
+          ]
+         },
+         "color": {
+          "enabled": true,
+          "dynamic": false,
+          "fields": [
+           {
+            "docvalues": true,
+            "include_term_vectors": true,
+            "index": true,
+            "name": "color",
+            "store": true,
+            "type": "text"
+           }
+          ]
+         },
+         "colorvect_l2": {
+          "enabled": true,
+          "dynamic": false,
+          "fields": [
+           {
+            "dims": 3,
+            "index": true,
+            "name": "colorvect_l2",
+            "similarity": "l2_norm",
+            "type": "vector",
+            "vector_index_optimized_for": "recall"
+           }
+          ]
+         },
+         "embedding_vector_dot": {
+          "enabled": true,
+          "dynamic": false,
+          "fields": [
+           {
+            "dims": 1536,
+            "index": true,
+            "name": "embedding_vector_dot",
+            "similarity": "dot_product",
+            "type": "vector",
+            "vector_index_optimized_for": "recall"
+           }
+          ]
+         }
+        }
+       }
+      }
+     },
+     "store": {
+      "indexType": "scorch",
+      "segmentVersion": 16
+     }
+    },
+    "sourceType": "gocbcore",
+    "sourceName": "vector-sample",
+    "sourceParams": {},
+    "planParams": {
+     "maxPartitionsPerPIndex": 1024,
+     "indexPartitions": 1,
+     "numReplicas": 0
+    },
+    "uuid": "42676f35cc30b84a"
+   }

--- a/modules/vector-search/pages/create-vector-search-index-rest-api.adoc
+++ b/modules/vector-search/pages/create-vector-search-index-rest-api.adoc
@@ -53,6 +53,7 @@ Do not include the xref:search:search-index-params.adoc#uuid[uuid] or xref:searc
 TIP: If you remove the xref:search:search-index-params.adoc#uuid[uuid] and xref:search:search-index-params.adoc#sourceuuid[sourceUUID] parameters, you can copy the Search index definition JSON payload from the Couchbase {page-ui-name} to use in a REST API call.
 For more information about how to create a Vector Search index with the UI, see xref:create-vector-search-index-ui.adoc[]. 
 
+[#example]
 === Example
 
 In the following example, the JSON payload creates an index named `color-index` on the `vector-sample.color.rgb` keyspace. 
@@ -64,6 +65,8 @@ It also adds 3 normal Search index fields (`brightness`, `color`, and `descripti
 ----
 include::example$create-vector-search-index-payload.sh[]
 ----
+
+NOTE: This sample JSON Vector Search index is the same as the one provided in xref:create-vector-search-index-ui.adoc[].
 
 For more information about all the available JSON properties for a Search index, see xref:search:search-index-params.adoc[].
 

--- a/modules/vector-search/pages/create-vector-search-index-ui.adoc
+++ b/modules/vector-search/pages/create-vector-search-index-ui.adoc
@@ -95,6 +95,7 @@ This Vector Search index has a type mapping for a `color.rgb` collection and inc
 
 * The *brightness number* field, which is included in search results and supports sorting and faceting.
 * The *color string* field, which is included in search results, supports highlighting, phrase matching, and sorting and faceting.
+* The *description string* field, which is included in search results, supports highlighting, phrase matching, and sorting and faceting.
 * The *colorvect_l2 [ number ]* field, which has a Dimension of `3` and uses the *l2_norm* Similarity Metric.
 * The *embedding_vector_dot [ number ]* field, which has a dimension of `1536` and uses the *dot_product* Similarity Metric. 
 

--- a/modules/vector-search/pages/create-vector-search-index-ui.adoc
+++ b/modules/vector-search/pages/create-vector-search-index-ui.adoc
@@ -1,7 +1,8 @@
-= Create a Vector Search Index with the Web Console
+= Create a Vector Search Index with the {page-ui-name}
 :page-topic-type: guide
 :page-ui-name: {ui-name}
 :page-product-name: {product-name}
+:page-toclevels: 2
 :description: You can create a Vector Search index with the Couchbase {page-ui-name}. 
 
 [abstract]
@@ -78,13 +79,30 @@ For more information, see xref:search:child-field-options-reference.adoc[].
 For example, you could add the text field that you used to generate your vector embeddings. 
 . Click btn:[Create Index].
 
+[#example]
+=== Example: Creating a Vector Search Index for Vector Search Query Examples 
+
+If you want to use the sample dataset for the examples in xref:run-vector-search-ui.adoc[] and xref:run-vector-search-sdk.adoc[], then you can xref:search:import-search-index.adoc[import] the following Search index definition into {page-ui-name}:
+
+[source,json]
+----
+include::example$sample-vector-search-index-payload.json[]
+----
+
+NOTE: Make sure you imported the sample dataset with the recommended settings. 
+
+This Vector Search index has a type mapping for a `color.rgb` collection and includes the following fields: 
+
+* The *brightness number* field, which is included in search results and supports sorting and faceting.
+* The *color string* field, which is included in search results, supports highlighting, phrase matching, and sorting and faceting.
+* The *colorvect_l2 [ number ]* field, which has a Dimension of `3` and uses the *l2_norm* Similarity Metric.
+* The *embedding_vector_dot [ number ]* field, which has a dimension of `1536` and uses the *dot_product* Similarity Metric. 
+
 == Next Steps 
 
-This basic Vector Search index includes the vector embeddings from the child field you specified in your type mapping.
-If you chose to add additional child fields and enabled *Include in search results*, the Search Service can also return data from those fields when you run a Vector Search query.  
+A basic Vector Search index includes the vector embeddings from the child field you specified in your type mapping.
+If you choose to add additional child fields and enable *Include in search results*, the Search Service can also return data from those child fields when you run a Vector Search query.
 
-For example, if you used the Vector Search sample data, you might want to add child fields for the *colorvect_l2* vector field and the *color* string field.
-Adding the *color* string field lets you return the color names with your Search query.
 For more information about how to add additional child fields to your index, see xref:search:create-quick-index.adoc[] or xref:search:create-child-field.adoc[].
 
 You can customize your Vector Search index like any other Search index to add additional data and improve search results. 

--- a/modules/vector-search/pages/create-vector-search-index-ui.adoc
+++ b/modules/vector-search/pages/create-vector-search-index-ui.adoc
@@ -94,8 +94,7 @@ NOTE: Make sure you imported the sample dataset with the recommended settings.
 This Vector Search index has a type mapping for a `color.rgb` collection and includes the following fields: 
 
 * The *brightness number* field, which is included in search results and supports sorting and faceting.
-* The *color string* field, which is included in search results, supports highlighting, phrase matching, and sorting and faceting.
-* The *description string* field, which is included in search results, supports highlighting, phrase matching, and sorting and faceting.
+* The *color string* and *description string* fields, which are included in search results, support highlighting, phrase matching, and sorting and faceting.
 * The *colorvect_l2 [ number ]* field, which has a Dimension of `3` and uses the *l2_norm* Similarity Metric.
 * The *embedding_vector_dot [ number ]* field, which has a dimension of `1536` and uses the *dot_product* Similarity Metric. 
 

--- a/modules/vector-search/pages/run-vector-search-rest-api.adoc
+++ b/modules/vector-search/pages/run-vector-search-rest-api.adoc
@@ -32,7 +32,7 @@ For more information about how to create a Vector Search index, see xref:create-
 --
 include::partial$download-sample-partial.adoc[]
 
-For the best results, xref:search-create-quick-index.adoc[create child fields in Quick Mode] or xref:search:create-child-field.adoc[in Advanced Mode] for the `colorvect_l2` and `color` fields. 
+For the best results, consider using the sample Vector Search index from xref:create-vector-search-index-ui.adoc#example[Create a Vector Search Index with the {page-ui-name}] or xref:create-vector-search-index-rest-api.adoc#example[Create a Vector Search Index with the REST API and curl/HTTP]. 
 --
 
 == Procedure 

--- a/modules/vector-search/pages/run-vector-search-sdk.adoc
+++ b/modules/vector-search/pages/run-vector-search-sdk.adoc
@@ -33,7 +33,7 @@ For more information about how to create a Vector Search index, see xref:create-
 --
 include::partial$download-sample-partial.adoc[]
 
-For the best results, xref:search-create-quick-index.adoc[create child fields in Quick Mode] or xref:search:create-child-field.adoc[in the standard editor] for the `colorvect_l2` and `color` fields. 
+For the best results, consider using the sample Vector Search index from xref:create-vector-search-index-ui.adoc#example[Create a Vector Search Index with the {page-ui-name}] or xref:create-vector-search-index-rest-api.adoc#example[Create a Vector Search Index with the REST API and curl/HTTP]. 
 --
 
 * You have installed the Couchbase Go SDK. 
@@ -56,7 +56,7 @@ For more information about how to create a Vector Search index, see xref:create-
 --
 include::partial$download-sample-partial.adoc[]
 
-For the best results, xref:search-create-quick-index.adoc[create child fields in Quick Mode] or xref:search:create-child-field.adoc[in the standard editor] for the `colorvect_l2` and `color` fields. 
+For the best results, consider using the sample Vector Search index from xref:create-vector-search-index-ui.adoc#example[Create a Vector Search Index with the {page-ui-name}] or xref:create-vector-search-index-rest-api.adoc#example[Create a Vector Search Index with the REST API and curl/HTTP]. 
 --
 
 * You have installed the Couchbase Java SDK. 
@@ -79,7 +79,7 @@ For more information about how to create a Vector Search index, see xref:create-
 --
 include::partial$download-sample-partial.adoc[]
 
-For the best results, xref:search-create-quick-index.adoc[create child fields in Quick Mode] or xref:search:create-child-field.adoc[in the standard editor] for the `colorvect_l2` and `color` fields. 
+For the best results, consider using the sample Vector Search index from xref:create-vector-search-index-ui.adoc#example[Create a Vector Search Index with the {page-ui-name}] or xref:create-vector-search-index-rest-api.adoc#example[Create a Vector Search Index with the REST API and curl/HTTP].  
 --
 
 * You have installed the Couchbase Python SDK.

--- a/modules/vector-search/pages/run-vector-search-ui.adoc
+++ b/modules/vector-search/pages/run-vector-search-ui.adoc
@@ -27,7 +27,7 @@ For more information about how to create a Vector Search index, see xref:create-
 --
 include::partial$download-sample-partial.adoc[]
 
-For the best results, xref:search-create-quick-index.adoc[create child fields in Quick Mode] or xref:search:create-child-field.adoc[in Advanced Mode] for the `colorvect_l2` and `color` fields. 
+For the best results, consider using the sample Vector Search index from xref:create-vector-search-index-ui.adoc#example[Create a Vector Search Index with the {page-ui-name}] or xref:create-vector-search-index-rest-api.adoc#example[Create a Vector Search Index with the REST API and curl/HTTP]. 
 --
 
 * You have logged in to the Couchbase {page-ui-name}. 
@@ -56,6 +56,24 @@ It only returns the `k` number of similar vectors.
 
 The Search Service combines the Vector search results from a `knn` object with the traditional `query` object by using an `OR` function. 
 If the same documents match the `knn` and `query` objects, the Search Service ranks those documents higher in search results. 
+
+The document for the color `navy` should be the first result, followed by a similar color. 
+
+[#hybrid]
+=== Example: Run a Simple Hybrid Search Query 
+
+The following hybrid Search query searches for the top vector similar to the vector `[ 0, 0, 128 ]` in the `colorvect_l2` field. 
+It also runs a xref:search:search-request-params.adoc#numeric-range-queries[Numeric Range Query] on the `brightness` field to only return colors that have a brightness value between `70` and `80`: 
+
+[source,json]
+----
+include::example$run-hybrid-search-payload-ui.jsonc[]
+----
+
+The Search Service combines the Vector search results from a `knn` object with the traditional `query` object by using an `OR` function. 
+If the same documents match the `knn` and `query` objects, the Search Service ranks those documents higher in search results.
+
+The document for the color `navy` should be the first result, followed by colors that are similar and match the `brightness` field query. 
 
 [#large]
 === Example: Running a Semantic Search Query with a Large Embedding Vector

--- a/modules/vector-search/pages/run-vector-search-ui.adoc
+++ b/modules/vector-search/pages/run-vector-search-ui.adoc
@@ -60,7 +60,7 @@ If the same documents match the `knn` and `query` objects, the Search Service ra
 The document for the color `navy` should be the first result, followed by a similar color. 
 
 [#hybrid]
-=== Example: Run a Simple Hybrid Search Query 
+=== Example: Running a Simple Hybrid Search Query 
 
 The following hybrid Search query searches for the top vector similar to the vector `[ 0, 0, 128 ]` in the `colorvect_l2` field. 
 It also runs a xref:search:search-request-params.adoc#numeric-range-queries[Numeric Range Query] on the `brightness` field to only return colors that have a brightness value between `70` and `80`: 


### PR DESCRIPTION
Whole goal of this PR is to add some more specific examples to the vector search documentation after feedback came in from Sriram - this is the sister PR to https://github.com/couchbaselabs/docs-devex/pull/203

I added an example of a hybrid query, and added a direct "copy/paste" example Search index that people can hopefully use to just get going right away with the examples on the UI side. 

This side has the REST API, so some additional changes were necessary.

----


Adding a full sample payload that people can import for the UI topic

Adding an example section to create-vector-search-index-ui.adoc

Adding additional hybrid query example section to run-vector-search-ui.adoc

Adding recommendation to use sample vector search index in run-vector-search-sdk.adoc.

Adding recommendation to use sample vector search index in run-vector-search-rest-api.adoc.

Adding note that indexes are equivalent in create-vector-search-index-rest-api.adoc