### PR TITLE
[DOC-12049] LOOKUPIN operation in Eventing (Capella)

### DIFF
--- a/modules/eventing/pages/eventing-advanced-keyspace-accessors.adoc
+++ b/modules/eventing/pages/eventing-advanced-keyspace-accessors.adoc
@@ -24,7 +24,8 @@ Couchbase supports the following:
 * <<advanced-increment-op,Advanced INCREMENT>>
 * <<advanced-decrement-op,Advanced DECREMENT>>
 * <<advanced-touch-op,Advanced TOUCH>>
-* <<advanced-subdoc-array-op,Sub-Document MUTATEIN Operation>>
+* <<advanced-subdoc-array-op-mutatein,Sub-Document MUTATEIN Operation>>
+* <<advanced-subdoc-array-op-lookupin,Sub-Document LOOKUPIN Operation>>
 * <<multiple-collection-functions,Operations that Listen to Multiple Collections>>
 * <<optional-params,Optional Parameters>>
 
@@ -461,22 +462,21 @@ function OnUpdate(doc, meta) {
 ====
 
 
-[#advanced-subdoc-array-op]
+[#advanced-subdoc-array-op-mutatein]
 == Sub-Document MUTATEIN Operation
-
-ifeval::['{page-component-version}' == '7.6'] 
-_(Introduced in Couchbase Server 7.6)_ 
-endif::[]
 
 `result = couchbase.mutateIn(binding, meta, subdoc_operation_array, options)`
 
-Sub-Document operations let you modify only parts of a document instead of the entire document.
+Sub-Document MUTATEIN operations let you modify only parts of a document instead of the entire document.
 This makes them faster and more efficient than full-document operations like REPLACE and UPSERT.
 
-Sub-Document array operations do not have concurrency issues and can be performed without checking CAS.
+By default, a MUTATEIN operation does not modify Extended Attributes (XATTRs).
+To modify a document's XATTRs, you must:
 
-NOTE: Couchbase only supports Sub-Document MUTATEIN operations. 
-It does not support Sub-Document LOOKUPIN operations.
+* Pass `xattrs` as the third argument of your OnUpdate function.
+* Pass `{ "xattrs": true }` in the `subdoc_operation_array` argument of your OnUpdate function.
+
+Sub-Document array operations do not have concurrency issues and can be performed without checking CAS.
 
 ==== Examples
 ====
@@ -510,8 +510,86 @@ function OnUpdate(doc, meta) {
         couchbase.MutateInSpec.arrayPrepend("arrayTest", 1),
         couchbase.MutateInSpec.arrayInsert("arrayTest[0]", 0),
         couchbase.MutateInSpec.arrayAddUnique("arrayTest", 3)
-    ])
+    ]);
 };
