### PR TITLE
DOC-12533: Feedback on Language Constructs

### DIFF
--- a/modules/eventing/pages/eventing-language-constructs.adoc
+++ b/modules/eventing/pages/eventing-language-constructs.adoc
@@ -376,14 +376,14 @@ The `close()` method on the iterable handle can throw an exception if the underl
 |===
 
 [#analytics_call]
-=== `ANALYTICS()`
+=== `couchbase.analyticsQuery()`
 
 ifeval::['{page-component-version}' == '7.6'] 
 
 [.status]#Introduced in Couchbase Server 7.6#
 endif::[]
 
-The `ANALYTICS()` function provides integration with {sqlpp} Analytics directly from the Eventing Service.
+The `couchbase.analyticsQuery()` function provides integration with {sqlpp} Analytics directly from the Eventing Service.
 
 Integrating Eventing with Analytics:
 
@@ -394,31 +394,17 @@ Integrating Eventing with Analytics:
 [source,javascript]
 ----
 function OnUpdate(doc, meta) {
-    // Ignore information we don't care about
-    if (doc.type !== 'airline') return;
+  var count = 0;
+  const limit = 4;
 
-    // Get the total routes per IATA
-    var route_cnt = 0;     
-    // Uses a true variable as a SQL++ parameter  
-    var airline = doc.iata;  
+  let query = couchbase.analyticsQuery('SELECT * FROM default LIMIT $limit;', {"limit": limit});
+  for (let row of query) {
+  ++count;
+  }
 
-    var results = ANALYTICS(
-        "SELECT COUNT(*) AS cnt
-        FROM `travel-sample`.`inventory`.`route`
-        WHERE type = \"route\" 
-		AND airline = $1", [doc.iata]
-    );
-
-    // Stream results using the 'for' iterator
-    for (var item of results) {   
-        route_cnt = item.cnt;
-    }
-
-    // End the query and free the resources held
-    results.close();    
-
-    // Log the KEY, AIRLINE and ROUTE_CNT
-    log("key: " + meta.id + ", airline: " + doc.iata + ", route_cnt: " + route_cnt);
+  if (count === limit) {
+  dst_bucket[meta.id] = 'yes';
+  }
 }
 ----
 

--- a/modules/eventing/pages/eventing-language-constructs.adoc
+++ b/modules/eventing/pages/eventing-language-constructs.adoc
@@ -390,20 +390,22 @@ Integrating Eventing with Analytics:
 * Simplifies Eventing code logic and improves code readability
 * Eliminates security and network latency issues with the `curl()` function
 
+The following example assumes that the Analytics collection (dataset) called `default` already exists.
+
 [source,javascript]
 ----
 function OnUpdate(doc, meta) {
-  var count = 0;
-  const limit = 4;
+    var count = 0;
+    const limit = 4;
 
-  let query = couchbase.analyticsQuery('SELECT * FROM default LIMIT $limit;', {"limit": limit});
-  for (let row of query) {
-  ++count;
-  }
+    let query = couchbase.analyticsQuery('SELECT * FROM default LIMIT $limit;', {"limit": limit});
+    for (let row of query) {
+    ++count;
+    }
 
-  if (count === limit) {
-  dst_bucket[meta.id] = 'yes';
-  }
+    if (count === limit) {
+    dst_bucket[meta.id] = 'yes';
+    }
 }
 ----
 

--- a/modules/eventing/pages/eventing-language-constructs.adoc
+++ b/modules/eventing/pages/eventing-language-constructs.adoc
@@ -376,7 +376,7 @@ The `close()` method on the iterable handle can throw an exception if the underl
 |===
 
 [#analytics_call]
-=== `couchbase.analyticsQuery()`
+=== `couchbase.{zwsp}analyticsQuery({wj})`
 
 ifeval::['{page-component-version}' == '7.6'] 
 [.status]#Introduced in Couchbase Server 7.6#

--- a/modules/eventing/pages/eventing-language-constructs.adoc
+++ b/modules/eventing/pages/eventing-language-constructs.adoc
@@ -15,10 +15,10 @@ Certain capabilities have been removed and are not supported in order to handle 
 
 Eventing Functions support the following features:
 
-* <<basic_bucket_accessors,Basic Keyspace Accessors>>
-* <<advanced_bucket_accessors,Advanced Keyspace Accessors>>
-* <<logging,Logging>>
-* <<n1ql_statements,{sqlpp} Statements>>
+* <<basic_bucket_accessors>>
+* <<advanced_bucket_accessors>>
+* <<logging>>
+* <<n1ql_statements>>
 
 [#basic_bucket_accessors]
 === Basic Keyspace Accessors
@@ -77,7 +77,7 @@ function OnUpdate(doc, meta) {
 Advanced Keyspace Accessors expose a larger set of options and operators than <<basic_bucket_accessors,Basic Keyspace Accessors>>.
 They have non-trivial argument sets and return values.
 
-See xref:eventing-advanced-keyspace-accessors.adoc[Advanced Keyspace Accessors] for more details.
+See xref:eventing-advanced-keyspace-accessors.adoc[] for more details.
 
 [#logging]
 === Logging
@@ -196,10 +196,10 @@ To include comments in multiline statements, use `/* this format */` instead.
 
 The following features are not supported by Eventing Functions:
 
-* <<global-state,Global State>>
-* <<asynchrony,Asynchrony>>
-* <<browser_extensions,Browser and Other Extensions>>
-* <<library_imports,Library Imports>>
+* <<global-state>>
+* <<asynchrony>>
+* <<browser_extensions>>
+* <<library_imports>>
 
 [#global-state]
 === Global State
@@ -264,13 +264,13 @@ The Eventing Service does not support importing libraries into Eventing Function
 
 Eventing Functions support the following built-in functions:
 
-* <<n1ql_call,`N1QL()`>>
-* <<analytics_call,`ANALYTICS()`>>
-* <<crc64_call,`crc64()`>>
-* <<crc_64_go_iso_call, `crc_64_go_iso()`>>
-* <<base64_call,`base64()`>>
-* <<timers_general,`createTimer()` and `cancelTimer()`>>
-* <<curl_call,`curl()`>>
+* <<n1ql_call>>
+* <<analytics_call>>
+* <<crc64_call>>
+* <<crc_64_go_iso_call>>
+* <<base64_call>>
+* <<timers_general>>
+* <<curl_call>>
 
 [#n1ql_call]
 === `N1QL()`
@@ -379,7 +379,6 @@ The `close()` method on the iterable handle can throw an exception if the underl
 === `couchbase.analyticsQuery()`
 
 ifeval::['{page-component-version}' == '7.6'] 
-
 [.status]#Introduced in Couchbase Server 7.6#
 endif::[]
 
@@ -408,7 +407,7 @@ function OnUpdate(doc, meta) {
 }
 ----
 
-For more information about {sqlpp} Analytics, see xref:server:analytics:1_intro.adoc[What’s SQL++ for Analytics?].
+For more information about {sqlpp} Analytics, see xref:server:analytics:1_intro.adoc[].
 
 [#crc64_call]
 === `crc64()`
@@ -542,14 +541,14 @@ To cancel a Timer, you can do one of the following:
 * Call the `createTimer()` function again using a reference from the existing Timer you want to cancel.
 * Call the `cancelTimer()` function using `cancelTimer(callback, reference)`.
 
-For more information about Timers, see xref:eventing-timers.adoc[Timers].
+For more information about Timers, see xref:eventing-timers.adoc[].
 
 [#curl_call]
 === `curl()`
 
 The `curl()` function lets you interact with external entities through a REST endpoint from Eventing Functions, using either HTTP or HTTPS.
 
-For more information about the `curl()` function, see xref:eventing-curl-spec.adoc[cURL].
+For more information about the `curl()` function, see xref:eventing-curl-spec.adoc[].
 
 
 [#handler-signatures]
@@ -557,9 +556,9 @@ For more information about the `curl()` function, see xref:eventing-curl-spec.ad
 
 The Eventing Service calls the following JavaScript functions on events like mutations and fired Timers:
 
-* <<onupdate_handler,OnUpdate Handler>>
-* <<ondelete_handler,OnDelete Handler>>
-* <<timer_callback_handler,Timer Callback Handler>>
+* <<onupdate_handler>>
+* <<ondelete_handler>>
+* <<timer_callback_handler>>
 
 [#onupdate_handler]
 === OnUpdate Handler
@@ -648,7 +647,7 @@ function OnUpdate(doc, meta) {
 }
 ----
 
-For more information about Timers, see xref:eventing-timers.adoc[Timers].
+For more information about Timers, see xref:eventing-timers.adoc[].
 
 
 == Reserved Words

--- a/modules/eventing/pages/eventing-language-constructs.adoc
+++ b/modules/eventing/pages/eventing-language-constructs.adoc
@@ -398,13 +398,15 @@ function OnUpdate(doc, meta) {
     var count = 0;
     const limit = 4;
 
-    let query = couchbase.analyticsQuery('SELECT * FROM default LIMIT $limit;', {"limit": limit});
+    let query = couchbase.analyticsQuery('SELECT * FROM default LIMIT $limit;', {
+        "limit": limit
+    });
     for (let row of query) {
-    ++count;
+        ++count;
     }
 
     if (count === limit) {
-    dst_bucket[meta.id] = 'yes';
+        dst_bucket[meta.id] = 'yes';
     }
 }
 ----


### PR DESCRIPTION
Docs issue: DOC-12533

Corrects the name of the eventing `couchbase.analyticsQuery()` function. Some minor tweaks.

Docs preview: [Language Constructs › Built-in Functions › couchbase.​analyticsQuery(⁠)](https://preview.docs-test.couchbase.com/DOC-12533/server/current/eventing/eventing-language-constructs.html#analytics_call)
Password: [Preview docs for internal review](https://couchbasecloud.atlassian.net/wiki/x/dYF_dQ#Preview-docs-for-internal-review)