### PR TITLE
DOC-12048: New indexer setting for default value of "defer build"

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/alterindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/alterindex.adoc
@@ -12,6 +12,9 @@
 :logical-hierarchy: {sysinfo}#logical-hierarchy
 :querying-indexes: {sysinfo}#querying-indexes
 
+// TEMP
+include::partial$n1ql-language-reference/horizontal-style.adoc[]
+
 [abstract]
 {description}
 
@@ -60,9 +63,10 @@ image::n1ql-language-reference/alter-index.png["Syntax diagram: refer to source 
 
 The ALTER INDEX statement provides two possible syntaxes for specifying the index and the keyspace where the index is located.
 
-index-name:: (Required) A unique name that identifies the index.
-
 // TODO: Automatic links in EBNF.
+
+[horizontal]
+index-name:: (Required) A unique name that identifies the index.
 
 index-path:: (Optional) One possible syntax for specifying the keyspace.
 Refer to <<index-path>> below.
@@ -106,6 +110,7 @@ image::n1ql-language-reference/keyspace-full.png["Syntax diagram: refer to sourc
 If the index is built on a named collection, the index path may be a full keyspace path, including namespace, bucket, scope, and collection, followed by the index name.
 In this case, the {query-context}[query context] is ignored.
 
+[horizontal]
 namespace::
 (Required) An {identifiers}[identifier] that refers to the {logical-hierarchy}[namespace] of the keyspace.
 Currently, only the `default` namespace is available.
@@ -136,6 +141,7 @@ image::n1ql-language-reference/keyspace-prefix.png["Syntax diagram: refer to sou
 If the index is built on the default collection in the default scope within a bucket, the index path may be just an optional namespace and the bucket name, followed by the index name.
 In this case, the {query-context}[query context] should not be set.
 
+[horizontal]
 namespace::
 (Optional) An {identifiers}[identifier] that refers to the {logical-hierarchy}[namespace] of the keyspace.
 Currently, only the `default` namespace is available.
@@ -161,6 +167,7 @@ image::n1ql-language-reference/keyspace-partial.png["Syntax diagram: refer to so
 Alternatively, if the keyspace is a named collection, the index path may be just the collection name, followed by the index name.
 In this case, you must set the {query-context}[query context] to indicate the required namespace, bucket, and scope.
 
+[horizontal]
 collection::
 (Required) An {identifiers}[identifier] that refers to the {logical-hierarchy}[collection name] of the keyspace.
 
@@ -197,6 +204,7 @@ image::n1ql-language-reference/keyspace-path.png["Syntax diagram: refer to sourc
 If the keyspace is a named collection, or the default collection in the default scope within a bucket, the keyspace reference may be a keyspace path.
 In this case, the {query-context}[query context] should not be set.
 
+[horizontal]
 namespace::
 (Optional) An {identifiers}[identifier] that refers to the {logical-hierarchy}[namespace] of the keyspace.
 Currently, only the `default` namespace is available.
@@ -232,6 +240,7 @@ image::n1ql-language-reference/keyspace-partial.png["Syntax diagram: refer to so
 Alternatively, if the keyspace is a named collection, the keyspace reference may be just the collection name.
 In this case, you must set the {query-context}[query context] to indicate the required namespace, bucket, and scope.
 
+[horizontal]
 collection::
 (Required) An {identifiers}[identifier] that refers to the {logical-hierarchy}[collection name] of the keyspace.
 
@@ -264,6 +273,7 @@ image::n1ql-language-reference/index-with.png["Syntax diagram: refer to source c
 
 Use the `WITH` clause to specify additional options.
 
+[horizontal]
 expr::
 An object with the following properties:
 

--- a/modules/n1ql/pages/n1ql-language-reference/alterindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/alterindex.adoc
@@ -275,10 +275,15 @@ Use the `WITH` clause to specify additional options.
 
 [horizontal]
 expr::
-An object with the following properties:
+An object with the following properties.
 
-action;;
-[Required] A string denoting the operation to be performed.
+[options="header", cols="1a,4a,1a"]
+|===
+|Name|Description|Schema
+
+|**action** +
+__required__
+| A string denoting the operation to be performed.
 The possible values are:
 
 move:::
@@ -294,23 +299,38 @@ The planner decides where to place any new index replicas on the available index
 drop_replica:::
 Drops a specified replica temporarily; for example, to repair a replica.
 You must use the `replicaId` property to specify the replica to drop.
+| enum (move, replica_count, drop_replica)
 
-num_replica;;
-[Required if `action` is set to `replica_count`] An integer specifying the number of replicas of the index.
+|**num_replica** +
+__optional__
+| Required if `action` is set to `replica_count`.
+
+An integer specifying the number of replicas of the index.
 The index service will automatically distribute these indexes amongst the index nodes in the cluster for load balancing and high availability purposes.
 The index service attempts to distribute the replicas based on the server groups in use in the cluster where possible.
 (You can restrict the number of index nodes available for index and index replica placement using the `nodes` property, described below.)
+| Integer
 
-nodes;;
-[Required if `action` is set to `move`; optional if `action` is set to `replica_count`] An array of strings, specifying a list of nodes.
+|**nodes** +
+__optional__
+| Required if `action` is set to `move`; +
+Optional if `action` is set to `replica_count`.
+
+An array of strings, specifying a list of nodes.
 If `action` is set to `move`, the node list determines the new destination nodes for the index and its replicas.
-If `action` is set to `replica_count` and you are _increasing_ the number of replicas, the node list restricts the set of nodes available for placement of the index and its replicas.
-However, if `action` is set to `replica_count` and you are _decreasing_ the number of replicas, the `nodes` property is ignored.
-+
-include::partial$n1ql-language-reference/file-based-index-rebalance-note.adoc[]
+If `action` is set to `replica_count` and you are increasing the number of replicas, the node list restricts the set of nodes available for placement of the index and its replicas.
+However, if `action` is set to `replica_count` and you are decreasing the number of replicas, the `nodes` property is ignored.
 
-replicaId;;
-[Required if `action` is set to `drop_replica`] An integer, specifying a replica ID.
+include::partial$n1ql-language-reference/file-based-index-rebalance-note.adoc[]
+| String array
+
+|**replicaId** +
+__optional__
+| Required if `action` is set to `drop_replica`.
+
+An integer, specifying a replica ID.
+| Integer
+|===
 
 == Usage
 

--- a/modules/n1ql/pages/n1ql-language-reference/alterindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/alterindex.adoc
@@ -185,7 +185,7 @@ include::partial$grammar/dql.ebnf[tag=keyspace-ref]
 
 image::n1ql-language-reference/keyspace-ref.png["Syntax diagram: refer to source code listing", align=left]
 
-In Couchbase Server 7.0 and later, you can use the index name with the `ON` keyword and a keyspace reference to specify the keyspace on which the index is built.
+You can use the index name with the `ON` keyword and a keyspace reference to specify the keyspace on which the index is built.
 The keyspace reference may be a <<keyspace-path>> or a <<keyspace-partial>>.
 
 NOTE: If there is a hyphen (-) inside the index name or any part of the keyspace reference, you must wrap the index name or that part of the keyspace reference in backticks ({backtick}{nbsp}{backtick}).
@@ -258,7 +258,7 @@ include::partial$grammar/ddl.ebnf[tag=index-using]
 
 image::n1ql-language-reference/index-using.png["Syntax diagram: refer to source code listing", align=left]
 
-In Couchbase Server 6.5 and later, the index type for a secondary index must be Global Secondary Index (GSI).
+The index type for a secondary index must be Global Secondary Index (GSI).
 The `USING GSI` keywords are optional and may be omitted.
 
 [[index-with]]
@@ -551,5 +551,5 @@ WITH {"action": "drop_replica", "replicaId": 2};
 == Related Links
 
 Using the ALTER INDEX command to move one index at a time may be cumbersome if there are a lot of indexes to be moved.
-In Couchbase Server 7.0 and later, the _index redistribution_ setting enables you to specify how Couchbase Server redistributes indexes automatically on rebalance.
+The _index redistribution_ setting enables you to specify how Couchbase Server redistributes indexes automatically on rebalance.
 Refer to {rebalancing-the-index-service}[Rebalance] for more information.

--- a/modules/n1ql/pages/n1ql-language-reference/build-index.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/build-index.adoc
@@ -12,6 +12,9 @@
 :querying-indexes: xref:n1ql-intro/sysinfo.adoc#querying-indexes
 :keyspace-ref: xref:n1ql-language-reference/createindex.adoc#keyspace-ref
 
+// TEMP
+include::partial$n1ql-language-reference/horizontal-style.adoc[]
+
 [abstract]
 {description}
 
@@ -68,6 +71,7 @@ image::n1ql-language-reference/build-index.png["Syntax diagram: refer to source 
 
 // TODO: Automatic links in EBNF.
 
+[horizontal]
 keyspace-ref:: (Required) Specifies the keyspace where the indexes are built.
 Refer to <<keyspace-ref>> below.
 

--- a/modules/n1ql/pages/n1ql-language-reference/build-index.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/build-index.adoc
@@ -121,7 +121,7 @@ image::n1ql-language-reference/index-term.png["Syntax diagram: refer to source c
 You can specify one index term, or multiple index terms separated by commas.
 An index term must be specified for each index to be built.
 
-In Couchbase Server 6.5 and later, each index term may be an <<index-name>>, an <<index-expr>>, or a <<subquery-expr>>.
+Each index term may be an <<index-name>>, an <<index-expr>>, or a <<subquery-expr>>.
 The BUILD INDEX clause may contain a mixture of the different types of index term.
 
 [[index-name,index name]]

--- a/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
@@ -313,22 +313,26 @@ Use the WITH clause to specify additional options.
 
 [horizontal#index-with-args]
 expr::
-An object with the following properties:
+An object with the following properties.
 
-nodes;;
-[Optional] An array of strings, each of which represents a node name.
-+
+[options="header", cols="1a,4a,1a"]
+|===
+|Name|Description|Schema
+
+|**nodes** +
+__optional__
+| An array of strings, each of which represents a node name.
+
 include::partial$n1ql-language-reference/file-based-index-rebalance-note.adoc[]
-+
-****
+
+'''
 [.edition]#{community}#
 
 In Couchbase Server Community Edition, a single global secondary index can be placed on a single node that runs the indexing service.
 The `nodes` property allows you to specify the node that the index is placed on.
 (((default index placement)))If `nodes` is not specified, one of the nodes running the indexing service is randomly picked for the index.
-****
-+
-****
+
+'''
 [.edition]#{enterprise}#
 
 In Couchbase Server Enterprise Edition, you can specify multiple nodes to distribute replicas of an index across nodes running the indexing service: for example, `WITH {"nodes": ["node1:8091", "node2:8091", "node3:8091"]}`.
@@ -338,37 +342,43 @@ If specifying both [.var]`nodes` and [.var]`num_replica`, the number of nodes in
 
 (((default index placement)))If [.var]`nodes` is not specified, then the system chooses nodes on which to place the new index and any replicas, in order to achieve the best resource utilization across nodes running the indexing service.
 This is done by taking into account the current resource usage statistics of index nodes.
-****
-+
-IMPORTANT: A node name passed to the `nodes` property must include the cluster administration port, by default 8091.
-For example `WITH {"nodes": ["192.0.2.0:8091"]}` instead of `WITH {"nodes": ["192.0.2.0"]}`.
 
-defer_build;;
-[Optional] Boolean.
+'''
+A node name passed to the `nodes` property must include the cluster administration port, by default 8091.
 
-true:::
-When set to `true`, the `CREATE INDEX` operation queues the task for building the index but immediately pauses the building of the index of type GSI.
+**Example:** `["192.0.2.0:8091"]`
+|String array
+
+|**defer_build** +
+__optional__
+| Whether the index should be created in deferred build mode.
+
+When set to `true`, the `CREATE INDEX` operation queues the task for building the GSI index but immediately pauses the building of the index.
 Index building requires an expensive scan operation.
 Deferring building of the index with multiple indexes can optimize the expensive scan operation.
-Admins can defer building multiple indexes and, using the `BUILD INDEX` statement, multiple indexes to be built efficiently with one efficient scan of bucket data.
+Admins can defer building multiple indexes and, using the `BUILD INDEX` statement, build multiple indexes efficiently with one efficient scan of bucket data.
 
-false:::
-When set to `false`, the `CREATE INDEX` operation queues the task for building the index and immediately kicks off the building of the index of type GSI.
+When set to `false`, the `CREATE INDEX` operation queues the task for building the GSI index and immediately kicks off the building of the index.
 
-num_replica;;
-+
-****
-[.edition]#{enterprise}#
+**Default:** `false`
+|Boolean
+
+|**num_replica** +
+__optional__
+| [.edition]#{enterprise}#
 
 This property is only available in Couchbase Server Enterprise Edition.
 
-[Optional] Integer that specifies the number of {index-replication}[replicas] of the index to create.
+The number of {index-replication}[replicas] of the index to create.
 
 The indexer will automatically distribute these replicas amongst index nodes in the cluster for load-balancing and high availability purposes.
 The indexer will attempt to distribute the replicas based on the server groups in use in the cluster where possible.
 
 If the value of this property is not less than the number of index nodes in the cluster, then the index creation will fail.
-****
+
+**Default:** `1`
+|Integer
+|===
 
 == Usage
 

--- a/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
@@ -30,7 +30,7 @@ Secondary indexes are optional but increase query efficiency on a keyspace.
 
 == Purpose
 
-In Couchbase Server 7.0 and later, `CREATE INDEX` allows you to make multiple concurrent index creation requests.
+`CREATE INDEX` allows you to make multiple concurrent index creation requests.
 The command starts a task to create the index definition in the background.
 If there is an index creation task already running, the Index Service queues the incoming index creation request.
 `CREATE INDEX` returns as soon as the index creation phase is complete.
@@ -296,7 +296,7 @@ include::partial$grammar/ddl.ebnf[tag=index-using]
 
 image::n1ql-language-reference/index-using.png["Syntax diagram: refer to source code listing", align=left]
 
-In Couchbase Server 6.5 and later, the index type for a secondary index must be Global Secondary Index (GSI).
+The index type for a secondary index must be Global Secondary Index (GSI).
 The `USING GSI` keywords are optional and may be omitted.
 
 [[index-with]]

--- a/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
@@ -21,6 +21,9 @@ Secondary indexes contain a filtered or a full set of keys in a given keyspace.
 :logical-hierarchy: {sysinfo}#logical-hierarchy
 :querying-indexes: {sysinfo}#querying-indexes
 
+// TEMP
+include::partial$n1ql-language-reference/horizontal-style.adoc[]
+
 The `CREATE INDEX` statement allows you to create a secondary index.
 Secondary indexes contain a filtered or a full set of keys in a given keyspace.
 Secondary indexes are optional but increase query efficiency on a keyspace.
@@ -61,14 +64,14 @@ include::partial$grammar/ddl.ebnf[tag=create-index]
 
 image::n1ql-language-reference/create-index.png["Syntax diagram: refer to source code listing", align=left]
 
-[[index-name,index-name]]
+// TODO: Automatic links in EBNF.
+
+[horizontal#index-name, reftext="index-name"]
 index-name:: [Required] A unique name that identifies the index.
 +
 Valid GSI index names can contain any of the following characters: `A-Z` `a-z` `0-9` `&num;` `&lowbar;`, and must start with a letter, [`A-Z` `a-z`].
 The minimum length of an index name is 1 character and there is no maximum length set for an index name.
 When querying, if the index name contains a `&num;` or `&lowbar;` character, you must enclose the index name within backticks.
-
-// TODO: Automatic links in EBNF.
 
 keyspace-ref:: [Required] Specifies the keyspace where the index is created.
 Refer to <<keyspace-ref>> below.
@@ -133,6 +136,7 @@ image::n1ql-language-reference/keyspace-path.png["Syntax diagram: refer to sourc
 If the keyspace is a named collection, or the default collection in the default scope within a bucket, the keyspace reference may be a keyspace path.
 In this case, the {query-context}[query context] should not be set.
 
+[horizontal]
 namespace::
 (Optional) An {identifiers}[identifier] that refers to the {logical-hierarchy}[namespace] of the keyspace.
 Currently, only the `default` namespace is available.
@@ -168,6 +172,7 @@ image::n1ql-language-reference/keyspace-partial.png["Syntax diagram: refer to so
 Alternatively, if the keyspace is a named collection, the keyspace reference may be just the collection name with no path.
 In this case, you must set the {query-context}[query context] to indicate the required namespace, bucket, and scope.
 
+[horizontal]
 collection::
 (Required) An {identifiers}[identifier] that refers to the {logical-hierarchy}[collection name] of the keyspace.
 
@@ -188,7 +193,7 @@ image::n1ql-language-reference/index-key.png["Syntax diagram: refer to source co
 Refers to an attribute name or a scalar function or an ARRAY expression on the attribute.
 This constitutes an index-key for the index.
 
-[[index-key-args]]
+[horizontal#index-key-args]
 expr::
 A {sqlpp} {expression}[expression] over any fields in the document.
 This cannot use constant expressions, aggregate functions, or sub-queries.
@@ -217,7 +222,7 @@ image::n1ql-language-reference/key-attribs.png["Syntax diagram: refer to source 
 
 Specifies attributes for the index key.
 
-index-order:: [Optional] All index keys may include an index order clause.
+[horizontal]
 Refer to <<index-order>> below.
 
 include-missing:: [Optional] The leading index key may also include `INCLUDE MISSING` clause.
@@ -235,6 +240,7 @@ image::n1ql-language-reference/index-order.png["Syntax diagram: refer to source 
 
 Specifies the sort order of the index key.
 
+[horizontal]
 `ASC`::
 The index key is sorted in ascending order.
 
@@ -276,7 +282,7 @@ include::partial$grammar/dql.ebnf[tag=where-clause]
 
 image::n1ql-language-reference/where-clause.png["Syntax diagram: refer to source code listing", align=left]
 
-[[where-clause-args]]
+[horizontal#where-clause-args]
 cond::
 Specifies WHERE clause predicates to qualify the subset of documents to include in the index.
 
@@ -305,7 +311,7 @@ image::n1ql-language-reference/index-with.png["Syntax diagram: refer to source c
 
 Use the WITH clause to specify additional options.
 
-[[index-with-args]]
+[horizontal#index-with-args]
 expr::
 An object with the following properties:
 

--- a/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
@@ -67,34 +67,34 @@ image::n1ql-language-reference/create-index.png["Syntax diagram: refer to source
 // TODO: Automatic links in EBNF.
 
 [horizontal#index-name, reftext="index-name"]
-index-name:: [Required] A unique name that identifies the index.
+index-name:: (Required) A unique name that identifies the index.
 +
 Valid GSI index names can contain any of the following characters: `A-Z` `a-z` `0-9` `&num;` `&lowbar;`, and must start with a letter, [`A-Z` `a-z`].
 The minimum length of an index name is 1 character and there is no maximum length set for an index name.
 When querying, if the index name contains a `&num;` or `&lowbar;` character, you must enclose the index name within backticks.
 
-keyspace-ref:: [Required] Specifies the keyspace where the index is created.
+keyspace-ref:: (Required) Specifies the keyspace where the index is created.
 Refer to <<keyspace-ref>> below.
 
-index-key:: [Required] Specifies an index key.
+index-key:: (Required) Specifies an index key.
 Refer to <<index-key>> below.
 
-lead-key-attribs:: [Optional] Specifies attributes for the leading index key.
+lead-key-attribs:: (Optional) Specifies attributes for the leading index key.
 Refer to <<index-key-attrib>> below.
 
-key-attribs:: [Optional] Specifies attributes for a non-leading index key.
+key-attribs:: (Optional) Specifies attributes for a non-leading index key.
 Refer to <<index-key-attrib>> below.
 
-index-partition:: [Optional] Specifies index partitions.
+index-partition:: (Optional) Specifies index partitions.
 Refer to <<index-partition>> below.
 
-where-clause:: [Optional] Specifies filters for a partial index.
+where-clause:: (Optional) Specifies filters for a partial index.
 Refer to <<where-clause>> below.
 
-index-using:: [Optional] Specifies the index type.
+index-using:: (Optional) Specifies the index type.
 Refer to <<index-using>> below.
 
-index-with:: [Optional] Specifies options for the index.
+index-with:: (Optional) Specifies options for the index.
 Refer to <<index-with>> below.
 
 [[if-not-exists]]
@@ -223,9 +223,10 @@ image::n1ql-language-reference/key-attribs.png["Syntax diagram: refer to source 
 Specifies attributes for the index key.
 
 [horizontal]
+index-order:: (Optional) All index keys may include an index order clause.
 Refer to <<index-order>> below.
 
-include-missing:: [Optional] The leading index key may also include `INCLUDE MISSING` clause.
+include-missing:: (Optional) The leading index key may also include `INCLUDE MISSING` clause.
 Refer to <<include-missing>> below.
 
 [[index-order]]

--- a/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
@@ -419,6 +419,35 @@ The system automatically load-balances an index scan across the index and all it
 Adding index replicas enables you to scale scan throughput, in addition to providing high availability.
 ====
 
+=== Defer Index Builds by Default
+
+[.status]#Couchbase Server 7.6.2#
+
+Usually, the default setting for the `defer_build` option is `false`.
+In Couchbase Server 7.6.2 and later, you can change the default setting for the `defer_build` option.
+
+If you change the default setting for `defer_build` to `true`, index creation operates in deferred build mode by default.
+
+To change the default setting for deferred builds, use the REST API to set the `indexer.settings.defer_build` property.
+For example,
+
+[source,sh]
+----
+curl http://$BASEURL:9102/settings -u $USER:$PASSWORD \
+-d '{"indexer.settings.defer_build": true}'
+----
+
+Use the following command to retrieve the indexer settings:
+
+[source,sh]
+----
+curl -X GET http://$BASEURL:9102/settings -u $USER:$PASSWORD
+----
+
+* `$BASEURL` is the base URL for the API call, for example: `localhost`.
+* `$USER` is the username, for example: `Administrator`.
+* `$PASSWORD` is the password.
+
 == Examples
 
 To try the examples in this section, you must set the query context as described in each example.

--- a/modules/n1ql/pages/n1ql-language-reference/createprimaryindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createprimaryindex.adoc
@@ -61,23 +61,24 @@ image::n1ql-language-reference/create-primary-index.png["Syntax diagram: refer t
 
 [horizontal]
 index-name::
-[Optional] A unique name that identifies the index.
-If a name is not specified, the default name of `#primary` is applied.
+(Optional) A unique name that identifies the index.
+If a name is not specified, the default name of `#primary` is applied. [small]##[<<note-index-name>>]##
 +
 Valid GSI index names can contain any of the following characters: `A-Z` `a-z` `0-9` `&num;` `&lowbar;`, and must start with a letter, [`A-Z` `a-z`].
 The minimum length of an index name is 1 character and there is no maximum length set for an index name.
 When querying, if the index name contains a `&num;` or `&lowbar;` character, you must enclose the index name within backticks.
-+
-IMPORTANT: Unnamed primary indexes are dropped by using the `DROP PRIMARY INDEX` statement, and named primary indexes are dropped by using the `DROP INDEX` statement.
 
 keyspace-ref:: [Required] Specifies the keyspace where the index is created.
 Refer to <<keyspace-ref>> below.
 
-index-using:: [Optional] Specifies the index type.
+index-using:: (Optional) Specifies the index type.
 Refer to <<index-using>> below.
 
-index-with:: [Optional] Specifies options for the index.
+index-with:: (Optional) Specifies options for the index.
 Refer to <<index-with>> below.
+
+[[note-index-name,note]]
+NOTE: You can drop unnamed primary indexes using the `DROP PRIMARY INDEX` statement, and named primary indexes using the `DROP INDEX` statement.
 
 [[if-not-exists]]
 === IF NOT EXISTS Clause

--- a/modules/n1ql/pages/n1ql-language-reference/createprimaryindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createprimaryindex.adoc
@@ -14,6 +14,9 @@ Primary indexes contain a full set of keys in a given keyspace.
 :index-replication: xref:learn:services-and-indexes/indexes/index-replication.adoc#index-replication
 :query-settings: xref:manage:manage-settings/query-settings.adoc
 
+// TEMP
+include::partial$n1ql-language-reference/horizontal-style.adoc[]
+
 The `CREATE PRIMARY INDEX` statement allows you to create a primary index.
 Primary indexes contain a full set of keys in a given keyspace.
 Primary indexes are optional and are only required for running ad hoc queries on a keyspace that is not supported by a secondary index.
@@ -54,6 +57,9 @@ include::partial$grammar/ddl.ebnf[tag=create-primary-index]
 
 image::n1ql-language-reference/create-primary-index.png["Syntax diagram: refer to source code listing", align=left]
 
+// TODO: Automatic links in EBNF.
+
+[horizontal]
 index-name::
 [Optional] A unique name that identifies the index.
 If a name is not specified, the default name of `#primary` is applied.
@@ -63,8 +69,6 @@ The minimum length of an index name is 1 character and there is no maximum lengt
 When querying, if the index name contains a `&num;` or `&lowbar;` character, you must enclose the index name within backticks.
 +
 IMPORTANT: Unnamed primary indexes are dropped by using the `DROP PRIMARY INDEX` statement, and named primary indexes are dropped by using the `DROP INDEX` statement.
-
-// TODO: Automatic links in EBNF.
 
 keyspace-ref:: [Required] Specifies the keyspace where the index is created.
 Refer to <<keyspace-ref>> below.
@@ -114,6 +118,7 @@ image::n1ql-language-reference/keyspace-path.png["Syntax diagram: refer to sourc
 If the keyspace is a named collection, or the default collection in the default scope within a bucket, the keyspace reference may be a keyspace path.
 In this case, the {query-context}[query context] should not be set.
 
+[horizontal]
 namespace::
 (Optional) An {identifiers}[identifier] that refers to the {logical-hierarchy}[namespace] of the keyspace.
 Currently, only the `default` namespace is available.
@@ -149,6 +154,7 @@ image::n1ql-language-reference/keyspace-partial.png["Syntax diagram: refer to so
 Alternatively, if the keyspace is a named collection, the keyspace reference may be just the collection name with no path.
 In this case, you must set the {query-context}[query context] to indicate the required namespace, bucket, and scope.
 
+[horizontal]
 collection::
 (Required) An {identifiers}[identifier] that refers to the {logical-hierarchy}[collection name] of the keyspace.
 
@@ -181,7 +187,7 @@ image::n1ql-language-reference/index-with.png["Syntax diagram: refer to source c
 
 Use the WITH clause to specify additional options.
 
-[[index-with-args]]
+[horizontal#index-with-args]
 expr::
 An object with the following properties:
 

--- a/modules/n1ql/pages/n1ql-language-reference/createprimaryindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createprimaryindex.adoc
@@ -23,7 +23,7 @@ Primary indexes are optional and are only required for running ad hoc queries on
 
 == Purpose
 
-In Couchbase Server 7.0 and later, `CREATE PRIMARY INDEX` allows you to make multiple concurrent index creation requests.
+`CREATE PRIMARY INDEX` allows you to make multiple concurrent index creation requests.
 The command starts a task to create the primary index definition in the background.
 If there is an index creation task already running, the Index Service queues the incoming index creation request.
 `CREATE PRIMARY INDEX` returns as soon as the index creation phase is complete.
@@ -172,7 +172,7 @@ include::partial$grammar/ddl.ebnf[tag=index-using]
 
 image::n1ql-language-reference/index-using.png["Syntax diagram: refer to source code listing", align=left]
 
-In Couchbase Server 6.5 and later, the index type for a primary index must be Global Secondary Index (GSI).
+The index type for a primary index must be Global Secondary Index (GSI).
 The `USING GSI` keywords are optional and may be omitted.
 
 [[index-with]]

--- a/modules/n1ql/pages/n1ql-language-reference/createprimaryindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createprimaryindex.adoc
@@ -200,6 +200,7 @@ An object with the following properties.
 __optional__
 | An array of strings, each of which represents a node name.
 
+include::partial$n1ql-language-reference/file-based-index-rebalance-note.adoc[]
 
 '''
 [.edition]#{community}#

--- a/modules/n1ql/pages/n1ql-language-reference/createprimaryindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createprimaryindex.adoc
@@ -189,20 +189,25 @@ Use the WITH clause to specify additional options.
 
 [horizontal#index-with-args]
 expr::
-An object with the following properties:
+An object with the following properties.
 
-nodes;;
-[Optional] An array of strings, each of which represents a node name.
-+
-****
+[options="header", cols="1a,4a,1a"]
+|===
+|Name|Description|Schema
+
+|**nodes** +
+__optional__
+| An array of strings, each of which represents a node name.
+
+
+'''
 [.edition]#{community}#
 
 In Couchbase Server Community Edition, a single primary index of type `GSI` can be placed on a single node that runs the indexing service.
 The `nodes` property allows you to specify the node that the index is placed on.
 (((default index placement)))If `nodes` is not specified, one of the nodes running the indexing service is randomly picked for the index.
-****
-+
-****
+
+'''
 [.edition]#{enterprise}#
 
 In Couchbase Server Enterprise Edition, you can specify multiple nodes to distribute replicas of an index across nodes running the indexing service: for example, `WITH {"nodes": ["node1:8091", "node2:8091", "node3:8091"]}`.
@@ -212,37 +217,43 @@ If specifying both [.var]`nodes` and [.var]`num_replica`, the number of nodes in
 
 (((default index placement)))If [.var]`nodes` is not specified, then the system chooses nodes on which to place the new index and any replicas, in order to achieve the best resource utilization across nodes running the indexing service.
 This is done by taking into account the current resource usage statistics of index nodes.
-****
-+
-IMPORTANT: A node name passed to the `nodes` property must include the cluster administration port, by default 8091.
-For example `WITH {"nodes": ["192.0.2.0:8091"]}` instead of `WITH {"nodes": ["192.0.2.0"]}`.
 
-defer_build;;
-[Optional] Boolean.
+'''
+A node name passed to the `nodes` property must include the cluster administration port, by default 8091.
 
-true:::
-When set to `true`, the `CREATE PRIMARY INDEX` operation queues the task for building the index but immediately pauses the building of the index of type `GSI`.
+**Example:** `["192.0.2.0:8091"]`
+|String array
+
+|**defer_build** +
+__optional__
+| Whether the index should be created in deferred build mode.
+
+When set to `true`, the `CREATE PRIMARY INDEX` operation queues the task for building the GSI index but immediately pauses the building of the index.
 Index building requires an expensive scan operation.
 Deferring building of the index with multiple indexes can optimize the expensive scan operation.
-Admins can defer building multiple indexes and, using the `BUILD INDEX` statement, multiple indexes to be built efficiently with one efficient scan of keyspace data.
+Admins can defer building multiple indexes and, using the `BUILD INDEX` statement, build multiple indexes efficiently with one efficient scan of keyspace data.
 
-false:::
-When set to `false`, the `CREATE PRIMARY INDEX` operation queues the task for building the index and immediately kicks off the building of the index of type `GSI`.
+When set to `false`, the `CREATE PRIMARY INDEX` operation queues the task for building the GSI index and immediately kicks off the building of the index.
 
-num_replica;;
-+
-****
-[.edition]#{enterprise}#
+**Default:** `false`
+|Boolean
+
+|**num_replica** +
+__optional__
+| [.edition]#{enterprise}#
 
 This property is only available in Couchbase Server Enterprise Edition.
 
-[Optional] Integer that specifies the number of {index-replication}[replicas] of the index to create.
+The number of {index-replication}[replicas] of the index to create.
 
 The indexer will automatically distribute these replicas amongst index nodes in the cluster for load-balancing and high availability purposes.
 The indexer will attempt to distribute the replicas based on the server groups in use in the cluster where possible.
 
 If the value of this property is not less than the number of index nodes in the cluster, then the index creation will fail.
-****
+
+**Default:** `1`
+|Integer
+|===
 
 == Usage
 

--- a/modules/n1ql/pages/n1ql-language-reference/dropindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropindex.adoc
@@ -9,6 +9,9 @@
 :identifiers: xref:n1ql-language-reference/identifiers.adoc
 :drop-primary-index: xref:n1ql-language-reference/dropprimaryindex.adoc
 
+// TEMP
+include::partial$n1ql-language-reference/horizontal-style.adoc[]
+
 {description}
 Dropping an index that has replicas will also drop all of the replica indexes too.
 You can drop unnamed primary indexes using the {drop-primary-index}[DROP PRIMARY INDEX] statement.
@@ -33,9 +36,10 @@ image::n1ql-language-reference/drop-index.png["Syntax diagram: refer to source c
 
 The DROP INDEX statement provides two possible syntaxes for specifying the index and the keyspace where the index is located.
 
-index-name:: (Required) A unique name that identifies the index.
-
 // TODO: Automatic links in EBNF.
+
+[horizontal]
+index-name:: (Required) A unique name that identifies the index.
 
 index-path:: (Optional) One possible syntax for specifying the the keyspace.
 Refer to <<index-path>> below.
@@ -86,6 +90,7 @@ image::n1ql-language-reference/keyspace-full.png["Syntax diagram: refer to sourc
 If the index is built on a named collection, the index path may be a full keyspace path, including namespace, bucket, scope, and collection, followed by the index name.
 In this case, the {query-context}[query context] is ignored.
 
+[horizontal]
 namespace::
 (Required) An {identifiers}[identifier] that refers to the {logical-hierarchy}[namespace] of the keyspace.
 Currently, only the `default` namespace is available.
@@ -116,6 +121,7 @@ image::n1ql-language-reference/keyspace-prefix.png["Syntax diagram: refer to sou
 If the index is built on the default collection in the default scope within a bucket, the index path may be just an optional namespace and the bucket name, followed by the index name.
 In this case, the {query-context}[query context] should not be set.
 
+[horizontal]
 namespace::
 (Optional) An {identifiers}[identifier] that refers to the {logical-hierarchy}[namespace] of the keyspace.
 Currently, only the `default` namespace is available.
@@ -141,6 +147,7 @@ image::n1ql-language-reference/keyspace-partial.png["Syntax diagram: refer to so
 Alternatively, if the keyspace is a named collection, the index path may be just the collection name, followed by the index name.
 In this case, you must set the {query-context}[query context] to indicate the required namespace, bucket, and scope.
 
+[horizontal]
 collection::
 (Required) An {identifiers}[identifier] that refers to the {logical-hierarchy}[collection name] of the keyspace.
 
@@ -177,6 +184,7 @@ image::n1ql-language-reference/keyspace-path.png["Syntax diagram: refer to sourc
 If the keyspace is a named collection, or the default collection in the default scope within a bucket, the keyspace reference may be a keyspace path.
 In this case, the {query-context}[query context] should not be set.
 
+[horizontal]
 namespace::
 (Optional) An {identifiers}[identifier] that refers to the {logical-hierarchy}[namespace] of the keyspace.
 Currently, only the `default` namespace is available.
@@ -212,6 +220,7 @@ image::n1ql-language-reference/keyspace-partial.png["Syntax diagram: refer to so
 Alternatively, if the keyspace is a named collection, the keyspace reference may be just the collection name.
 In this case, you must set the {query-context}[query context] to indicate the required namespace, bucket, and scope.
 
+[horizontal]
 collection::
 (Required) An {identifiers}[identifier] that refers to the {logical-hierarchy}[collection name] of the keyspace.
 

--- a/modules/n1ql/pages/n1ql-language-reference/dropindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropindex.adoc
@@ -165,7 +165,7 @@ include::partial$grammar/dql.ebnf[tag=keyspace-ref]
 
 image::n1ql-language-reference/keyspace-ref.png["Syntax diagram: refer to source code listing", align=left]
 
-In Couchbase Server 7.0 and later, you can use the index name with the `ON` keyword and a keyspace reference to specify the keyspace on which the index is built.
+You can use the index name with the `ON` keyword and a keyspace reference to specify the keyspace on which the index is built.
 The keyspace reference may be a <<keyspace-path>> or a <<keyspace-partial>>.
 
 NOTE: If there is a hyphen (-) inside the index name or any part of the keyspace reference, you must wrap the index name or that part of the keyspace reference in backticks ({backtick}{nbsp}{backtick}).
@@ -238,7 +238,7 @@ include::partial$grammar/ddl.ebnf[tag=index-using]
 
 image::n1ql-language-reference/index-using.png["Syntax diagram: refer to source code listing", align=left]
 
-In Couchbase Server 6.5 and later, the index type for a secondary index must be Global Secondary Index (GSI).
+The index type for a secondary index must be Global Secondary Index (GSI).
 The `USING GSI` keywords are optional and may be omitted.
 
 == Usage

--- a/modules/n1ql/pages/n1ql-language-reference/dropprimaryindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropprimaryindex.adoc
@@ -35,10 +35,10 @@ image::n1ql-language-reference/drop-primary-index.png["Syntax diagram: refer to 
 // TODO: Automatic links in EBNF.
 
 [horizontal]
-keyspace-ref:: [Required] Specifies the keyspace where the index is located.
+keyspace-ref:: (Required) Specifies the keyspace where the index is located.
 Refer to <<keyspace-ref>> below.
 
-index-using:: [Optional] Specifies the index type.
+index-using:: (Optional) Specifies the index type.
 Refer to <<index-using>> below.
 
 [[if-exists]]

--- a/modules/n1ql/pages/n1ql-language-reference/dropprimaryindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropprimaryindex.adoc
@@ -8,6 +8,9 @@
 :identifiers: xref:n1ql-language-reference/identifiers.adoc
 :logical-hierarchy: xref:n1ql-intro/sysinfo.adoc#logical-hierarchy
 
+// TEMP
+include::partial$n1ql-language-reference/horizontal-style.adoc[]
+
 {description}
 
 IMPORTANT: Named primary indexes that are created using CREATE PRIMARY INDEX can only be dropped using the DROP INDEX command.
@@ -31,6 +34,7 @@ image::n1ql-language-reference/drop-primary-index.png["Syntax diagram: refer to 
 
 // TODO: Automatic links in EBNF.
 
+[horizontal]
 keyspace-ref:: [Required] Specifies the keyspace where the index is located.
 Refer to <<keyspace-ref>> below.
 
@@ -76,6 +80,7 @@ image::n1ql-language-reference/keyspace-path.png["Syntax diagram: refer to sourc
 If the keyspace is a named collection, or the default collection in the default scope within a bucket, the keyspace reference may be a keyspace path.
 In this case, the {query-context}[query context] should not be set.
 
+[horizontal]
 namespace::
 (Optional) An {identifiers}[identifier] that refers to the {logical-hierarchy}[namespace] of the keyspace.
 Currently, only the `default` namespace is available.
@@ -111,6 +116,7 @@ image::n1ql-language-reference/keyspace-partial.png["Syntax diagram: refer to so
 Alternatively, if the keyspace is a named collection, the keyspace reference may be just the collection name with no path.
 In this case, you must set the {query-context}[query context] to indicate the required namespace, bucket, and scope.
 
+[horizontal]
 collection::
 (Required) An {identifiers}[identifier] that refers to the {logical-hierarchy}[collection name] of the keyspace.
 

--- a/modules/n1ql/pages/n1ql-language-reference/dropprimaryindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropprimaryindex.adoc
@@ -134,7 +134,7 @@ include::partial$grammar/ddl.ebnf[tag=index-using]
 
 image::n1ql-language-reference/index-using.png["Syntax diagram: refer to source code listing", align=left]
 
-In Couchbase Server 6.5 and later, the index type for a primary index must be Global Secondary Index (GSI).
+The index type for a primary index must be Global Secondary Index (GSI).
 The `USING GSI` keywords are optional and may be omitted.
 
 == Example


### PR DESCRIPTION
Docs issue: DOC-12048

This PR documents the new indexer setting for the default value of "defer build", and also makes some drive-by improvements to the documentation for the INDEX commands. 

The main change to look at is [here](https://github.com/couchbaselabs/docs-devex/pull/239/files#diff-cd61ab3e9c99ff482ac9be2c4a1b678f672c98824772738664dcba87d13989b2), lines 439 on.

Docs preview: [CREATE INDEX › Usage › Defer Index Builds by Default](https://preview.docs-test.couchbase.com/DOC-12048/server/current/n1ql/n1ql-language-reference/createindex.html#defer-index-builds-by-default)
Credentials: [Preview docs for internal review](https://couchbasecloud.atlassian.net/wiki/x/dYF_dQ#Preview-docs-for-internal-review)