### PR TITLE
[DOC-12432] Document Usage of {"ctl": { "validate" : true }, } for Search Queries

### DIFF
--- a/modules/search/examples/query-sample-results-unindexed.jsonc
+++ b/modules/search/examples/query-sample-results-unindexed.jsonc
@@ -1,0 +1,42 @@
+{
+    "status": {
+        "total": 1,
+        "failed": 0,
+        "successful": 1
+    },
+    "request": {
+        "query": {
+            "location": [
+                -2.235143,
+                53.482358
+            ],
+            "distance": "100mi",
+            "field": "geo"
+        },
+        "size": 10,
+        "from": 0,
+        "highlight": {
+            "style": null,
+            "fields": null
+        },
+        "fields": [
+            "content"
+        ],
+        "facets": null,
+        "explain": true,
+        "sort": [
+            "-_score"
+        ],
+        "includeLocations": false,
+        "search_after": null,
+        "search_before": null,
+        "knn": null,
+        "knn_operator": ""
+    },
+    "hits": [],
+    "total_hits": 0,
+    "cost": 0,
+    "max_score": 0,
+    "took": 4150150,
+    "facets": null
+}

--- a/modules/search/examples/query-sample-results-validate.jsonc
+++ b/modules/search/examples/query-sample-results-validate.jsonc
@@ -1,0 +1,24 @@
+{
+    "error": "rest_index: Query, indexName: travel-sample.inventory.landmark-content-index, err: bleve: QueryBleve query validation failed against index, err: query_validate: field not indexed, name: geo, type: geopoint",
+    "request": {
+        "ctl": {
+            "validate": true
+        },
+        "explain": true,
+        "fields": [
+            "content"
+        ],
+        "from": 0,
+        "highlight": {},
+        "query": {
+            "distance": "100mi",
+            "field": "geo",
+            "location": {
+                "lat": 53.482358,
+                "lon": -2.235143
+            }
+        },
+        "size": 10
+    },
+    "status": "fail"
+}

