### PR TITLE
DOC-12641: Convert Capella dev REST API references to use OpenAPI generator

### DIFF
--- a/modules/n1ql/pages/n1ql-intro/cbq.adoc
+++ b/modules/n1ql/pages/n1ql-intro/cbq.adoc
@@ -1359,6 +1359,7 @@ $
 ----
 ====
 
+[#executing-a-script]
 == Executing a Script
 
 You can use the [.param]`--script` option to start cbq, execute a single {sqlpp} query, and exit the shell.

--- a/modules/n1ql/pages/n1ql-language-reference/execfunction.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/execfunction.adoc
@@ -92,7 +92,9 @@ For examples, refer to xref:n1ql-language-reference/createfunction.adoc#examples
 == Related Links
 
 * To create user-defined functions, refer to xref:n1ql-language-reference/createfunction.adoc[].
+ifdef::flag-devex-rest-api[]
 * To manage external libraries and external functions, see xref:server:n1ql:n1ql-rest-api/functions.adoc[].
+endif::flag-devex-rest-api[]
 * To see the execution plan for a user-defined function, see xref:n1ql-language-reference/explainfunction.adoc[].
 * To include a user-defined function in an expression, see xref:n1ql-language-reference/userfun.adoc[].
 * To monitor user-defined functions, see xref:n1ql:n1ql-intro/sysinfo.adoc#sys-functions[Monitor Functions].

--- a/modules/n1ql/pages/n1ql-language-reference/explainfunction.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/explainfunction.adoc
@@ -137,7 +137,9 @@ include::n1ql:example$utility/explainfunctionjs.jsonc[]
 == Related Links
 
 * To create user-defined functions, refer to xref:n1ql-language-reference/createfunction.adoc[].
+ifdef::flag-devex-rest-api[]
 * To manage external libraries and external functions, see xref:server:n1ql:n1ql-rest-api/functions.adoc[].
+endif::flag-devex-rest-api[]
 * To execute a user-defined function, see xref:n1ql-language-reference/execfunction.adoc[].
 * To include a user-defined function in an expression, see xref:n1ql-language-reference/userfun.adoc[].
 * To monitor user-defined functions, see xref:n1ql:n1ql-intro/sysinfo.adoc#sys-functions[Monitor Functions].

--- a/modules/n1ql/pages/n1ql-language-reference/updatestatistics.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/updatestatistics.adoc
@@ -69,7 +69,7 @@ How frequently you should run the `UPDATE STATISTICS` statement to gather statis
 For data that does not change frequently, there is no need to run `UPDATE STATISTICS`.
 For data that changes constantly, you should run `UPDATE STATISTICS` more frequently.
 
-To gather statistics automatically, consider running a `cron` job at regular intervals to execute the `UPDATE STATISTICS` statement via the xref:n1ql:n1ql-rest-api/index.adoc[Query Service REST API].
+To gather statistics automatically, consider running a `cron` job at regular intervals to execute the `UPDATE STATISTICS` statement via the xref:n1ql:n1ql-intro/cbq.adoc#executing-a-script[cbq shell].
 
 [[result]]
 == Result

--- a/modules/n1ql/pages/n1ql-language-reference/userfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/userfun.adoc
@@ -186,7 +186,9 @@ At the latitude of the selected hotel, each geohash represents an area of approx
 == Related Links
 
 * To create user-defined functions, refer to xref:n1ql-language-reference/createfunction.adoc[].
+ifdef::flag-devex-rest-api[]
 * To manage external libraries and external functions, see xref:server:n1ql:n1ql-rest-api/functions.adoc[].
+endif::flag-devex-rest-api[]
 * To execute a user-defined function, see xref:n1ql-language-reference/execfunction.adoc[].
 * To see the execution plan for a user-defined function, see xref:n1ql-language-reference/explainfunction.adoc[].
 * To monitor user-defined functions, see xref:n1ql:n1ql-intro/sysinfo.adoc#sys-functions[Monitor Functions].

--- a/modules/n1ql/pages/n1ql-manage/monitoring-n1ql-query.adoc
+++ b/modules/n1ql/pages/n1ql-manage/monitoring-n1ql-query.adoc
@@ -16,10 +16,10 @@ ifdef::basebackend-html[]
     width: auto !important;
   }
 
