### PR TITLE
[DOC-12203] Updated Cycle clause in WITH RECURSIVE page (Server 7.6)

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/with-recursive.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/with-recursive.adoc
@@ -71,7 +71,7 @@ The optional CYCLE clause provides one method for avoiding infinite recursions.
 It enables you to specify one or more fields whose values are likely to repeat.
 
 expr::
-(Required) An identifier representing a field.
+(Required) An xref:n1ql:n1ql-language-reference/identifiers.adoc[identifier] representing a field, or a xref:n1ql:n1ql-language-reference/select-syntax.adoc#path[path] representing a field/nested-field.
 
 [[options-clause]]
 === OPTIONS Clause

--- a/modules/n1ql/pages/n1ql-language-reference/with-recursive.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/with-recursive.adoc
@@ -71,7 +71,7 @@ The optional CYCLE clause provides one method for avoiding infinite recursions.
 It enables you to specify one or more fields whose values are likely to repeat.
 
 expr::
-(Required) An xref:n1ql:n1ql-language-reference/identifiers.adoc[identifier] representing a field, or a xref:n1ql:n1ql-language-reference/select-syntax.adoc#path[path] representing a field/nested-field.
+(Required) An xref:n1ql:n1ql-language-reference/identifiers.adoc[identifier] or a xref:n1ql:n1ql-language-reference/select-syntax.adoc#path[path] representing a field/nested-field.
 
 [[options-clause]]
 === OPTIONS Clause
@@ -130,7 +130,7 @@ It's not allowed anywhere else.
 ** Breaching the request timeout, if configured.
 ** Breaching the request memory quota, if configured.
 ** Exceeding the implicit document limit (10000) when a memory quota is not in use and when no explicit document limit is set in the options.
-** Exceeding the implicit level limit (1000) when the level option is not in use.
+** Exceeding the implicit level limit (1000) when the level option is not in use and when no explicit document limit is set in the options.
 
 [#examples_section]
 == Examples


### PR DESCRIPTION
Updated expression description for the cycle clause in the [WITH RECURSIVE page](https://docs.couchbase.com/server/current/n1ql/n1ql-language-reference/with-recursive.html#cycle-clause) for the 7.6 Server docs.