### PR TITLE
[DOC-12252] Add tip with links to other SDK examples

### DIFF
--- a/modules/vector-search/pages/run-vector-search-sdk.adoc
+++ b/modules/vector-search/pages/run-vector-search-sdk.adoc
@@ -11,6 +11,21 @@
 
 For more information about how the Search Service scores documents in search results, see xref:search:run-searches.adoc#scoring[Scoring for Search Queries].
 
+[TIP]
+====
+Not all available Couchbase SDK languages are covered by the examples on this page.
+
+For additional Vector Search examples, see: 
+
+* xref:dotnet-sdk:howtos:full-text-searching-with-sdk.adoc#vector-search[.NET SDK]
+* xref:cxx-sdk:howtos:vector-searching-with-sdk.adoc[C++ SDK]
+* xref:kotlin-sdk:howtos:full-text-search.adoc#vector-search[Kotlin SDK]
+* xref:nodejs-sdk:howtos:full-text-searching-with-sdk.adoc#vector-search[Node.js SDK]
+* xref:php-sdk:howtos:full-text-searching-with-sdk.adoc#vector-search[PHP SDK]
+* xref:ruby-sdk:howtos:full-text-searching-with-sdk.adoc#vector-search[Ruby SDK]
+* xref:scala-sdk:howtos:vector-searching-with-sdk.adoc[Scala SDK]
+
+====
 
 == Prerequisites
 

--- a/modules/vector-search/pages/run-vector-search-sdk.adoc
+++ b/modules/vector-search/pages/run-vector-search-sdk.adoc
@@ -15,15 +15,9 @@ For more information about how the Search Service scores documents in search res
 ====
 Not all available Couchbase SDK languages are covered by the examples on this page.
 
-For additional Vector Search examples, see: 
+For additional Vector Search examples, see the SDK documentation: 
 
-* xref:dotnet-sdk:howtos:full-text-searching-with-sdk.adoc#vector-search[.NET SDK]
-* xref:cxx-sdk:howtos:vector-searching-with-sdk.adoc[C++ SDK]
-* xref:kotlin-sdk:howtos:full-text-search.adoc#vector-search[Kotlin SDK]
-* xref:nodejs-sdk:howtos:full-text-searching-with-sdk.adoc#vector-search[Node.js SDK]
-* xref:php-sdk:howtos:full-text-searching-with-sdk.adoc#vector-search[PHP SDK]
-* xref:ruby-sdk:howtos:full-text-searching-with-sdk.adoc#vector-search[Ruby SDK]
-* xref:scala-sdk:howtos:vector-searching-with-sdk.adoc[Scala SDK]
+xref:dotnet-sdk:howtos:full-text-searching-with-sdk.adoc#vector-search[.NET] | xref:cxx-sdk:howtos:vector-searching-with-sdk.adoc[C++] | xref:kotlin-sdk:howtos:full-text-search.adoc#vector-search[Kotlin] | xref:nodejs-sdk:howtos:full-text-searching-with-sdk.adoc#vector-search[Node.js] | xref:php-sdk:howtos:full-text-searching-with-sdk.adoc#vector-search[PHP] | xref:ruby-sdk:howtos:full-text-searching-with-sdk.adoc#vector-search[Ruby] | xref:scala-sdk:howtos:vector-searching-with-sdk.adoc[Scala]
 
 ====
 


### PR DESCRIPTION
Quick fix to add a tip that shows the other examples Richard wrote up for Vector Search for the other SDK languages. 

It'll at least stop further complaints, even if it's not a perfect solution. 

This is the Capella version of the fix. 