### PR TITLE
minor fixes to bucket and index names in sample search index and alias JSON

### DIFF
--- a/modules/search/examples/search-index-alias.jsonc
+++ b/modules/search/examples/search-index-alias.jsonc
@@ -4,7 +4,7 @@
     "params": {
       "targets": {
         "travel-sample.inventory.travel-index": {},
-        "vector-sample.color.color-index": {}
+        "color-vector-sample.color.color-test": {}
       }
     },
     "sourceType": "nil",

--- a/modules/vector-search/examples/sample-vector-search-index-payload.json
+++ b/modules/vector-search/examples/sample-vector-search-index-payload.json
@@ -106,7 +106,7 @@
      }
     },
     "sourceType": "gocbcore",
-    "sourceName": "vector-sample",
+    "sourceName": "color-vector-sample",
     "sourceParams": {},
     "planParams": {
      "maxPartitionsPerPIndex": 1024,


### PR DESCRIPTION
minor fixes to bucket and index names in sample search index and alias JSON so that these work with the corresponding sample data sets