### PR TITLE
[DOC-11988-7.6]: RBAC role change impact to eventing function

### DIFF
--- a/modules/eventing/pages/eventing-rbac.adoc
+++ b/modules/eventing/pages/eventing-rbac.adoc
@@ -7,10 +7,10 @@
 [#description]
 == Description: What is RBAC
 
-Couchbase provides _Role-Based Access Control_ (RBAC), in which access privileges are assigned to fixed roles; which are in turn assigned to users (each of which may be an administrator or an application) either _directly_; or _indirectly_, by means of _user-groups_.
+Couchbase provides _Role-Based Access Control_ (RBAC), in which access privileges are assigned to fixed roles, which are in turn assigned to users, (each of which may be an administrator or an application) either _directly_; or _indirectly_, by means of _user-groups_.
 
 Couchbase Server Enterprise Edition provides RBAC with multiple roles for finer access control.
-Community Edition provides multiple users that can be assigned to limited set of roles.
+Community Edition provides multiple users that can be assigned to a limited set of roles.
 There are three fixed roles in the community edition of Couchbase providing coarser access control: Bucket Full Access (`bucket_full_access[*]`), Admin (`admin`), and Read Only Admin (`ro_admin`).
 
 A Couchbase-Server _role_ permits one or more _resources_ to be accessed according to defined _privileges_.
@@ -27,9 +27,11 @@ For more information, see xref:learn:security/authorization-overview.adoc[Author
 A bucket.scope combination is used for identifying functions belonging to the same group.
 
 Only the "Eventing Full Admin" role and also the "Full Admin" role can set the bucket.scope to  *+*+.+*+*; all other Eventing non-privileged users need to define a *Function Scope* for their Eventing functions that references an existing resource of bucket.scope. 
-This provides role based isolation of Eventing functions between non-privileged users
+This provides role-based isolation of Eventing functions between non-privileged users.
 
-Typically you should set Function Scope to the bucket.scope that holds the collection that is the source of your mutations to your Eventing Function.  This best practice ensures that you _do not_  inadvertently cause an Eventing Function to undeploy by removing a *Function Scope* pointing to a resource that is not required for the function to run.
+include::@cloud:eventing:eventing-rbac.adoc[tag="rbac-change-warning"]
+
+Typically, you should set Function Scope to the bucket.scope that holds the collection that is the source of your mutations to your Eventing Function.  This best practice ensures that you _do not_  inadvertently cause an Eventing Function to undeploy by removing a *Function Scope* pointing to a resource that is not required for the function to run.
 
 NOTE: A user can be assigned multiple "Eventing / Manage Scope Function" RBAC roles and if any of these roles match an existing Eventing Function's *Function Scope* then that user can manage, modify, or delete the Eventing Function even if it was created or imported by someone else.
 

--- a/modules/eventing/pages/eventing-rbac.adoc
+++ b/modules/eventing/pages/eventing-rbac.adoc
@@ -29,7 +29,7 @@ A bucket.scope combination is used for identifying functions belonging to the sa
 Only the "Eventing Full Admin" role and also the "Full Admin" role can set the bucket.scope to  *+*+.+*+*; all other Eventing non-privileged users need to define a *Function Scope* for their Eventing functions that references an existing resource of bucket.scope. 
 This provides role-based isolation of Eventing functions between non-privileged users.
 
-include::@cloud:eventing:eventing-rbac.adoc[tag="rbac-change-warning"]
+include::_@cloud:eventing:eventing-rbac.adoc[tags=rbac-change-warning]
 
 Typically, you should set Function Scope to the bucket.scope that holds the collection that is the source of your mutations to your Eventing Function.  This best practice ensures that you _do not_  inadvertently cause an Eventing Function to undeploy by removing a *Function Scope* pointing to a resource that is not required for the function to run.
 


### PR DESCRIPTION
Adding warning about changing roles that are attached to a deployed function.