--- a/modules/search/examples/query-sample-results.jsonc
+++ b/modules/search/examples/query-sample-results.jsonc
@@ -1,0 +1,740 @@
+{
+    // tag::query_summary[]
+    "status": {
+        "total": 1,
+        "failed": 0,
+        "successful": 1
+    },
+    "request": {
+        "query": {
+            "query": "+view +food +beach"
+        },
+        "size": 10,
+        "from": 0,
+        "highlight": {
+            "style": null,
+            "fields": null
+        },
+        "fields": [
+            "*"
+        ],
+        "facets": null,
+        "explain": true,
+        "sort": [
+            "-_score"
+        ],
+        "includeLocations": false,
+        "search_after": null,
+        "search_before": null,
+        "knn": null,
+        "knn_operator": ""
+    },
+    // end::query_summary[]
+    "hits": [
+    // tag::first_hit[]
+        {
+            "index": "travel-sample.inventory.landmark-content-index_6369e656b9eec849_4c1c5584",
+            "id": "landmark_4428",
+            "score": 2.425509689250102,
+            "explanation": {
+                "value": 2.425509689250102,
+                "message": "sum of:",
+                "children": [
+                    {
+                        "value": 2.425509689250102,
+                        "message": "sum of:",
+                        "children": [
+                            {
+                                "value": 1.0124422206433388,
+                                "message": "product of:",
+                                "children": [
+                                    {
+                                        "value": 1.0124422206433388,
+                                        "message": "sum of:",
+                                        "children": [
+                                            {
+                                                "value": 1.0124422206433388,
+                                                "message": "weight(_all:view^1.000000 in \u0000\u0000\u0000\u0000\u0000\u0000\nN), product of:",
+                                                "children": [
+                                                    {
+                                                        "value": 0.6460760126054528,
+                                                        "message": "queryWeight(_all:view^1.000000), product of:",
+                                                        "children": [
+                                                            {
+                                                                "value": 1,
+                                                                "message": "boost"
+                                                            },
+                                                            {
+                                                                "value": 4.701190745593387,
+                                                                "message": "idf(docFreq=110, maxDocs=4495)"
+                                                            },
+                                                            {
+                                                                "value": 0.1374281639627249,
+                                                                "message": "queryNorm"
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "value": 1.5670636285665962,
+                                                        "message": "fieldWeight(_all:view in \u0000\u0000\u0000\u0000\u0000\u0000\nN), product of:",
+                                                        "children": [
+                                                            {
+                                                                "value": 1,
+                                                                "message": "tf(termFreq(_all:view)=1"
+                                                            },
+                                                            {
+                                                                "value": 0.3333333432674408,
+                                                                "message": "fieldNorm(field=_all, doc=\u0000\u0000\u0000\u0000\u0000\u0000\nN)"
+                                                            },
+                                                            {
+                                                                "value": 4.701190745593387,
+                                                                "message": "idf(docFreq=110, maxDocs=4495)"
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "value": 1,
+                                        "message": "coord(1/1)"
+                                    }
+                                ]
+                            },
+                            {
+                                "value": 0.9006237048061059,
+                                "message": "product of:",
+                                "children": [
+                                    {
+                                        "value": 0.9006237048061059,
+                                        "message": "sum of:",
+                                        "children": [
+                                            {
+                                                "value": 0.9006237048061059,
+                                                "message": "weight(_all:beach^1.000000 in \u0000\u0000\u0000\u0000\u0000\u0000\nN), product of:",
+                                                "children": [
+                                                    {
+                                                        "value": 0.6093547205466089,
+                                                        "message": "queryWeight(_all:beach^1.000000), product of:",
+                                                        "children": [
+                                                            {
+                                                                "value": 1,
+                                                                "message": "boost"
+                                                            },
+                                                            {
+                                                                "value": 4.433987204485146,
+                                                                "message": "idf(docFreq=144, maxDocs=4495)"
+                                                            },
+                                                            {
+                                                                "value": 0.1374281639627249,
+                                                                "message": "queryNorm"
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "value": 1.4779957788760876,
+                                                        "message": "fieldWeight(_all:beach in \u0000\u0000\u0000\u0000\u0000\u0000\nN), product of:",
+                                                        "children": [
+                                                            {
+                                                                "value": 1,
+                                                                "message": "tf(termFreq(_all:beach)=1"
+                                                            },
+                                                            {
+                                                                "value": 0.3333333432674408,
+                                                                "message": "fieldNorm(field=_all, doc=\u0000\u0000\u0000\u0000\u0000\u0000\nN)"
+                                                            },
+                                                            {
+                                                                "value": 4.433987204485146,
+                                                                "message": "idf(docFreq=144, maxDocs=4495)"
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "value": 1,
+                                        "message": "coord(1/1)"
+                                    }
+                                ]
+                            },
+                            {
+                                "value": 0.5124437638006571,
+                                "message": "product of:",
+                                "children": [
+                                    {
+                                        "value": 0.5124437638006571,
+                                        "message": "sum of:",
+                                        "children": [
+                                            {
+                                                "value": 0.5124437638006571,
+                                                "message": "weight(_all:food^1.000000 in \u0000\u0000\u0000\u0000\u0000\u0000\nN), product of:",
+                                                "children": [
+                                                    {
+                                                        "value": 0.4596440040764192,
+                                                        "message": "queryWeight(_all:food^1.000000), product of:",
+                                                        "children": [
+                                                            {
+                                                                "value": 1,
+                                                                "message": "boost"
+                                                            },
+                                                            {
+                                                                "value": 3.3446128568019726,
+                                                                "message": "idf(docFreq=430, maxDocs=4495)"
+                                                            },
+                                                            {
+                                                                "value": 0.1374281639627249,
+                                                                "message": "queryNorm"
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "value": 1.1148709854930678,
+                                                        "message": "fieldWeight(_all:food in \u0000\u0000\u0000\u0000\u0000\u0000\nN), product of:",
+                                                        "children": [
+                                                            {
+                                                                "value": 1,
+                                                                "message": "tf(termFreq(_all:food)=1"
+                                                            },
+                                                            {
+                                                                "value": 0.3333333432674408,
+                                                                "message": "fieldNorm(field=_all, doc=\u0000\u0000\u0000\u0000\u0000\u0000\nN)"
+                                                            },
+                                                            {
+                                                                "value": 3.3446128568019726,
+                                                                "message": "idf(docFreq=430, maxDocs=4495)"
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "value": 1,
+                                        "message": "coord(1/1)"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            // tag::locations[]
+            "locations": {
+                "content": {
+                    "beach": [
+                        {
+                            "pos": 11,
+                            "start": 61,
+                            "end": 66,
+                            "array_positions": null
+                        }
+                    ],
+                    "food": [
+                        {
+                            "pos": 3,
+                            "start": 13,
+                            "end": 17,
+                            "array_positions": null
+                        }
+                    ],
+                    "view": [
+                        {
+                            "pos": 8,
+                            "start": 46,
+                            "end": 50,
+                            "array_positions": null
+                        }
+                    ]
+                }
+            },
+            // end::locations[]
+            // tag::highlight[]
+            "fragments": {
+                "content": [
+                    "serves fresh <mark>food</mark> at very reasonable prices - <mark>view</mark> of stoney <mark>beach</mark> with herons"
+                ]
+            },
+            // end::highlight[]
+            "sort": [
+                "_score"
+            ],
+            // tag::field_content[]
+            "fields": {
+                "content": "serves fresh food at very reasonable prices - view of stoney beach with herons"
+            }
+            // end::field_content[]
+        },
+        // end::first_hit[]
+        {
+            "index": "travel-sample.inventory.landmark-content-index_6369e656b9eec849_4c1c5584",
+            "id": "landmark_26385",
+            "score": 1.6270812956011347,
+            "explanation": {
+                "value": 1.6270812956011347,
+                "message": "sum of:",
+                "children": [
+                    {
+                        "value": 1.6270812956011347,
+                        "message": "sum of:",
+                        "children": [
+                            {
+                                "value": 0.6791668602218446,
+                                "message": "product of:",
+                                "children": [
+                                    {
+                                        "value": 0.6791668602218446,
+                                        "message": "sum of:",
+                                        "children": [
+                                            {
+                                                "value": 0.6791668602218446,
+                                                "message": "weight(_all:view^1.000000 in \u0000\u0000\u0000\u0000\u0000\u0000\u0006~), product of:",
+                                                "children": [
+                                                    {
+                                                        "value": 0.6460760126054528,
+                                                        "message": "queryWeight(_all:view^1.000000), product of:",
+                                                        "children": [
+                                                            {
+                                                                "value": 1,
+                                                                "message": "boost"
+                                                            },
+                                                            {
+                                                                "value": 4.701190745593387,
+                                                                "message": "idf(docFreq=110, maxDocs=4495)"
+                                                            },
+                                                            {
+                                                                "value": 0.1374281639627249,
+                                                                "message": "queryNorm"
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "value": 1.051218195646895,
+                                                        "message": "fieldWeight(_all:view in \u0000\u0000\u0000\u0000\u0000\u0000\u0006~), product of:",
+                                                        "children": [
+                                                            {
+                                                                "value": 1,
+                                                                "message": "tf(termFreq(_all:view)=1"
+                                                            },
+                                                            {
+                                                                "value": 0.22360679507255554,
+                                                                "message": "fieldNorm(field=_all, doc=\u0000\u0000\u0000\u0000\u0000\u0000\u0006~)"
+                                                            },
+                                                            {
+                                                                "value": 4.701190745593387,
+                                                                "message": "idf(docFreq=110, maxDocs=4495)"
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "value": 1,
+                                        "message": "coord(1/1)"
+                                    }
+                                ]
+                            },
+                            {
+                                "value": 0.6041567225889205,
+                                "message": "product of:",
+                                "children": [
+                                    {
+                                        "value": 0.6041567225889205,
+                                        "message": "sum of:",
+                                        "children": [
+                                            {
+                                                "value": 0.6041567225889205,
+                                                "message": "weight(_all:beach^1.000000 in \u0000\u0000\u0000\u0000\u0000\u0000\u0006~), product of:",
+                                                "children": [
+                                                    {
+                                                        "value": 0.6093547205466089,
+                                                        "message": "queryWeight(_all:beach^1.000000), product of:",
+                                                        "children": [
+                                                            {
+                                                                "value": 1,
+                                                                "message": "boost"
+                                                            },
+                                                            {
+                                                                "value": 4.433987204485146,
+                                                                "message": "idf(docFreq=144, maxDocs=4495)"
+                                                            },
+                                                            {
+                                                                "value": 0.1374281639627249,
+                                                                "message": "queryNorm"
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "value": 0.9914696681876435,
+                                                        "message": "fieldWeight(_all:beach in \u0000\u0000\u0000\u0000\u0000\u0000\u0006~), product of:",
+                                                        "children": [
+                                                            {
+                                                                "value": 1,
+                                                                "message": "tf(termFreq(_all:beach)=1"
+                                                            },
+                                                            {
+                                                                "value": 0.22360679507255554,
+                                                                "message": "fieldNorm(field=_all, doc=\u0000\u0000\u0000\u0000\u0000\u0000\u0006~)"
+                                                            },
+                                                            {
+                                                                "value": 4.433987204485146,
+                                                                "message": "idf(docFreq=144, maxDocs=4495)"
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "value": 1,
+                                        "message": "coord(1/1)"
+                                    }
+                                ]
+                            },
+                            {
+                                "value": 0.3437577127903696,
+                                "message": "product of:",
+                                "children": [
+                                    {
+                                        "value": 0.3437577127903696,
+                                        "message": "sum of:",
+                                        "children": [
+                                            {
+                                                "value": 0.3437577127903696,
+                                                "message": "weight(_all:food^1.000000 in \u0000\u0000\u0000\u0000\u0000\u0000\u0006~), product of:",
+                                                "children": [
+                                                    {
+                                                        "value": 0.4596440040764192,
+                                                        "message": "queryWeight(_all:food^1.000000), product of:",
+                                                        "children": [
+                                                            {
+                                                                "value": 1,
+                                                                "message": "boost"
+                                                            },
+                                                            {
+                                                                "value": 3.3446128568019726,
+                                                                "message": "idf(docFreq=430, maxDocs=4495)"
+                                                            },
+                                                            {
+                                                                "value": 0.1374281639627249,
+                                                                "message": "queryNorm"
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "value": 0.7478781616679533,
+                                                        "message": "fieldWeight(_all:food in \u0000\u0000\u0000\u0000\u0000\u0000\u0006~), product of:",
+                                                        "children": [
+                                                            {
+                                                                "value": 1,
+                                                                "message": "tf(termFreq(_all:food)=1"
+                                                            },
+                                                            {
+                                                                "value": 0.22360679507255554,
+                                                                "message": "fieldNorm(field=_all, doc=\u0000\u0000\u0000\u0000\u0000\u0000\u0006~)"
+                                                            },
+                                                            {
+                                                                "value": 3.3446128568019726,
+                                                                "message": "idf(docFreq=430, maxDocs=4495)"
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "value": 1,
+                                        "message": "coord(1/1)"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            "locations": {
+                "content": {
+                    "beach": [
+                        {
+                            "pos": 25,
+                            "start": 127,
+                            "end": 132,
+                            "array_positions": null
+                        }
+                    ],
+                    "food": [
+                        {
+                            "pos": 17,
+                            "start": 90,
+                            "end": 94,
+                            "array_positions": null
+                        }
+                    ],
+                    "view": [
+                        {
+                            "pos": 34,
+                            "start": 169,
+                            "end": 173,
+                            "array_positions": null
+                        }
+                    ]
+                }
+            },
+            "fragments": {
+                "content": [
+                    "Burgers, seafood, and other simple but tasty meals right at the harbor. You can take your <mark>food</mark> around the corner to sit on the <mark>beach</mark> or the sea wall and enjoy the ocean <mark>view</mark> while you eat."
+                ]
+            },
+            "sort": [
+                "_score"
+            ],
+            "fields": {
+                "content": "Burgers, seafood, and other simple but tasty meals right at the harbor. You can take your food around the corner to sit on the beach or the sea wall and enjoy the ocean view while you eat."
+            }
+        },
+        {
+            "index": "travel-sample.inventory.landmark-content-index_6369e656b9eec849_4c1c5584",
+            "id": "landmark_38035",
+            "score": 1.1962539437368078,
+            "explanation": {
+                "value": 1.1962539437368078,
+                "message": "sum of:",
+                "children": [
+                    {
+                        "value": 1.1962539437368078,
+                        "message": "sum of:",
+                        "children": [
+                            {
+                                "value": 0.4993333997460529,
+                                "message": "product of:",
+                                "children": [
+                                    {
+                                        "value": 0.4993333997460529,
+                                        "message": "sum of:",
+                                        "children": [
+                                            {
+                                                "value": 0.4993333997460529,
+                                                "message": "weight(_all:view^1.000000 in \u0000\u0000\u0000\u0000\u0000\u0000\u0006\ufffd), product of:",
+                                                "children": [
+                                                    {
+                                                        "value": 0.6460760126054528,
+                                                        "message": "queryWeight(_all:view^1.000000), product of:",
+                                                        "children": [
+                                                            {
+                                                                "value": 1,
+                                                                "message": "boost"
+                                                            },
+                                                            {
+                                                                "value": 4.701190745593387,
+                                                                "message": "idf(docFreq=110, maxDocs=4495)"
+                                                            },
+                                                            {
+                                                                "value": 0.1374281639627249,
+                                                                "message": "queryNorm"
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "value": 0.7728709780330244,
+                                                        "message": "fieldWeight(_all:view in \u0000\u0000\u0000\u0000\u0000\u0000\u0006\ufffd), product of:",
+                                                        "children": [
+                                                            {
+                                                                "value": 1,
+                                                                "message": "tf(termFreq(_all:view)=1"
+                                                            },
+                                                            {
+                                                                "value": 0.16439898312091827,
+                                                                "message": "fieldNorm(field=_all, doc=\u0000\u0000\u0000\u0000\u0000\u0000\u0006\ufffd)"
+                                                            },
+                                                            {
+                                                                "value": 4.701190745593387,
+                                                                "message": "idf(docFreq=110, maxDocs=4495)"
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "value": 1,
+                                        "message": "coord(1/1)"
+                                    }
+                                ]
+                            },
+                            {
+                                "value": 0.4441848504964135,
+                                "message": "product of:",
+                                "children": [
+                                    {
+                                        "value": 0.4441848504964135,
+                                        "message": "sum of:",
+                                        "children": [
+                                            {
+                                                "value": 0.4441848504964135,
+                                                "message": "weight(_all:beach^1.000000 in \u0000\u0000\u0000\u0000\u0000\u0000\u0006\ufffd), product of:",
+                                                "children": [
+                                                    {
+                                                        "value": 0.6093547205466089,
+                                                        "message": "queryWeight(_all:beach^1.000000), product of:",
+                                                        "children": [
+                                                            {
+                                                                "value": 1,
+                                                                "message": "boost"
+                                                            },
+                                                            {
+                                                                "value": 4.433987204485146,
+                                                                "message": "idf(docFreq=144, maxDocs=4495)"
+                                                            },
+                                                            {
+                                                                "value": 0.1374281639627249,
+                                                                "message": "queryNorm"
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "value": 0.7289429875885212,
+                                                        "message": "fieldWeight(_all:beach in \u0000\u0000\u0000\u0000\u0000\u0000\u0006\ufffd), product of:",
+                                                        "children": [
+                                                            {
+                                                                "value": 1,
+                                                                "message": "tf(termFreq(_all:beach)=1"
+                                                            },
+                                                            {
+                                                                "value": 0.16439898312091827,
+                                                                "message": "fieldNorm(field=_all, doc=\u0000\u0000\u0000\u0000\u0000\u0000\u0006\ufffd)"
+                                                            },
+                                                            {
+                                                                "value": 4.433987204485146,
+                                                                "message": "idf(docFreq=144, maxDocs=4495)"
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "value": 1,
+                                        "message": "coord(1/1)"
+                                    }
+                                ]
+                            },
+                            {
+                                "value": 0.25273569349434155,
+                                "message": "product of:",
+                                "children": [
+                                    {
+                                        "value": 0.25273569349434155,
+                                        "message": "sum of:",
+                                        "children": [
+                                            {
+                                                "value": 0.25273569349434155,
+                                                "message": "weight(_all:food^1.000000 in \u0000\u0000\u0000\u0000\u0000\u0000\u0006\ufffd), product of:",
+                                                "children": [
+                                                    {
+                                                        "value": 0.4596440040764192,
+                                                        "message": "queryWeight(_all:food^1.000000), product of:",
+                                                        "children": [
+                                                            {
+                                                                "value": 1,
+                                                                "message": "boost"
+                                                            },
+                                                            {
+                                                                "value": 3.3446128568019726,
+                                                                "message": "idf(docFreq=430, maxDocs=4495)"
+                                                            },
+                                                            {
+                                                                "value": 0.1374281639627249,
+                                                                "message": "queryNorm"
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "value": 0.5498509525913937,
+                                                        "message": "fieldWeight(_all:food in \u0000\u0000\u0000\u0000\u0000\u0000\u0006\ufffd), product of:",
+                                                        "children": [
+                                                            {
+                                                                "value": 1,
+                                                                "message": "tf(termFreq(_all:food)=1"
+                                                            },
+                                                            {
+                                                                "value": 0.16439898312091827,
+                                                                "message": "fieldNorm(field=_all, doc=\u0000\u0000\u0000\u0000\u0000\u0000\u0006\ufffd)"
+                                                            },
+                                                            {
+                                                                "value": 3.3446128568019726,
+                                                                "message": "idf(docFreq=430, maxDocs=4495)"
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "value": 1,
+                                        "message": "coord(1/1)"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            "locations": {
+                "content": {
+                    "beach": [
+                        {
+                            "pos": 17,
+                            "start": 86,
+                            "end": 91,
+                            "array_positions": null
+                        }
+                    ],
+                    "food": [
+                        {
+                            "pos": 50,
+                            "start": 280,
+                            "end": 284,
+                            "array_positions": null
+                        }
+                    ],
+                    "view": [
+                        {
+                            "pos": 30,
+                            "start": 169,
+                            "end": 173,
+                            "array_positions": null
+                        }
+                    ]
+                }
+            },
+            "fragments": {
+                "content": [
+                    "… <mark>Beach</mark> distillery offers a full menu, Sunday brunch, drinks, and a tremendous ocean <mark>view</mark> with comfortable fire pits. Happy hour Mon-Fri from 5PM to 7PM offers half-priced drinks and a discounted <mark>food</mark> …"
+                ]
+            },
+            "sort": [
+                "_score"
+            ],
+            "fields": {
+                "content": "Famous for &quot;the Blue Lady&quot;, a ghost rumored to haunt the premises, the Moss Beach distillery offers a full menu, Sunday brunch, drinks, and a tremendous ocean view with comfortable fire pits. Happy hour Mon-Fri from 5PM to 7PM offers half-priced drinks and a discounted food menu."
+            }
+        }
+    ],
+    // tag::end_summary[]
+    "total_hits": 3,
+    "cost": 123616,
+    "max_score": 2.425509689250102,
+    "took": 636964,
+    "facets": null
+    // end::end_summary[]
+}

--- a/modules/search/examples/run-search-full-request.jsonc
+++ b/modules/search/examples/run-search-full-request.jsonc
@@ -9,7 +9,7 @@
                     "bool": false
                 },
                 {
-                    "field": "ratings.Cleanliness",
+                    "field": "reviews.ratings.Cleanliness",
                     "min": 1,
                     "max": 3,
                     "inclusive_min": true,
@@ -71,8 +71,9 @@
             // end::vectors[]
             "level": "at_plus",
             "results": "complete"
-        }
+        },
         // end::consistency[]
+        "validate": true
     },
     // end::ctl[]
     "size": 10,
@@ -147,9 +148,9 @@
                 "by": "field",
                 "field": "field2",
                 "desc": false,
-                "mode": "max",
+                "mode": "default",
                 "missing": "last",
-                "type": "number"
+                "type": "string"
             },
             "-_score",
             "-_id"
@@ -158,8 +159,8 @@
     // end::sort[]
     "includeLocations": false,
     "score": "none",
-    "search_after": ["field1Value", "5", "10.033205341869529", "1234"],
-    "search_before": ["field1Value", "5", "10.033205341869529", "1234"],
+    "search_after": ["field1String", "field2String", "10.033205341869529", "hotel_1234"],
+    "search_before": ["field1String", "field2String", "10.033205341869529", "hotel_1234"],
     "limit": 10,
     "offset": 0,
     "collections": ["collection1", "collection2"]

--- a/modules/search/examples/run-search-unindexed-field.sh
+++ b/modules/search/examples/run-search-unindexed-field.sh
@@ -1,0 +1,19 @@
+curl -XPOST -H "Content-Type: application/json" \
+  -u ${CB_USERNAME}:${CB_PASSWORD} http://${CB_HOSTNAME}:8094/api/bucket/travel-sample/scope/inventory/index/landmark-content-index/query \
+  -d '{
+    "explain": true,
+    "fields": [
+      "content"
+    ],
+    "highlight": {},
+    "query": {
+        "location": {
+            "lon": -2.235143,
+            "lat": 53.482358
+        },
+            "distance": "100mi",
+            "field": "geo"
+    },
+    "size": 10,
+    "from": 0
+  }'

--- a/modules/search/examples/run-search-validate-ui.jsonc
+++ b/modules/search/examples/run-search-validate-ui.jsonc
@@ -1,0 +1,20 @@
+{
+    "explain": true,
+    "fields": [
+      "content"
+    ],
+    "highlight": {},
+    "query": {
+        "location": {
+            "lon": -2.235143,
+            "lat": 53.482358
+        },
+            "distance": "100mi",
+            "field": "geo"
+    },
+    "ctl": {
+        "validate": true
+    },
+    "size": 10,
+    "from": 0
+}

--- a/modules/search/examples/run-search-validate.sh
+++ b/modules/search/examples/run-search-validate.sh
@@ -1,0 +1,22 @@
+curl -XPOST -H "Content-Type: application/json" \
+  -u ${CB_USERNAME}:${CB_PASSWORD} http://${CB_HOSTNAME}:8094/api/bucket/travel-sample/scope/inventory/index/landmark-content-index/query \
+  -d '{
+    "explain": true,
+    "fields": [
+      "content"
+    ],
+    "highlight": {},
+    "query": {
+        "location": {
+            "lon": -2.235143,
+            "lat": 53.482358
+        },
+            "distance": "100mi",
+            "field": "geo"
+    },
+    "ctl": {
+        "validate": true
+    },
+    "size": 10,
+    "from": 0
+  }'

--- a/modules/search/pages/search-request-params.adoc
+++ b/modules/search/pages/search-request-params.adoc
@@ -49,6 +49,14 @@ Set the total number of results to return for a single page of search results.
 
 If you provide both the `size` and `limit` properties, the Search Service uses the `size` value.
 
+The Search Service returns the `size` number of results: 
+
+* Starting at the offset in the `from` or `offset` property.
+* Starting from the key specified in the <<search_after,search_after property>>.
+* Starting backward from the key specified in the <<search_before,search_before property>>.
+
+The `size` property is added by default to all Search requests, if not otherwise specified, with a value of `10`.
+
 |from/offset |Integer |No a|
 
 Set an offset value to change where pagination starts for search results, based on the Search query's <<sort,>>. 
@@ -56,6 +64,8 @@ Set an offset value to change where pagination starts for search results, based 
 For example, if you set a `size` value of `5` and a `from` value of `10`, the Search query returns results 11 through 15 on a page. 
 
 If you provide both the `from` and `offset` properties, the Search Service uses the `from` value.
+
+The `from` property is added by default to all Search requests, if not otherwise specified, with a value of `0`.
 
 |highlight |Object |No a|
 
@@ -87,7 +97,7 @@ To create an explanation for a search result's score in search results, set `exp
 
 To turn off explanations for search result scoring, set `explain` to `false`.
 
-|sort |Array |No a|
+|[[sort_arr]]sort |Array |No a|
 
 Contains an array of strings or JSON objects to set how to sort search results. 
 
@@ -114,31 +124,45 @@ To turn off document relevancy scoring in search results, set `score` to `none`.
 
 To turn on document relevancy scoring in search results, remove the `score` property.
 
-|search_after |Array |No a|
+|[[search_after]]search_after |Array |No a|
 
-NOTE: If you use `search_after` in a search request, you can't use `search_before`. Both properties are included in the example code to show the correct syntax.
+NOTE: If you use `search_after` in a search request, you can't use `search_before`.
+Both properties are included in the example code to show the correct syntax.
 
 Use `search_after` with `from/offset` and `sort` to control pagination in search results. 
 
-Give a value for each string or JSON object in the `sort` array to the `search_after` array.
-The Search Service starts search result pagination after the document with those values. 
+Give a value for each string or JSON object in the <<sort_arr,sort array>> to the `search_after` array.
+You must provide the values in the same order that they appear in the <<sort_arr,sort array>>.
+Values in the `search_after` array must be strings.
+You cannot use `search_after` with numbers or other field data types - if your `sort` array includes fields with a `date` or `number` type, you cannot use `search_after`. 
+Only result relevancy score values can be entered as strings in the array. 
 
-You must provide the values in the same order that they appear in the `sort` array. 
+The Search Service starts search result pagination after the document with the values you provide in the array.
 
 For example, if you had a set of 10 documents to sort based on `_id` values of 1-10, with `from` set to `2` and `search_after` set to `8`, documents 9-10 appear on the same page. 
 
-|search_before |Array |No a|
+To reduce the resource costs of deeper pagination on your Search queries, try to always include your document ID values as the final sort criteria in your <<sort_arr,sort array>>. 
+Set the `search_after` property to include the values from the last result on your previous page of search results to effectively paginate. 
 
-NOTE: If you use `search_before` in a search request, you can't use `search_after`. Both properties are included in the example code to show the correct syntax.
+|[[search_before]]search_before |Array |No a|
+
+NOTE: If you use `search_before` in a search request, you can't use `search_after`.
+Both properties are included in the example code to show the correct syntax.
 
 Use `search_before` with `from/offset` and `sort` to control pagination in search results.
 
 Give a value for each string or JSON object in the `sort` array to the `search_before` array.
-The Search Service starts search result pagination before the document with those values. 
+You must provide the values in the same order that they appear in the `sort` array.
+Values in the `search_before` array must be strings.
+You cannot use `search_before` with numbers or other field data types - if your `sort` array includes fields with a `date` or `number` type, you cannot use `search_before`. 
+Only result relevancy score values can be entered as strings in the array.
 
-You must provide the values in the same order that they appear in the `sort` array. 
+The Search Service starts search result pagination before the document with the values you provide in the array.   
 
-For example, if you had a set of 10 documents to sort based on `_id` values of 1-10, with `from` set to `2` and `search_before` set to `8`, documents 2-6 appear on the same page. 
+For example, if you had a set of 10 documents to sort based on `_id` values of 1-10, with `from` set to `2` and `search_before` set to `8`, documents 2-6 appear on the same page.
+
+To reduce the resource costs of deeper pagination on your Search queries, try to always include your document ID values as the final sort criteria in your <<sort_arr,sort array>>. 
+Set the `search_before` property to include the values from the last result on your previous page of search results to effectively paginate. 
 
 |[[collections]]collections |Array |No |Contains an array of strings that specify the collections where you want to run the query. 
 
@@ -1889,7 +1913,9 @@ The Search Service uses a consistency vector to synchronize the last document wr
 include::example$run-search-full-request.jsonc[tag=ctl]
 ----
 
-The `ctl` object contains the following properties:
+You can also use the `ctl` object with the `validate` property to add an extra check to your queries and get help troubleshooting when a query does not return results. 
+
+The `ctl` object can contain the following properties:
 
 [cols="1,1,1,4"]
 |====
@@ -1907,6 +1933,16 @@ The query might return partial results if any index partitions responded before 
 An object that contains a `vectors` object and the `level` and `results` properties.
 
 For more information, see <<consistency,>>.
+
+|[[validate]]validate |Boolean |No a|
+
+Add the `validate` property with a value of `true` to add extra validation checks to your Search query.
+
+For example, the Search Service can tell you through the Web Console or the REST API that a field in your Search query is not in your Search index: 
+
+----
+err: query_validate: field not indexed, field: ratings.Cleanliness, type: number
+----
 
 |====
 
@@ -2165,6 +2201,9 @@ The following `sort` object orders search results by the values in `field1`, the
 ----
 include::example$run-search-full-request.jsonc[tag=sort]
 ----
+
+This means that if 2 documents have the same value in `field1`, then the Search Service will sort them again based on their `field2` values.
+If they have the same value in `field2`, then sorting will happen again based on each document's score, and then finally the documents' ID values. 
 
 The `sort` object can contain the following string values: 
 

--- a/modules/search/pages/search-request-params.adoc
+++ b/modules/search/pages/search-request-params.adoc
@@ -1913,7 +1913,7 @@ The Search Service uses a consistency vector to synchronize the last document wr
 include::example$run-search-full-request.jsonc[tag=ctl]
 ----
 
-You can also use the `ctl` object with the `validate` property to add an extra check to your queries and get help troubleshooting when a query does not return results. 
+In Couchbase Server 7.6.4 and later, you can also use the `ctl` object with the `validate` property to add an extra check to your queries and get help troubleshooting when a query does not return results. 
 
 The `ctl` object can contain the following properties:
 
@@ -1935,6 +1935,8 @@ An object that contains a `vectors` object and the `level` and `results` propert
 For more information, see <<consistency,>>.
 
 |[[validate]]validate |Boolean |No a|
+
+[.status]#Couchbase Server 7.6.4#
 
 Add the `validate` property with a value of `true` to add extra validation checks to your Search query.
 

--- a/modules/search/pages/simple-search-rest-api.adoc
+++ b/modules/search/pages/simple-search-rest-api.adoc
@@ -50,13 +50,57 @@ You can choose to copy a full command-line curl example, or copy just the xref:s
 For more information about how to perform a search with the UI, see xref:simple-search-ui.adoc[].
 ====
 
-=== Example
+=== Example: Simple Text Search 
 
 In the following example, the JSON payload queries an index named `landmark-content-index` for the strings `view`, `food`, and `beach`:
 
 [source,console]
 ----
 include::example$run-search-payload.sh[]
+----
+
+If the request is successful, the Search Service API starts by returning a status and a summary of the query request: 
+
+[source,json]
+----
+include::example$query-sample-results.jsonc[tag=query_summary]
+----
+
+The Search Service returns an array, called `hits`, which contains objects that describe the matches found in each document in the Search index: 
+
+[source,json]
+----
+include::example$query-sample-results.jsonc[tag=first_hit]
+----
+
+The Search query set score explanations to `true`, so the Search Service shows how it calculated the score for each document. 
+
+It also includes the locations of each match, under the `locations` object: 
+
+[source,json]
+----
+include::example$query-sample-results.jsonc[tag=locations]
+----
+
+The Search query enabled highlighting, so the Search Service uses the `<mark>` HTML tag to mark each match it found inside the Search index, inside a `fragments` object: 
+
+[source,json]
+----
+include::example$query-sample-results.jsonc[tag=highlight]
+----
+
+Since the target Search index was configured to store field values and return them in results, the Search Service returns the original field content in the `fields` object: 
+
+[source,json]
+----
+include::example$query-sample-results.jsonc[tag=field_content]
+----
+
+At the end of the `hits` array, the Search Service returns a quick summary of the total number of hits, the maximum score, how long the query took, and other information: 
+
+[source,json]
+----
+include::example$query-sample-results.jsonc[tag=end_summary]
 ----
 
 For more information about the available properties for a Search query JSON payload, see xref:search-request-params.adoc[].
@@ -67,6 +111,38 @@ If the REST API call is successful, the Search Service returns a `200 OK` and th
 ----
 include::example$run-search-response.json[]
 ----
+
+=== Example: Validate a Search Request 
+
+In the following example, the JSON payload queries a Search index, `landmark-content-index`, using a xref:search-request-params.adoc#geopoint-queries-distance[Distance/Radius-Based Geopoint Query] on the `geo` field: 
+
+[source,json]
+----
+include::example$run-search-unindexed-field.sh[]
+----
+
+The query runs, but does not return any results: 
+
+[source,json]
+----
+include::example$query-sample-results-unindexed.jsonc[]
+----
+
+To try and validate why the query did not return any results, you can include the xref:search-request-params.adoc#ctl[ctl object] with the `validate` property:
+
+[source,json]
+----
+include::example$run-search-validate.sh[]
+----
+
+With the `validate` property included, the Search query now returns a `400 Bad Request` error and the following JSON response:
+
+[source,json]
+----
+include::example$query-sample-results-validate.jsonc[]
+----
+
+The Search Service validates the query and identifies that the `geo` field used in the query is not included in the Search index. 
 
 == Next Steps 
 

--- a/modules/search/pages/simple-search-rest-api.adoc
+++ b/modules/search/pages/simple-search-rest-api.adoc
@@ -114,6 +114,8 @@ include::example$run-search-response.json[]
 
 === Example: Validate a Search Request 
 
+[.status]#Couchbase Server 7.6.4#
+
 In the following example, the JSON payload queries a Search index, `landmark-content-index`, using a xref:search-request-params.adoc#geopoint-queries-distance[Distance/Radius-Based Geopoint Query] on the `geo` field: 
 
 [source,json]

--- a/modules/search/pages/simple-search-ui.adoc
+++ b/modules/search/pages/simple-search-ui.adoc
@@ -43,7 +43,7 @@ To run a simple search with the Couchbase {page-ui-name}:
 For more information about the available parameters, see xref:search-request-params.adoc[].
 .. Click btn:[Execute].
 
-=== Example
+=== Example: Simple Text Search
 
 For example, the following query searches for the strings `view`, `food`, and `beach`:
 
@@ -57,6 +57,22 @@ It also returns all available fields in the index, and returns 10 results per pa
 
 TIP: Use a xref:index-aliases.adoc[Search index alias] to search multiple Search indexes in a single search query. 
 Use the xref:search-request-params.adoc#collections[`collections` parameter] in your request to specify an array of collections to search from the Search index.
+
+=== Example: Validate a Search Query
+
+For example, the following query searches a Search index, `landmark-content-index`, using a xref:search-request-params.adoc#geopoint-queries-distance[Distance/Radius-Based Geopoint Query] on the `geo` field.
+The query includes the xref:search-request-params.adoc#ctl[ctl object] with the `validate` property to validate the query:
+
+[source,json]
+----
+include::example$run-search-validate-ui.jsonc[]
+----
+
+Since the `landmark-content-index` does not include a mapping for the `geo` field and the `validate` property is included in the query, the Web Console returns the following error: 
+
+----
+query_validate: field not indexed, name: geo, type: geopoint
+----
 
 == Next Steps 
 

--- a/modules/search/pages/simple-search-ui.adoc
+++ b/modules/search/pages/simple-search-ui.adoc
@@ -60,6 +60,8 @@ Use the xref:search-request-params.adoc#collections[`collections` parameter] in 
 
 === Example: Validate a Search Query
 
+[.status]#Couchbase Server 7.6.4#
+
 For example, the following query searches a Search index, `landmark-content-index`, using a xref:search-request-params.adoc#geopoint-queries-distance[Distance/Radius-Based Geopoint Query] on the `geo` field.
 The query includes the xref:search-request-params.adoc#ctl[ctl object] with the `validate` property to validate the query:
 


### PR DESCRIPTION
Docs issue: DOC-12432

Updates made by @sarahlwelton . I force-pushed to resolve a merge conflict with `prerelease/7.6.4`. 

Looks like this is an improvement to the documentation (for clarification), so I think no release notes needed for 7.6.4?