### PR TITLE
DOC-12652: Convert other server REST API references to use OpenAPI generator

### DIFF
--- a/modules/learn/pages/services-and-indexes/indexes/query-without-index.adoc
+++ b/modules/learn/pages/services-and-indexes/indexes/query-without-index.adoc
@@ -316,7 +316,7 @@ You can get or set the N1QL Feature Controller setting in any of the following w
 
 |REST API
 |Cluster-level
-|xref:rest-api:rest-cluster-query-settings.adoc[]
+|xref:n1ql-rest-settings:index.adoc[]
 |`queryN1qlFeatCtrl`
 
 |REST API

--- a/modules/n1ql/pages/n1ql-language-reference/curl.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/curl.adoc
@@ -227,13 +227,13 @@ Click btn:[+] to add another URL to the list.
 
 Click btn:[-] to remove a URL from the list.
 
-==== From CBQ
+==== From the Query Settings REST API
 
-From a CBQ prompt, you can send a CURL() command to allow or disallow specific URLs, for example:
+You can send a call to the Query Settings REST API to allow or disallow specific URLs, for example:
 
 [source,sh]
 ----
-include::rest-api:example$query-settings-post-access.sh[]
+include::rest-api:example$query-settings-post-access.sh[tags=request]
 ----
 
 The access list file command structure is described in the following table.

--- a/modules/n1ql/pages/n1ql-language-reference/curl.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/curl.adoc
@@ -8,6 +8,9 @@
 :url-yahoo-api: https://developer.yahoo.com/api/
 :url-google-geo: https://developers.google.com/maps/documentation/geocoding/intro
 
+// TEMP
+include::partial$n1ql-language-reference/table-style.adoc[]
+
 The `CURL()` function implements a subset of {url-wiki-curl}[cURL^] functionality and enables {sqlpp} queries to interact and integrate with external JSON data sources available over HTTP/REST.
 This allows federated queries against external data sources, such as the {url-google-maps}[Google geocoding API^], {url-yahoo-api}[Yahoo API^], or other Couchbase clusters.
 The federated queries can leverage full querying capabilities of {sqlpp}, including functions, expressions, sub-queries, JOINs, NESTs, UNNESTs etc.

--- a/modules/n1ql/pages/n1ql-language-reference/curl.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/curl.adoc
@@ -640,7 +640,7 @@ WHERE to_number(hdp_low) < min_threshold;
 ====
 
 [[Ex6]]
-.Use CURL() to allow two URLs and disallow one URL
+.Allow two URLs and disallow one URL
 ====
 .Request
 [source,sh]
@@ -655,7 +655,7 @@ curl -X POST -u Administrator:password \
 ====
 
 [[Ex7]]
-.Use CURL() to allow all access to all endpoints
+.Allow all access to all endpoints
 ====
 .Request
 [source,sh]
@@ -668,7 +668,7 @@ curl -X POST -u Administrator:password \
 ====
 
 [[Ex8]]
-.Use CURL() to turn off access to all endpoints and clear the Allowed and Disallowed lists
+.Turn off access to all endpoints and clear the Allowed and Disallowed lists
 ====
 .Request
 [source,sh]
@@ -683,7 +683,7 @@ curl -X POST -u Administrator:password \
 ====
 
 [[Ex9]]
-.Use CURL() to turn off access to all endpoints but make no changes to the Allowed and Disallowed lists
+.Turn off access to all endpoints but make no changes to the Allowed and Disallowed lists
 ====
 .Request
 [source,sh]
@@ -696,7 +696,7 @@ curl -X POST -u Administrator:password \
 ====
 
 [[Ex10]]
-.Use CURL() to turn off access to all endpoints, allow one URL, and clear the Disallowed list
+.Turn off access to all endpoints, allow one URL, and clear the Disallowed list
 ====
 .Request
 [source,sh]
@@ -711,7 +711,7 @@ curl -X POST -u Administrator:password \
 ====
 
 [[Ex11]]
-.Use CURL() to turn off access to all endpoints, disallow one URL, and clear the Allowed list
+.Turn off access to all endpoints, disallow one URL, and clear the Allowed list
 ====
 .Request
 [source,sh]
@@ -726,7 +726,7 @@ curl -X POST -u Administrator:password \
 ====
 
 [[Ex12]]
-.Use CURL() to allow an IP address and port instead of a website name
+.Allow an IP address and port instead of a website name
 ====
 .Request
 [source,sh]