+----
+====
+
+====
+.Operation
+[source,javascript]
+----
+function OnUpdate(doc, meta, xattrs) {
+    var meta = {"id": meta.id};
+ 
+    // INSERT XATTR 
+    couchbase.mutateIn(dst_bucket, meta, [
+        couchbase.MutateInSpec.insert("testField", "insert", {"xattrs": true})
+    ]);
+ 
+    // UPSERT XATTR
+    couchbase.mutateIn(dst_bucket, meta, [
+        couchbase.MutateInSpec.upsert("testField", "upsert", {"xattrs": true})
+    ]);
+ 
+    // REPLACE XATTR
+    couchbase.mutateIn(dst_bucket, meta, [
+        couchbase.MutateInSpec.replace("testField", "replace", {"xattrs": true})
+    ]);
+ 
+    // REMOVE XATTR
+    couchbase.mutateIn(dst_bucket, meta, [
+        couchbase.MutateInSpec.remove("testField", {"xattrs": true})
+    ]);
+ 
+    // ARRAY OPERATIONS WITH XATTR
+    couchbase.mutateIn(dst_bucket, meta, [
+        couchbase.MutateInSpec.upsert("arrayTest", [], {"xattrs": true}),
+        couchbase.MutateInSpec.arrayAppend("arrayTest", 2, {"xattrs": true}),
+        couchbase.MutateInSpec.arrayPrepend("arrayTest", 1, {"xattrs": true}),
+        couchbase.MutateInSpec.arrayInsert("arrayTest[0]", 0, {"xattrs": true}),
+        couchbase.MutateInSpec.arrayAddUnique("arrayTest", 3, {"xattrs": true})
+    ]);
+};
+----
+====
+
+
+[#advanced-subdoc-array-op-lookupin]
+== Sub-Document LOOKUPIN Operation
+
+`result = couchbase.lookupIn(binding, meta, subdoc_array, options)`
+
+Sub-Document LOOKUPIN operations let you search for a specific field in a document without having to search and retrieve the entire document.
+
+By default, a LOOKUPIN operation does not fetch Extended Attributes (XATTRs).
+To fetch a document's XATTRs, you must:
+
+* Pass `xattrs` as the third argument of your OnUpdate function.
+* Pass `{ "xattrs": true }` in the `subdoc_array` argument of your OnUpdate function.
+
+The `subdoc_array` argument contains one or more of the following `couchbase.lookupIn.get` specs:
+
+* `<subdoc_path>`, which is the key of the subdocument you want to fetch.
+* `{ "xattrs": true }`, if you want to fetch a document's XATTRs.
+* `{ "doc":[{ "value”: <subdoc_value_0>, ”success”: <bool> }, { "value”: <subdoc_value_1>, ”success”:<bool>} ], ”meta”: <meta>, ”success”: <overall fetch operation success bool> }`, which returns results.
+* `result.doc[i].value`, which gives you access to the i-th value of the subdocument.
+If there's an error in fetching the i-th `subdoc_path`, the `result.doc[i].value` is undefined.
+
+==== Example
+====
+.Operation
+[source,javascript]
+----
+function OnUpdate(doc, meta, xattrs) {
+  var meta = {"id": meta.id}; 
+  var result = couchbase.lookupIn(dst_bucket, meta, [
+    couchbase.LookupInSpec.get("<subdoc_path_0>", {"xattrs": true}),
+    couchbase.LookupInSpec.get("<subdoc_path_1>", {"xattrs": true})
+  ]);
+  var value_0 = result.doc[0].value;
+  var value_1 = result.doc[1].value;
+} 
 ----
 ====
 
@@ -625,10 +703,6 @@ function OnUpdate(doc, meta) {
 
 [#optional-params-recursion]
 === Optional `{ "self_recursion": true }` Parameter
-
-ifeval::['{page-component-version}' == '7.6'] 
-_(Introduced in Couchbase Server 7.6)_ 
-endif::[]
 
 You can use the optional fourth parameter `{ "self_recursion": true }` to prevent the suppression of recursive source bucket mutations and to process the mutations that you have just created.
 

--- a/modules/eventing/pages/eventing-examples.adoc
+++ b/modules/eventing/pages/eventing-examples.adoc
@@ -112,7 +112,7 @@ The following scriptlets demonstrate how to use Advanced Keyspace Accessors, whi
 | xref:eventing:eventing-handler-advancedSelfRecursion.adoc[advancedSelfRecursion]
 | xref:eventing:eventing-handler-advancedMutateInField.adoc[advancedMutateInField]
 | xref:eventing:eventing-handler-advancedMutateInArray.adoc[advancedMutateInArray]
-|
+| xref:eventing:eventing-handler-advancedLookupInOp.adoc[advancedLookupInField]
 |===
 
 [#examples-scriptlets-binary-documents]

--- a/modules/eventing/pages/eventing-handler-advancedLookupInOp.adoc
+++ b/modules/eventing/pages/eventing-handler-advancedLookupInOp.adoc
@@ -1,0 +1,80 @@
+= Function: Advanced Sub-Document LOOKUPIN Operation
+:description: pass:q[Perform the Advanced Sub-Document LOOKUPIN operation on a field where Eventing interacts with the Data Service.]
+:page-edition: Enterprise Edition
+:tabs:
+
+{description}
+
+The `advancedLookupInField` function:
+
+* Demonstrates the CAS-free Sub-Document LOOKUPIN operation on a document field
+* Requires Eventing Storage (or a metadata collection) and a source collection
+* Requires a binding of type `bucket alias`
+* Operates on any mutation where the `meta.id` or KEY starts with `lookupinfield:`
+
+For more information about the Advanced Sub-Document LOOKUPIN operation, see xref:eventing-advanced-keyspace-accessors.adoc#advanced-subdoc-array-op-lookupin[Sub-Document LOOKUPIN Operation].
+
+[{tabs}]
+====
+advancedLookupInField::
++
+--
+[source,javascript]
+----
+// Configure the settings for the advancedLookupInField function as follows:
+//
+// Version 7.6+
+//   "Function Scope"
+//     *.* (or try bulk.data if non-privileged)
+//   "Listen to Location"
+//     bulk.data.source
+//   "Eventing Storage"
+//     rr100.eventing.metadata
+//   Binding(s)
+//    1. "binding type", "alias name...", "bucket.scope.collection", "Access"
+//       "bucket alias", "src_col",       "bulk.data.source",        "read and write"
+
+function OnUpdate(doc, meta, xattrs) {
+  if (meta.id.startsWith("lookupinfield:") === false) return;
+  
+  var meta = { "id": meta.id };
+  var res;
+  var opcnt = 1;
+  
+  res =
+    couchbase.lookupIn(src_col, meta, [
+      couchbase.LookupInSpec.get("<doc_path_0>", {"xattrs": false}),
+      couchbase.LookupInSpec.get("<doc_path_1>")
+    ]);
+  log(opcnt++,res);
+}
+----
+--
+
+Input data::
++
+--
+[source,json]
+----
+INPUT: KEY lookupinfield:001
+
+{
+    "id": "lookupinfield:001",
+}
+
+----
+--
+
+Output data::
++
+--
+[source,json]
+----
+2024-03-15T14:42:53.314-07:00 [INFO] 1 {"meta":{"id":"lookupinfield:001","cas":"1710538973313433600"},"success":true} 
+
+2024-03-15T14:42:53.316-07:00 [INFO] 2 {"meta":{"id":"lookupinfield:001","cas":"1710538973315596288"},"success":true} 
+
+2024-03-15T14:42:53.317-07:00 [INFO] 3 {"meta":{"id":"lookupinfield:001","cas":"1710538973316841472"},"success":true} 
+----
+--
+====

--- a/modules/eventing/pages/eventing-handler-advancedMutateInArray.adoc
+++ b/modules/eventing/pages/eventing-handler-advancedMutateInArray.adoc
@@ -15,7 +15,7 @@ The `advancedMutateInArray` function:
 For example, you can generate an input document with the KEY `combine_landmark_names` and the DATA `{ "id": "combine_landmark_names", "landmark_names": [] }`, then set the number of workers in the Eventing Function's setting to 18.
 Running the Function adds 4,495 landmark names to an array without conflict and in no particular order.
 
-For more information about the Advanced Sub-Document MUTATEIN operation, see xref:eventing-advanced-keyspace-accessors.adoc#advanced-subdoc-array-op[Sub-Document MUTATEIN Operation].
+For more information about the Advanced Sub-Document MUTATEIN operation, see xref:eventing-advanced-keyspace-accessors.adoc#advanced-subdoc-array-op-mutatein[Sub-Document MUTATEIN Operation].
 
 [{tabs}]
 ====

--- a/modules/eventing/pages/eventing-handler-advancedMutateInField.adoc
+++ b/modules/eventing/pages/eventing-handler-advancedMutateInField.adoc
@@ -12,7 +12,7 @@ The `advancedMutateInField` function:
 * Requires a binding of type `bucket alias`
 * Operates on any mutation where the `meta.id` or KEY starts with `mutateinfield:`
 
-For more information about the Advanced Sub-Document MUTATEIN operation , see xref:eventing-advanced-keyspace-accessors.adoc#advanced-subdoc-array-op[Sub-Document MUTATEIN Operation].
+For more information about the Advanced Sub-Document MUTATEIN operation , see xref:eventing-advanced-keyspace-accessors.adoc#advanced-subdoc-array-op-mutatein[Sub-Document MUTATEIN Operation].
 
 [{tabs}]
 ====


### PR DESCRIPTION
(PR in progress for 7.6.2 release)

Server doc ticket: https://github.com/couchbaselabs/docs-devex/pull/230

Doc ticket: https://issues.couchbase.com/browse/DOC-12049
Dev ticket: https://issues.couchbase.com/browse/MB-61203

Changes in this PR:
- Updated "Advanced Keyspace Accessors" page to include the new LOOKUPIN sub-document operation 
- Added new page called "Function: Advanced Sub-Document LOOKUPIN Operation"

Still to do:
- Add "Function: Advanced Sub-Document LOOKUPIN Operation" to nav file so it shows up on the sidebar