### PR TITLE
[DOC-12934] Add an admonition calling out lack of Windows support

### DIFF
--- a/modules/vector-search/pages/create-vector-search-index-rest-api.adoc
+++ b/modules/vector-search/pages/create-vector-search-index-rest-api.adoc
@@ -12,6 +12,8 @@ You must create a Search index before you can xref:run-vector-search-rest-api.ad
 TIP: Vector Search indexes can include all the same features and settings as a Search index. 
 For more information about Search indexes, see the xref:search:search.adoc[Search documentation].
 
+include::partial$vector-search-no-windows.adoc[]
+
 == Prerequisites 
 
 * You have the Search Service enabled on a node in your database.

--- a/modules/vector-search/pages/create-vector-search-index-ui.adoc
+++ b/modules/vector-search/pages/create-vector-search-index-ui.adoc
@@ -13,6 +13,8 @@ You must create a Vector Search index before you can xref:run-vector-search-ui.a
 TIP: Vector Search indexes can include all the same features and settings as a Search index. 
 For more information about Search indexes, see the xref:search:search.adoc[Search documentation].
 
+include::partial$vector-search-no-windows.adoc[]
+
 == Prerequisites
 
 * You have the Search Service enabled on a node in your database.

--- a/modules/vector-search/pages/fine-tune-vector-search.adoc
+++ b/modules/vector-search/pages/fine-tune-vector-search.adoc
@@ -7,7 +7,7 @@
 [abstract]
 {description}
 
-
+include::partial$vector-search-no-windows.adoc[]
 
 The Search Service automatically tunes your Vector Search indexes to achieve a balance between: 
 

--- a/modules/vector-search/pages/pre-filtering-vector-search.adoc
+++ b/modules/vector-search/pages/pre-filtering-vector-search.adoc
@@ -12,6 +12,7 @@ The Search Service supports pre-filtering on Vector Search queries.
 Pre-filtering allows you to execute vector searches over a subset of the vector index, 
 via the means of a filter request that qualifies the subset.
 
+include::partial$vector-search-no-windows.adoc[]
 
 == Prerequisites
 

--- a/modules/vector-search/pages/run-vector-search-rest-api.adoc
+++ b/modules/vector-search/pages/run-vector-search-rest-api.adoc
@@ -9,6 +9,8 @@
 
 For more information about how the Search Service scores documents in search results, see xref:run-searches.adoc#scoring[Scoring for Search Queries].
 
+include::partial$vector-search-no-windows.adoc[]
+
 == Prerequisites 
 
 * You have the Search Service enabled on a node in your database.

--- a/modules/vector-search/pages/run-vector-search-sdk.adoc
+++ b/modules/vector-search/pages/run-vector-search-sdk.adoc
@@ -9,6 +9,8 @@
 [abstract]
 {description}
 
+include::partial$vector-search-no-windows.adoc[]
+
 For more information about how the Search Service scores documents in search results, see xref:search:run-searches.adoc#scoring[Scoring for Search Queries].
 
 [TIP]

--- a/modules/vector-search/pages/run-vector-search-ui.adoc
+++ b/modules/vector-search/pages/run-vector-search-ui.adoc
@@ -9,6 +9,8 @@
 
 For more information about how the Search Service scores documents in search results, see xref:run-searches.adoc#scoring[Scoring for Search Queries].
 
+include::partial$vector-search-no-windows.adoc[]
+
 == Prerequisites 
 
 * You have the Search Service enabled on a node in your database.

--- a/modules/vector-search/pages/vector-search-index-architecture.adoc
+++ b/modules/vector-search/pages/vector-search-index-architecture.adoc
@@ -6,6 +6,8 @@
 [abstract]
 {description}
 
+include::partial$vector-search-no-windows.adoc[]
+
 A Vector Search index still relies on <<sync,>> and uses <<segments,>> to manage merging and persisting data to disk in your cluster.
 All changes from Database Change Protocol (DCP) and the Data Service are introduced to a Search index in batches, which are further managed by segments. 
 

--- a/modules/vector-search/pages/vector-search.adoc
+++ b/modules/vector-search/pages/vector-search.adoc
@@ -7,6 +7,8 @@
 [abstract]
 {description}
 
+include::partial$vector-search-no-windows.adoc[]
+
 == About Vector Search
 
 Vector Search builds on Couchbase {page-product-name}'s xref:search:search.adoc[Search Service] to provide vector index support.

--- a/modules/vector-search/partials/vector-search-no-windows.adoc
+++ b/modules/vector-search/partials/vector-search-no-windows.adoc
@@ -1,0 +1,7 @@
+[IMPORTANT]
+--
+You cannot use Vector Search on Windows platforms.
+You can use Vector Search on Linux from Couchbase {page-product-name} version 7.6.0 and MacOS from version 7.6.2.
+
+You can still use other features of the xref:search:search.adoc[Search Service].
+--


### PR DESCRIPTION
Vector Search is not supported on Windows platforms due to some bugs right now. 

We've never announced that it's available on Windows in release notes, but we might as well make the information more obvious that it's not supported. 