### PR TITLE
DOC-12699: Update views deprecation notice

### DIFF
--- a/modules/learn/pages/services-and-indexes/indexes/indexes.adoc
+++ b/modules/learn/pages/services-and-indexes/indexes/indexes.adoc
@@ -46,5 +46,5 @@ See the section on xref:analytics:7_using_index.adoc[Using Indexes] in Couchbase
 
 View:: Supports xref:learn:views/views-intro.adoc[Couchbase Views], with fields and information extracted from documents.
 Views are deprecated in Couchbase Server 7.0, and will be removed in a future release. 
-Instead of views, use indexes and queries using the xref:services-and-indexes/services/index-service.adoc[Index Service] (GSI) and the xref:services-and-indexes/services/query-service.adoc[Query Service] (SQL++).
+Instead of views, use indexes and queries using the xref:services-and-indexes/services/index-service.adoc[Index Service] (GSI) and the xref:services-and-indexes/services/query-service.adoc[Query Service] ({sqlpp}).
 Views will not run on the newer xref:learn:buckets-memory-and-storage/storage-engines.adoc[Magma storage engine].

--- a/modules/learn/pages/services-and-indexes/indexes/indexes.adoc
+++ b/modules/learn/pages/services-and-indexes/indexes/indexes.adoc
@@ -45,4 +45,6 @@ If changes in operational data result in corresponding modifications to shadow d
 See the section on xref:analytics:7_using_index.adoc[Using Indexes] in Couchbase Analytics.
 
 View:: Supports xref:learn:views/views-intro.adoc[Couchbase Views], with fields and information extracted from documents.
-Views are deprecated in Couchbase Server 7.0, and will be removed in a future release.
+Views are deprecated in Couchbase Server 7.0, and will be removed in a future release. 
+Instead of views, use indexes and queries using the xref:services-and-indexes/services/index-service.adoc[Index Service] (GSI) and the xref:services-and-indexes/services/query-service.adoc[Query Service] (SQL++).
+Views will not run on the newer xref:learn:buckets-memory-and-storage/storage-engines.adoc[Magma storage engine].


### PR DESCRIPTION
Update views deprecation notice to include additional info -- "Instead of views, use indexes and queries using the Index Service (GSI) and the Query Service (SQL++)".