-  /* Hyphenate inline code in tables */
+  /* Wrap inline code in tables */
   td.tableblock p code,
   p.tableblock code{
-    hyphens: auto;
+    overflow-wrap: anywhere;
   }
 
   /* Do not hyphenate words in the table */
@@ -34,16 +34,18 @@ ifdef::basebackend-html[]
   }
 
   /* Spacing for markdown blocks */
-  .doc .openblock .content p {
+  .doc .openblock > .content > p {
     margin-top: 1rem;
   }
 
-  .doc .openblock .content ul {
+  .doc .openblock > .content > ul,
+  .doc .openblock > .content > ol {
     margin-top: 1.5rem;
     margin-left: 1rem;
   }
 
-  .doc .openblock .content ul li + li {
+  .doc .openblock > .content > ul li + li,
+  .doc .openblock > .content > ol li + li {
     margin-top: 0.5rem;
   }
 </style>
@@ -923,7 +925,7 @@ curl $BASE_URL/admin/settings -u $USER:$PASSWORD \
 endif::flag-devex-rest-api[]
 
 [#query-monitoring-settings]
-== Query Profiling
+== [[Request]]Query Profiling
 
 Query profiling enables you to obtain more detailed monitoring information and finer execution timings for any query.
 You can set query profiling to the following levels:
@@ -1336,6 +1338,18 @@ The `profile` object contains the following attributes:
 
 include::n1ql-rest-query:index.adoc[tags=Profile]
 
+[[Execution_Timings,Execution Timings]]
+*Execution Timings*
+
+include::n1ql-rest-query:index.adoc[tags=Execution_Timings]
+
+[[Statistics,Statistics]]
+*Statistics*
+
+include::n1ql-rest-query:index.adoc[tags=Statistics]
+
+include::n1ql-rest-query:partial$definitions/Statistics/definition-end.adoc[opts=optional]
+
 [[plan]]
 === Profiling Details in System Catalogs
 
@@ -1482,7 +1496,7 @@ Getting the plan for a statement that you ran when the profile was set to `timin
 ----
 ====
 
-For field names and meanings, see <<_execution_timings,Execution Timings>>.
+For field names and meanings, see <<Execution_Timings>>.
 
 == Query Profiling Summary
 

--- a/modules/n1ql/pages/n1ql-manage/monitoring-n1ql-query.adoc
+++ b/modules/n1ql/pages/n1ql-manage/monitoring-n1ql-query.adoc
@@ -16,10 +16,16 @@ ifdef::basebackend-html[]
     width: auto !important;
   }
 
+  /* Hyphenate inline code in tables */
+  td.tableblock p code,
+  p.tableblock code{
+    hyphens: auto;
+  }
+
   /* Do not hyphenate words in the table */
   td.tableblock p,
   p.tableblock{
-    hyphens: manual !important;
+    hyphens: manual;
   }
 
   /* Vertical alignment */
@@ -27,10 +33,19 @@ ifdef::basebackend-html[]
     vertical-align: top !important;
   }
 
-  /* Hide content of tags section */
-  div.sect2 > h3#tags,
-  div.sect2 > h3#tags ~ *{
-    display: none;
+  /* Spacing for markdown blocks */
+  .doc .openblock .content p {
+    margin-top: 1rem;
+  }
+
+  .doc .openblock .content ul {
+    margin-top: 1.5rem;
+    margin-left: 1rem;
+  }
+
+  .doc .openblock .content ul li + li {
+    margin-top: 0.5rem;
+  }
 </style>
 ++++
 endif::[]
@@ -160,7 +175,7 @@ Getting system vitals, as described in <<sys-vitals-get>>, returns results simil
 
 This catalog contains the following attributes:
 
-include::n1ql:partial$n1ql-rest-api/admin/definitions.adoc[tags=vitals]
+include::n1ql-rest-admin:index.adoc[tags=Vitals]
 
 [#sys-active-req]
 == Monitor and Manage Active Requests
@@ -307,7 +322,7 @@ Getting active requests, as described in <<sys-active-get>>, returns results sim
 
 This catalog contains the following attributes:
 
-include::n1ql:partial$n1ql-rest-api/admin/definitions.adoc[tags=requests]
+include::n1ql-rest-admin:index.adoc[tags=Requests]
 
 For query plan field names and meanings, see <<monitor-profile-details>>.
 
@@ -550,7 +565,7 @@ In this example, the names of the prepared statements are identical, but they ar
 
 This catalog contains the following attributes:
 
-include::n1ql:partial$n1ql-rest-api/admin/definitions.adoc[tags=statements]
+include::n1ql-rest-admin:index.adoc[tags=Statements]
 
 For query plan field names and meanings, see <<monitor-profile-details>>.
 
@@ -1319,7 +1334,7 @@ the cbq shell, the following statistics are returned when `profile` is set to `t
 
 The `profile` object contains the following attributes:
 
-include::n1ql:partial$n1ql-rest-api/query/definitions.adoc[tags=profile]
+include::n1ql-rest-query:index.adoc[tags=Profile]
 
 [[plan]]
 === Profiling Details in System Catalogs

--- a/modules/n1ql/pages/n1ql-manage/query-settings.adoc
+++ b/modules/n1ql/pages/n1ql-manage/query-settings.adoc
@@ -33,10 +33,10 @@ ifdef::basebackend-html[]
     width: auto !important;
   }
 
-  /* Hyphenate inline code in tables */
+  /* Wrap inline code in tables */
   td.tableblock p code,
   p.tableblock code{
-    hyphens: auto;
+    overflow-wrap: anywhere;
   }
 
   /* Do not hyphenate words in the table */
@@ -51,16 +51,18 @@ ifdef::basebackend-html[]
   }
 
   /* Spacing for markdown blocks */
-  .doc .openblock .content p {
+  .doc .openblock > .content > p {
     margin-top: 1rem;
   }
 
-  .doc .openblock .content ul {
+  .doc .openblock > .content > ul,
+  .doc .openblock > .content > ol {
     margin-top: 1.5rem;
     margin-left: 1rem;
   }
 
-  .doc .openblock .content ul li + li {
+  .doc .openblock > .content > ul li + li,
+  .doc .openblock > .content > ol li + li {
     margin-top: 0.5rem;
   }
 </style>

--- a/modules/n1ql/pages/n1ql-manage/query-settings.adoc
+++ b/modules/n1ql/pages/n1ql-manage/query-settings.adoc
@@ -33,15 +33,35 @@ ifdef::basebackend-html[]
     width: auto !important;
   }
 
+  /* Hyphenate inline code in tables */
+  td.tableblock p code,
+  p.tableblock code{
+    hyphens: auto;
+  }
+
   /* Do not hyphenate words in the table */
   td.tableblock p,
   p.tableblock{
-    hyphens: manual !important;
+    hyphens: manual;
   }
 
   /* Vertical alignment */
   td.tableblock{
     vertical-align: top !important;
+  }
+
+  /* Spacing for markdown blocks */
+  .doc .openblock .content p {
+    margin-top: 1rem;
+  }
+
+  .doc .openblock .content ul {
+    margin-top: 1.5rem;
+    margin-left: 1rem;
+  }
+
+  .doc .openblock .content ul li + li {
+    margin-top: 0.5rem;
   }
 </style>
 ++++
@@ -140,7 +160,7 @@ endif::flag-devex-rest-api[]
 The table below contains details of all request-level parameters, along with examples.
 
 .Request-Level Parameters
-include::n1ql:partial$n1ql-rest-api/query/definitions.adoc[tag=settings]
+include::n1ql-rest-query:index.adoc[tag=Request]
 
 [discrete#transactional-scan-consistency]
 ===== Transactional Scan Consistency


### PR DESCRIPTION
Jira issue: DOC-12641

This PR updates the Query Admin and Query Service REST APIs to use openapi-generator, purely so that portions of the generated documents can be reused in the Capella dev docs.

This must be merged at the same time as the following PR:

* https://github.com/couchbaselabs/cb-swagger/pull/152