### PR TITLE
DOC-12443: Reorganize GSI documents

### DIFF
--- a/modules/learn/pages/services-and-indexes/indexes/indexes.adoc
+++ b/modules/learn/pages/services-and-indexes/indexes/indexes.adoc
@@ -29,10 +29,15 @@ A Secondary Index is frequently referred to as a _Global Secondary Index_, or _G
 This is the kind of index used most frequently in Couchbase Server, for queries performed with {sqlpp}.
 For information on Global Secondary Indexes, see xref:services-and-indexes/indexes/global-secondary-indexes.adoc[Using Indexes].
 
-Full Text:: Provided by the xref:services-and-indexes/services/search-service.adoc[Search Service], this is a specially purposed index, which contains targets derived from the textual contents of documents within one or more specified keyspaces.
-Text-matches of different degrees of exactitude can be searched for.
-Both input and target text-values can be purged of irrelevant characters (such as punctuation marks or html tags).
-For information on how to create Full Text Indexes, see xref:fts:fts-creating-indexes.adoc[Creating Indexes].
+Search:: Provided by the xref:services-and-indexes/services/search-service.adoc[Search Service], this is a specially purposed index, which contains targets derived from the contents of documents within one or more specified keyspaces.
+Search indexes support text matching, geospatial, date-time, numeric range searches, and more.
+For text matching, you can add filters to remove undesirable characters from input and target text values, such as punctuation marks or HTML tags.
+For information on how to create Search indexes, see xref:search:create-search-indexes.adoc[].
+
+Vector Search:: Provided by the xref:services-and-indexes/services/search-service.adoc[Search Service], this is a type of Search index which supports vector embeddings.
+Use Vector Search indexes to run searches with the Search service using vector comparisons.
+You can use Vector Search indexes for Retrieval Augmented Generation (RAG) with an existing Large Language Model (LLM).
+To create Vector Search indexes, see xref:vector-search:create-vector-search-index-ui.adoc[] or xref:vector-search:create-vector-search-index-rest-api.adoc[].
 
 Analytics:: Provided by the xref:services-and-indexes/services/analytics-service.adoc[Analytics Service], this is a materialized access path for the shadow data in an Analytics collection.
 Analytics indexes can be used to speed up Analytics selection queries and join queries.


### PR DESCRIPTION
Backport parts of the following PR to release/7.6:

* https://github.com/couchbase/docs-server/pull/3672

I decided for now just to make the Vector Search changes to the indexing overview but to leave all the files in place.