@@ -741,7 +741,7 @@ curl -X POST -u Administrator:password \
 ====
 
 [[Ex13]]
-.Use CURL() to allow and disallow the same URL -- and get an error
+.Allow and disallow the same URL -- and get an error
 ====
 .Request
 [source,sh]

--- a/modules/n1ql/pages/n1ql-language-reference/curl.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/curl.adoc
@@ -233,7 +233,7 @@ You can send a call to the Query Settings REST API to allow or disallow specific
 
 [source,sh]
 ----
-include::rest-api:example$query-settings-post-access.sh[tags=request]
+include::n1ql-rest-settings:example$query-settings-post-access.sh[tags=request]
 ----
 
 The access list file command structure is described in the following table.

--- a/modules/n1ql/pages/n1ql-language-reference/curl.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/curl.adoc
@@ -239,7 +239,7 @@ include::rest-api:example$query-settings-post-access.sh[]
 The access list file command structure is described in the following table.
 
 .Structure of Access List for CURL()
-include::rest-api:partial$query-settings/definitions.adoc[tag=access]
+include::n1ql-rest-settings:index.adoc[tag=Access]
 
 == Design Considerations
 

--- a/modules/n1ql/pages/n1ql-manage/query-settings.adoc
+++ b/modules/n1ql/pages/n1ql-manage/query-settings.adoc
@@ -370,11 +370,11 @@ http://localhost:8091/settings/querySettings \
 The table below contains details of all cluster-level query settings.
 
 .Cluster-Level Query Settings
-include::rest-api:partial$query-settings/definitions.adoc[tag=settings]
+include::n1ql-rest-settings:index.adoc[tag=Settings]
 
-[[_access]]
+[[Access,Access]]
 **Access**
-include::rest-api:partial$query-settings/definitions.adoc[tag=access]
+include::n1ql-rest-settings:index.adoc[tag=Access]
 
 [[service-level-query-settings]]
 == Node-Level Query Settings

--- a/modules/n1ql/pages/n1ql-manage/query-settings.adoc
+++ b/modules/n1ql/pages/n1ql-manage/query-settings.adoc
@@ -4,7 +4,7 @@
 :page-partial:
 
 // External cross-references
-:rest-cluster-query-settings: xref:rest-api:rest-cluster-query-settings.adoc
+:rest-cluster-query-settings: xref:n1ql-rest-settings:index.adoc
 :general-settings-query-settings: xref:manage:manage-settings/general-settings.adoc#query-settings
 :couchbase-cli-setting-query: xref:cli:cbcli/couchbase-cli-setting-query.adoc
 :n1ql-rest-api-admin: xref:n1ql-rest-admin:index.adoc

--- a/modules/n1ql/partials/n1ql-language-reference/table-style.adoc
+++ b/modules/n1ql/partials/n1ql-language-reference/table-style.adoc
@@ -1,0 +1,51 @@
+// FIXME: Temporary pass-through CSS for REST API tables with Markdown blocks
+
+ifdef::basebackend-html[]
+++++
+<style type="text/css">
+  /* No maximum width for table cells */
+  .doc table.spread > tbody > tr > *,
+  .doc table.stretch > tbody > tr > * {
+    max-width: none !important;
+  }
+
+  /* Ignore fixed column widths */
+  col{
+    width: auto !important;
+  }
+
+  /* Wrap inline code in tables */
+  td.tableblock p code,
+  p.tableblock code{
+    overflow-wrap: anywhere;
+  }
+
+  /* Do not hyphenate words in the table */
+  td.tableblock p,
+  p.tableblock{
+    hyphens: manual;
+  }
+
+  /* Vertical alignment */
+  td.tableblock{
+    vertical-align: top !important;
+  }
+
+  /* Spacing for markdown blocks */
+  .doc .openblock > .content > p {
+    margin-top: 1rem;
+  }
+
+  .doc .openblock > .content > ul,
+  .doc .openblock > .content > ol {
+    margin-top: 1.5rem;
+    margin-left: 1rem;
+  }
+
+  .doc .openblock > .content > ul li + li,
+  .doc .openblock > .content > ol li + li {
+    margin-top: 0.5rem;
+  }
+</style>
+++++
+endif::[]


### PR DESCRIPTION
Jira issue: DOC-12652

Migrates the Query Settings and Index Stats REST API documentation.

This PR must be merged at the same time as the following:

* https://github.com/couchbaselabs/cb-swagger/pull/154
* https://github.com/couchbase/docs-server/pull/3714