### PR TITLE
[AV-93910] Document App Services Compatibility setting

### DIFF
--- a/modules/eventing/pages/add-eventing-functions.adoc
+++ b/modules/eventing/pages/add-eventing-functions.adoc
@@ -93,7 +93,7 @@ When you set the Feed Boundary to `From Now`, the Function is only invoked on fu
 |Enable App Services Compatibility
 |Select this option only when using App Services with the same collection as this Eventing Function, as it prevents duplicate processing.
 
-This setting is off by default.
+This setting is selected by default and mandatory when an App Service already links to the Eventing Function's chosen collection.
 
 |===
 

--- a/modules/eventing/pages/add-eventing-functions.adoc
+++ b/modules/eventing/pages/add-eventing-functions.adoc
@@ -90,6 +90,11 @@ When you set the Feed Boundary to `From Now`, the Function is only invoked on fu
 |Language Compatibility
 |The language version of the handler for backward compatibility.
 
+|Enable App Services Compatibility
+|Select this option only when using App Services with the same collection as this Eventing Function, as it prevents duplicate processing.
+
+This setting is off by default.
+
 |===
 
 For more information about terminology, see xref:eventing-terminologies.adoc[Eventing terminology].

--- a/modules/eventing/pages/manage-eventing-functions.adoc
+++ b/modules/eventing/pages/manage-eventing-functions.adoc
@@ -158,6 +158,9 @@ To edit a larger number of your Function's settings, undeploy or pause your Func
 |Language Compatibility
 |Can only be edited when the Function is in an undeployed or paused state.
 
+|Enable App Services Compatibility
+|Can only be edited when the Function does not share the same collection as an App Service.
+
 |===
 
 


### PR DESCRIPTION
Eventing will be available to App Services with 7.6.5 (in a follow-up change at the end of Feb). This adds mention of the setting in the Create Function proc, as well as in the modify functions page.

Related PR for App Services is here: https://github.com/couchbase/docs-capella/pull/136