### PR TITLE
DOC-12533: Feedback on Language Constructs

### DIFF
--- a/modules/eventing/pages/eventing-language-constructs.adoc
+++ b/modules/eventing/pages/eventing-language-constructs.adoc
@@ -379,7 +379,7 @@ The `close()` method on the iterable handle can throw an exception if the underl
 === `couchbase.{zwsp}analyticsQuery({wj})`
 
 ifeval::['{page-component-version}' == '7.6'] 
-[.status]#Introduced in Couchbase Server 7.6#
+_(Introduced in Couchbase Server 7.6)_
 endif::[]
 
 The `couchbase.analyticsQuery()` function provides integration with {sqlpp} Analytics directly from the Eventing Service.
@@ -472,7 +472,7 @@ This does not apply to any other data type (e.g., numeric data or JSON data type
 === `crc_64_go_iso()`
 
 ifeval::['{page-component-version}' == '7.6'] 
-[.status]#Introduced in Couchbase Server 7.6#
+_(Introduced in Couchbase Server 7.6)_
 endif::[]
 
 `crc_64_go_iso()` performs the same function as <<crc64_call,`crc64()`>>, but does not include the enclosing quotation marks from the parameter in the translation if its parameter type is `string`. 
@@ -493,7 +493,7 @@ function OnUpdate(doc, meta) {
 === `base64()`
 
 ifeval::['{page-component-version}' == '7.6'] 
-[.status]#Introduced in Couchbase Server 7.6#
+_(Introduced in Couchbase Server 7.6)_
 endif::[]
 
 The `base64()` functions let you pack large-dimensional arrays of floats as base64 encoded strings when you use the Eventing Service to generate vector embeddings.


### PR DESCRIPTION
Reverts changes to "Introduced in Couchbase Server 7.6" messages. Currently the status label is used within a page for features which are unique to a particular patch version, not for new features. I think however that this distinction is confusing, and perhaps we should look at it again.