### PR TITLE
NO ISSUE: Fix broken link in tutorial

### DIFF
--- a/modules/tutorials/pages/java-tutorial/install-couchbase-java-sdk.adoc
+++ b/modules/tutorials/pages/java-tutorial/install-couchbase-java-sdk.adoc
@@ -16,8 +16,6 @@ Before continuing this tutorial, you must first:
 * Install the Java Software Development Kit (version 8, 11, 17, or 21)
 * Install Apache Maven (version 3+)
 
-For more information about the Java SDK installation, see the xref:java-sdk:project-docs/sdk-full-installation.adoc[full installation page].
-
 [TIP]
 ====
 The easiest way to install and manage Java SDKs and Maven on your machine is through https://sdkman.io/install[SDKMan^].
@@ -25,6 +23,7 @@ The easiest way to install and manage Java SDKs and Maven on your machine is thr
 After following the instructions to install SDKMan, open a terminal window and run the commands `sdk install java` and `sdk install maven` to install the latest versions of Java and Maven. 
 ====
 
+For more information about the Java SDK installation, see the xref:java-sdk:project-docs:sdk-full-installation.adoc[full installation page].
 
 == Set Up the Java SDK
 


### PR DESCRIPTION
Fixes link to the Java full installation page.

Also moves the tip to use SDKMan before the link to the Java full installation page, because SDKMan is the recommended method.