### PR TITLE
Update with-recursive.adoc

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/with-recursive.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/with-recursive.adoc
@@ -71,7 +71,7 @@ The optional CYCLE clause provides one method for avoiding infinite recursions.
 It enables you to specify one or more fields whose values are likely to repeat.
 
 expr::
-(Required) An identifier representing a field.
+(Required) An identifier or path representing a field/nested-field.
 
 [[options-clause]]
 === OPTIONS Clause
@@ -130,7 +130,7 @@ It's not allowed anywhere else.
 ** Breaching the request timeout, if configured.
 ** Breaching the request memory quota, if configured.
 ** Exceeding the implicit document limit (10000) when a memory quota is not in use and when no explicit document limit is set in the options.
-** Exceeding the implicit level limit (1000) when the level option is not in use.
+** Exceeding the implicit level limit (1000) when the level option is not in use and when no explicit document limit is set in the options.
 
 [#examples_section]
 == Examples


### PR DESCRIPTION
Minor:

Cycle field expression allows path as well to access nested feilds( in 7.6.0)
A new error is added in 7.62, to disallow any other expression, for eg: 1+1(an arithmetic expression), in 7.6.0 we just ignore such examples:
```
 WITH RECURSIVE cyc AS ( SELECT 0 as _from, 1 as _to, 0 as lvl UNION SELECT n._from, n._to, c.lvl+1 as lvl FROM `shellTest`._default.cycleTest n JOIN cyc c ON c._to = n._from) CYCLE _from, _to, 1+1 RESTRICT SELECT cyc.* FROM cyc;
{
    "requestID": "5aa50b56-8fe4-41ad-a395-0a984e181c79",
    "errors": [
        {
            "code": 3307,
            "msg": "Cycle fields validation failed for with term: cyc - cause: invalid cycle field expression term: (1 + 1) only identifier/path expressions are allowed"
        }
    ],
    "status": "fatal",
    "metrics": {
        "elapsedTime": "7.668208ms",
        "executionTime": "7.335208ms",
        "resultCount": 0,
        "resultSize": 0,
        "serviceLoad": 2,
        "errorCount": 1
    }
}
```