### PR TITLE
[DOC-10792] Add OBJECT_TYPES/OBJECT_TYPES_NESTED functions

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/objectfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/objectfun.adoc
@@ -1360,7 +1360,7 @@ LIMIT 1;
 
 === Description
 
-This function returns an object with all field values replaced by their types as would be reported by the TYPE() function.
+This function takes an object and returns a new one where all the values are replaced with their data types as reported by the TYPE() function.
 
 === Arguments
 
@@ -1368,7 +1368,7 @@ expression:: An expression representing an object.
 
 === Return Value
 
-An object with the same fields as the input object with all values listed as the type.
+An object with the same fields as the input object, but with all values replaced by their corresponding data types. 
 
 === Example
 
@@ -1377,7 +1377,7 @@ An object with the same fields as the input object with all values listed as the
 .Query
 [source,sqlpp]
 ----
-SELECT OBJECT_TYPES({"field1":1,"field2":"two","field3":NULL,"field4":{"sub1":TRUE}}) 
+SELECT OBJECT_TYPES({"flight":"AI444","duration":180,"gate":NULL,"aircraft":{"model":"Boeing 737"}}) 
     AS object_types;
 ----
 
@@ -1387,10 +1387,10 @@ SELECT OBJECT_TYPES({"field1":1,"field2":"two","field3":NULL,"field4":{"sub1":TR
 [
     {
         "object_types":{
-            "field1":"number",
-            "field2":"string",
-            "field3":"null",
-            "field4":"object"
+            "flight":"string",
+            "duration":"number",
+            "gate":"null",
+            "aircraft":"object"
         }
     }
 ]
@@ -1402,7 +1402,8 @@ SELECT OBJECT_TYPES({"field1":1,"field2":"two","field3":NULL,"field4":{"sub1":TR
 
 === Description
 
-This function returns the object with all non-composite field values replaced by their types as would be reported by the TYPE() function.  All composite type (ARRAYs and OBJECTs) fields are recursively processed with the same value replacement.
+This function takes an object and returns a new one where all non-composite field values replaced with their data types as reported by the TYPE() function. 
+Additionally, all composite type fields (ARRAYs and OBJECTs) are recursively processed in the same way, ensuring that all nested values are also replaced with their types. 
 
 === Arguments
 
@@ -1410,7 +1411,7 @@ expression:: An expression representing an object.
 
 === Return Value
 
-An object with the same fields as the input object with all non-composite values listed as the type.
+An object with the same fields as the input object, but with all values replaced by their corresponding non-composite data types. 
 
 === Example
 
@@ -1419,7 +1420,7 @@ An object with the same fields as the input object with all non-composite values
 .Query
 [source,sqlpp]
 ----
-SELECT OBJECT_TYPES_NESTED({"field1":1,"field2":[1,2,true],"field3":null,"field4":{"sub1":true}}) 
+SELECT OBJECT_TYPES_NESTED({"flight":"AI444","crewMembers":["Alice Bobson","John Flo",true],"gate":NULL,"aircraft":{"model":"Boeing 737", "capacity":200}}) 
     AS object_types_nested;
 ----
 
@@ -1429,15 +1430,16 @@ SELECT OBJECT_TYPES_NESTED({"field1":1,"field2":[1,2,true],"field3":null,"field4
 [
   {
     "object_types_nested": {
-      "field1": "number",
-      "field2": [
-        "number",
-        "number",
+      "flight": "string",
+      "crewMembers": [
+        "string",
+        "string",
         "boolean"
       ],
-      "field3": "null",
-      "field4": {
-        "sub1": "boolean"
+      "gate": "null",
+      "aircraft": {
+        "model": "string",
+        "capacity":"number"
       }
     }
   }

--- a/modules/n1ql/pages/n1ql-language-reference/objectfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/objectfun.adoc
@@ -540,36 +540,63 @@ SELECT OBJECT_NAMES(special_flights[*]) AS names;
 ====
 
 [[fn-obj-pairs,OBJECT_PAIRS()]]
-== OBJECT_PAIRS(`expression`)
+== OBJECT_PAIRS(`expression`, [ `options` ])
 
-_Alias_: *OBJECT_OUTER_PAIRS(`expression`)*
+_Alias_: *OBJECT_OUTER_PAIRS(`expression`, [ `options` ])*
 
 === Description
 
-This function returns an array of objects, containing the names and values of each attribute in the input object.
-It is particularly useful when iterating over multiple objects in an array, as it collates the values from similarly-named attributes into a single nested array.
+This function returns an array of objects, containing the names and values of each attribute in the input object. 
+It also provides an option to return attribute types instead of values. 
 
-In this case, the function returns a null entry from any object which does not contain the shared attribute name, rather like an OUTER JOIN.
+The function is particularly useful when iterating over multiple objects in an array, as it collates the values from similarly-named attributes into a single nested array. 
+However, if an object does not contain a shared attribute name, it returns a null entry, similar to an OUTER JOIN.
+
 For an illustration, refer to the examples below.
 
 === Arguments
 
 expression:: An expression representing an object.
 
+options:: [Optional]
+A JSON object specifying options for the function.
+
+
+=== Options
+
+[options="header", cols="1a,3a,1a"]
+|===
+| Name | Description | Schema
+
+| **types** +
+__required__
+| Determines whether the function returns attribute types or values.
+
+If TRUE, the function returns the name and type of each attribute.
+
+If FALSE, the function returns the name and value of each attribute.
+
+*Default:* `FALSE`
+| Boolean
+|===
+
 === Return Value
 
-An array of objects, each containing two attributes:
+An array of objects, each containing the following attributes:
 
 name:: The name of an attribute in the source object.
 
 val:: The value of an attribute in the source object; or an array, containing the collated values of similarly-named attributes in the source objects.
 
-The objects in the array are sorted by attribute name, in {sqlpp} collation order.
+type:: The type of an attribute in the source object. Returned only when the 'types' parameter is set to 'TRUE'. 
+
+NOTE: Each returned object will have either **val** or **type** (depending on the input parameters), but not both. 
+Also, the objects in the array are sorted by attribute name, in {sqlpp} collation order.
 
 === Examples
 
 [[obj-pairs-ex1,OBJECT_PAIRS() Example 1]]
-.Single object
+.A single input object returning names and values
 ====
 .Query
 [source,sqlpp]
@@ -603,6 +630,40 @@ SELECT OBJECT_PAIRS({"flight": "AI444", "utc": "4:44:44", "codename": "green"})
 ====
 
 [[obj-pairs-ex2,OBJECT_PAIRS() Example 2]]
+.A single input object returning names and types
+====
+.Query
+[source,sqlpp]
+----
+SELECT OBJECT_PAIRS({"flight": "AI444", "utc": "4:44:44", "codename": "green"},{"types":TRUE})
+    AS outer_pairs;
+----
+
+.Results
+[source,json]
+----
+[
+  {
+    "outer_pairs": [
+      {
+        "name": "codename",
+        "type": "string"
+      },
+      {
+        "name": "flight",
+        "type": "string"
+      },
+      {
+        "name": "utc",
+        "type": "string"
+      }
+    ]
+  }
+]
+----
+====
+
+[[obj-pairs-ex3,OBJECT_PAIRS() Example 3]]
 .Iterating over objects in an array
 ====
 In this example, notice that where the source objects have similarly-named attributes, the values from each of those attributes are collated into a single array in the output.
@@ -659,6 +720,7 @@ SELECT OBJECT_PAIRS(special_flights[*]) AS outer_pairs;
 ]
 ----
 ====
+
 
 [[fn-obj-pairs-nested,OBJECT_PAIRS_NESTED()]]
 == OBJECT_PAIRS_NESTED(`object` [, `options`])

--- a/modules/n1ql/pages/n1ql-language-reference/objectfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/objectfun.adoc
@@ -584,11 +584,22 @@ If FALSE, the function returns the name and value of each attribute.
 
 An array of objects, each containing the following attributes:
 
-name:: The name of an attribute in the source object.
+[options="header", cols="1a,3a,1a"]
+|===
+| Name | Description | Schema
 
-val:: The value of an attribute in the source object; or an array, containing the collated values of similarly-named attributes in the source objects.
+| **name** +
+| The name of an attribute in the source object.
+| String
 
-type:: The type of an attribute in the source object. Returned only when the `types` parameter is set to `TRUE`. 
+| **val** +
+| The value of an attribute in the source object; or an array, containing the collated values of similarly-named attributes in the source objects.
+| Depends on the value returned. It can be a string, number, boolean, or others. 
+
+| **type** +
+| The type of an attribute in the source object. Returned only when the `types` parameter is set to `TRUE`. 
+| String
+|===
 
 NOTE: Each returned object will have either **val** or **type** (depending on the specified options), and not both. 
 Also, the objects in the array are sorted by attribute name, in {sqlpp} collation order.
@@ -780,14 +791,26 @@ If FALSE, the function returns the name and value of each field.
 
 An array of objects, each containing the following attributes:
 
-name:: The full path to every possible field within the source object, subject to the specified options.
-+
+[options="header", cols="1a,3a,1a"]
+|===
+| Name | Description | Schema
+
+| **name** +
+| The full path to every possible field within the source object, subject to the specified options. +
+
 The result uses xref:n1ql-language-reference/nestedops.adoc[nested operators] to specify the path to all nested attributes or elements.
 If any attribute names within a field path contain special characters, they are escaped using backticks (`{backtick}{backtick}`).
 
-val:: The value of a field in the source object; or an array, containing the collated values of similarly-named fields in the source objects.
+| String
 
-type:: The type of a field in the source object. Returned only when the 'types' parameter is set to 'TRUE'. 
+| **val** +
+| The value of a field in the source object; or an array, containing the collated values of similarly-named fields in the source objects.
+| Depends on the value returned. It can be a string, number, boolean, or others. 
+
+| **type** +
+| The type of a field in the source object. Returned only when the 'types' parameter is set to 'TRUE'.
+| String
+|===
 
 NOTE: Each returned object will have either **val** or **type** (depending on the specified options), and not both. 
 Also, the objects in the array are sorted by field name, in {sqlpp} collation order.

--- a/modules/n1ql/pages/n1ql-language-reference/objectfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/objectfun.adoc
@@ -540,9 +540,9 @@ SELECT OBJECT_NAMES(special_flights[*]) AS names;
 ====
 
 [[fn-obj-pairs,OBJECT_PAIRS()]]
-== OBJECT_PAIRS(`expression`, [ `options` ])
+== OBJECT_PAIRS(`expression` [, `options` ])
 
-_Alias_: *OBJECT_OUTER_PAIRS(`expression`, [ `options` ])*
+_Alias_: *OBJECT_OUTER_PAIRS(`expression` [, `options` ])*
 
 === Description
 
@@ -570,7 +570,7 @@ A JSON object specifying options for the function.
 
 | **types** +
 __required__
-| Determines whether the function returns attribute types or values.
+| Determines whether to return attribute types or values.
 
 If TRUE, the function returns the name and type of each attribute.
 
@@ -588,9 +588,9 @@ name:: The name of an attribute in the source object.
 
 val:: The value of an attribute in the source object; or an array, containing the collated values of similarly-named attributes in the source objects.
 
-type:: The type of an attribute in the source object. Returned only when the 'types' parameter is set to 'TRUE'. 
+type:: The type of an attribute in the source object. Returned only when the `types` parameter is set to `TRUE`. 
 
-NOTE: Each returned object will have either **val** or **type** (depending on the input parameters), but not both. 
+NOTE: Each returned object will have either **val** or **type** (depending on the specified options), and not both. 
 Also, the objects in the array are sorted by attribute name, in {sqlpp} collation order.
 
 === Examples
@@ -727,38 +727,70 @@ SELECT OBJECT_PAIRS(special_flights[*]) AS outer_pairs;
 
 === Description
 
-Similar to <<fn-obj-pairs>>, this function returns an array of objects, containing the names and values of each field in the input object.
-A field in this context may be any attribute or element, nested at any level within the object.
+Similar to <<fn-obj-pairs>>, this function returns an array of objects, containing the names and values of each field in the input object. 
+It also provides an option to return field types instead of values. 
+A field in this context may be any attribute or element, nested at any level within the object. 
 
 This function may be useful when iterating over multiple objects in an array, as it collates and unnests the values from similarly-named fields across all objects in the input array.
-In this case, the function returns a null entry from any object which does not contain the shared field name, rather like an OUTER JOIN.
+However, if an object does not contain a shared field name, it returns a null entry, similar to an OUTER JOIN.
+
 For an illustration, refer to the examples below.
 
 === Arguments
 
 object:: An expression representing an object.
 
-options:: [Optional] An object containing the following possible parameters:
+options:: [Optional] A JSON object specifying options for the function. 
 
-composites;; A boolean.
-If `true`, every level of every nested field is displayed; if `false`, only the deepest possible nested fields are returned.
-Default `false`.
+=== Options
 
-pattern;; A regular expression used to filter the returned paths.
+[options="header", cols="1a,3a,1a"]
+|===
+| Name | Description | Schema
+
+| **composites** +
+__optional__
+| If TRUE, every level of every nested field is displayed.
+
+If FALSE, only the deepest possible nested fields are returned.
+
+*Default:* `FALSE`
+| Boolean
+
+| **pattern** +
+__optional__
+| A regular expression used to filter the returned paths.
 The pattern is matched against the composite path names, not the individual field names.
+
+| String
+
+| **types** +
+__optional__
+| Determines whether to return field types or values.
+
+If TRUE, the function returns the name and type of each field.
+
+If FALSE, the function returns the name and value of each field.
+
+*Default:* `FALSE`
+| Boolean
+|===
 
 === Return Value
 
-An array of objects, each containing two attributes:
+An array of objects, each containing the following attributes:
 
 name:: The full path to every possible field within the source object, subject to the specified options.
 +
 The result uses xref:n1ql-language-reference/nestedops.adoc[nested operators] to specify the path to all nested attributes or elements.
 If any attribute names within a field path contain special characters, they are escaped using backticks (`{backtick}{backtick}`).
 
-val:: The value of an attribute in the source object; or an array, containing the collated values of similarly-named attributes in the source objects.
+val:: The value of a field in the source object; or an array, containing the collated values of similarly-named fields in the source objects.
 
-The objects in the array are sorted by attribute name, in {sqlpp} collation order.
+type:: The type of a field in the source object. Returned only when the 'types' parameter is set to 'TRUE'. 
+
+NOTE: Each returned object will have either **val** or **type** (depending on the specified options), and not both. 
+Also, the objects in the array are sorted by field name, in {sqlpp} collation order.
 
 === Examples
 
@@ -769,11 +801,12 @@ The objects in the array are sorted by attribute name, in {sqlpp} collation orde
 [source,sqlpp]
 ----
 WITH input AS ({
- "attribute": {"first-part": 1, "second-part": 2}
-})
+    "attribute": {"flight-name": "AI444", "flight-number": 737}
+  })
 SELECT OBJECT_PAIRS_NESTED(input) AS nested_pairs,
        OBJECT_PAIRS_NESTED(input, {"composites": true}) AS nested_pairs_comp,
-       OBJECT_PAIRS_NESTED(input, {"pattern": "first"}) AS nested_pairs_pattern;
+       OBJECT_PAIRS_NESTED(input, {"pattern": "name"}) AS nested_pairs_pattern,
+       OBJECT_PAIRS_NESTED(input, {"types": true}) AS nested_pairs_types;
 ----
 
 .Results
@@ -783,35 +816,45 @@ SELECT OBJECT_PAIRS_NESTED(input) AS nested_pairs,
   {
     "nested_pairs": [
       {
-        "name": "attribute.first-part",
-        "val": 1
+        "name": "attribute.flight-name",
+        "val": "AI444"
       },
       {
-        "name": "attribute.second-part",
-        "val": 2
+        "name": "attribute.flight-number",
+        "val": 737
       }
     ],
     "nested_pairs_comp": [
       {
         "name": "attribute",
         "val": {
-          "first-part": 1,
-          "second-part": 2
+          "flight-name": "AI444",
+          "flight-number": 737
         }
       },
       {
-        "name": "attribute.first-part",
-        "val": 1
+        "name": "attribute.flight-name",
+        "val": "AI444"
       },
       {
-        "name": "attribute.second-part",
-        "val": 2
+        "name": "attribute.flight-number",
+        "val": 737
       }
     ],
     "nested_pairs_pattern": [
       {
-        "name": "attribute.first-part",
-        "val": 1
+        "name": "attribute.flight-name",
+        "val": "AI444"
+      }
+    ],
+    "nested_pairs_types": [
+      {
+        "name": "attribute.flight-name",
+        "type": "string"
+      },
+      {
+        "name": "attribute.flight-number",
+        "type": "number"
       }
     ]
   }
@@ -925,7 +968,7 @@ SELECT OBJECT_PAIRS_NESTED(special_flights[*], {"composites": true}) AS nested_p
 ]
 ----
 
-Compare this example with <<obj-pairs-ex2>>.
+Compare this example with <<obj-pairs-ex3>>.
 ====
 
 [[fn-obj-paths,OBJECT_PATHS()]]

--- a/modules/n1ql/pages/n1ql-language-reference/objectfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/objectfun.adoc
@@ -1355,6 +1355,97 @@ LIMIT 1;
 ----
 ====
 
+[[fn-obj-type,OBJECT_TYPES()]]
+== OBJECT_TYPES(`expression`)
+
+=== Description
+
+This function returns an object with all field values replaced by their types as would be reported by the TYPE() function.
+
+=== Arguments
+
+expression:: An expression representing an object.
+
+=== Return Value
+
+An object with the same fields as the input object with all values listed as the type.
+
+=== Example
+
+[[obj-type-ex,OBJECT_TYPES() Example]]
+====
+.Query
+[source,sqlpp]
+----
+SELECT OBJECT_TYPES({"field1":1,"field2":"two","field3":NULL,"field4":{"sub1":TRUE}}) 
+    AS object_types;
+----
+
+.Results
+[source,json]
+----
+[
+    {
+        "object_types":{
+            "field1":"number",
+            "field2":"string",
+            "field3":"null",
+            "field4":"object"
+        }
+    }
+]
+----
+====
+
+[[fn-obj-types-nested,OBJECT_TYPES_NESTED()]]
+== OBJECT_TYPES_NESTED(`expression`)
+
+=== Description
+
+This function returns the object with all non-composite field values replaced by their types as would be reported by the TYPE() function.  All composite type (ARRAYs and OBJECTs) fields are recursively processed with the same value replacement.
+
+=== Arguments
+
+expression:: An expression representing an object.
+
+=== Return Value
+
+An object with the same fields as the input object with all non-composite values listed as the type.
+
+=== Example
+
+[[obj-type-nested-ex,OBJECT_TYPES_NESTED() Example]]
+====
+.Query
+[source,sqlpp]
+----
+SELECT OBJECT_TYPES_NESTED({"field1":1,"field2":[1,2,true],"field3":null,"field4":{"sub1":true}}) 
+    AS object_types_nested;
+----
+
+.Results
+[source,json]
+----
+[
+  {
+    "object_types_nested": {
+      "field1": "number",
+      "field2": [
+        "number",
+        "number",
+        "boolean"
+      ],
+      "field3": "null",
+      "field4": {
+        "sub1": "boolean"
+      }
+    }
+  }
+]
+----
+====
+
+
 [[fn-obj-unwrap,OBJECT_UNWRAP()]]
 == OBJECT_UNWRAP(`expression`)
 

--- a/modules/n1ql/pages/n1ql-language-reference/objectfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/objectfun.adoc
@@ -1465,7 +1465,7 @@ LIMIT 1;
 
 === Description
 
-This function takes an object and returns a new one where all the values are replaced with their data types as reported by the TYPE() function.
+This function returns the data type of every field in the supplied object, as reported by the xref:n1ql-language-reference/typefun.adoc#fn-type-type[TYPE()] function.
 
 === Arguments
 
@@ -1482,7 +1482,10 @@ An object with the same fields as the input object, but with all values replaced
 .Query
 [source,sqlpp]
 ----
-SELECT OBJECT_TYPES({"flight":"AI444","duration":180,"gate":NULL,"aircraft":{"model":"Boeing 737"}}) 
+SELECT OBJECT_TYPES({"flight": "AI444",
+                     "duration": 180,
+                     "gate": NULL,
+                     "aircraft": {"model": "Boeing 737"}}) 
     AS object_types;
 ----
 
@@ -1507,8 +1510,8 @@ SELECT OBJECT_TYPES({"flight":"AI444","duration":180,"gate":NULL,"aircraft":{"mo
 
 === Description
 
-This function takes an object and returns a new one where all non-composite field values replaced with their data types as reported by the TYPE() function. 
-Additionally, all composite type fields (ARRAYs and OBJECTs) are recursively processed in the same way, ensuring that all nested values are also replaced with their types. 
+This function returns the data type of every non-composite field in the supplied object, as reported by the xref:n1ql-language-reference/typefun.adoc#fn-type-type[TYPE()] function.
+Additionally, all composite type fields (ARRAYs and OBJECTs) are recursively processed in the same way, returning the data types of all nested values. 
 
 === Arguments
 
@@ -1525,7 +1528,13 @@ An object with the same fields as the input object, but with all values replaced
 .Query
 [source,sqlpp]
 ----
-SELECT OBJECT_TYPES_NESTED({"flight":"AI444","crewMembers":["Alice Bobson","John Flo",true],"gate":NULL,"aircraft":{"model":"Boeing 737", "capacity":200}}) 
+SELECT OBJECT_TYPES_NESTED({"flight":"AI444",
+                            "crewMembers": ["Alice Bobson",
+                                            "John Flo",
+                                            true],
+                            "gate": NULL,
+                            "aircraft": {"model": "Boeing 737",
+                                         "capacity":200}}) 
     AS object_types_nested;
 ----
 


### PR DESCRIPTION
[DOC-10792]

- Added two new object functions - object_types() and object_types_nested().
- Updated two existing object functions to add the 'options'/'types' parameter - object_pairs() and object_pairs_nested().

Preview: https://preview.docs-test.couchbase.com/docs-devex-DOC-10792-object-type-functions/server/current/n1ql/n1ql-language-reference/objectfun.html


[DOC-10792]: https://couchbasecloud.atlassian.net/browse/DOC-10792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