### PR TITLE
[DOC-11988-capella]: RBAC role change impact to eventing function

### DIFF
--- a/modules/eventing/pages/eventing-rbac.adoc
+++ b/modules/eventing/pages/eventing-rbac.adoc
@@ -27,9 +27,20 @@ For more information, see xref:learn:security/authorization-overview.adoc[Author
 A bucket.scope combination is used for identifying functions belonging to the same group.
 
 Only the "Eventing Full Admin" role and also the "Full Admin" role can set the bucket.scope to  *+*+.+*+*; all other Eventing non-privileged users need to define a *Function Scope* for their Eventing functions that references an existing resource of bucket.scope. 
-This provides role based isolation of Eventing functions between non-privileged users
+This provides role-based isolation of Eventing functions between non-privileged users
 
-Typically you should set Function Scope to the bucket.scope that holds the collection that is the source of your mutations to your Eventing Function.  This best practice ensures that you _do not_  inadvertently cause an Eventing Function to undeploy by removing a *Function Scope* pointing to a resource that is not required for the function to run.
+// tag::rbac-change-warning[]
+[CAUTION]
+====
+Changing the access role (i.e.,
+by revoking write permissions) could impact deployed eventing functions that have been assigned to this role. +
+_This may result in the function being undeployed._ +
+In this case, redeploy the function with the correctly assigned role to allow access.
+====
+// end::rbac-change-warning[]
+
+Typically, you should set Function Scope to the `bucket.scope` that holds the collection that is the source of the mutations to your Eventing Function. +
+This best practice ensures that you _do not_  inadvertently cause an Eventing Function to undeploy by removing a *Function Scope* pointing to a resource that is not required for the function to run.
 
 NOTE: A user can be assigned multiple "Eventing / Manage Scope Function" RBAC roles and if any of these roles match an existing Eventing Function's *Function Scope* then that user can manage, modify, or delete the Eventing Function even if it was created or imported by someone else.
 
@@ -136,7 +147,7 @@ The "Function Scope" in an Eventing Function works with the RBAC selection in "E
 A tenant might be based on company departments such as administration, sales, production and support.
 
 Below we have two tenants example (an admin and a limited user) and four Eventing Functions each with a different *Function Scope*. 
-We logged into the UI with either an Eventing Full Admin" or "Full Admin" role and thus we can access all of the  Eventing Functions. 
+We logged into the UI with either an Eventing Full Admin" or "Full Admin" role, and thus we can access all of the  Eventing Functions.
 
 image::rbac_admin_view.png[,%100]
 


### PR DESCRIPTION
Added cautionary note concerning changing permissions that are attached to a deployed function.
Note that the caution is wrapped in tags so that the same caution can be used in the Server docs.