### PR TITLE
[quickfix]: strange overlapping  text on diagram

### DIFF
--- a/modules/tutorials/partials/diagrams/couchbase-hierarchy.puml
+++ b/modules/tutorials/partials/diagrams/couchbase-hierarchy.puml
@@ -23,20 +23,20 @@ collection --> document3
 
 note right of bucket
 
- Maximum of  30 per cluster
- 
+ Maximum of 30 per cluster
+
 end note
 
 note left of scope
 
   Maximum of 1000 per cluster
-  
+
 end note
 
 note right of collection
 
   Maximum of 1000 per cluster
-  
+
 end note
 
 @enduml


### PR DESCRIPTION

Weird artifact on the architecture diagram that was causing one the text on one of the labels to overlap.
