### PR TITLE
[DOC-10871] Add OBJECT_CONCAT2 Function

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/objectfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/objectfun.adoc
@@ -109,6 +109,62 @@ SELECT OBJECT_CONCAT({"abc": 1}, {"def": 2}, {"ghi": 3}, {"ghi": 4}, {"ghi": [5,
 ----
 ====
 
+[[fn-obj-concat2,OBJECT_CONCAT2()]]
+== OBJECT_CONCAT2(`expr`, `expr` ...)
+
+=== Description
+
+This function concatenates multiple input objects into a single new object, and requires at least two input objects to work. 
+Unlike <<fn-obj-concat>>, this function supports both plain objects and arrays of objects as arguments. 
+
+
+=== Arguments
+
+expr:: An expression representing an object or an array of objects. 
+The first argument must be a plain object and cannot be an array. 
+
+=== Return Value
+
+An object constructed by concatenating all the input objects.
+If any of the input objects contain the same attribute name, the attribute from the last relevant object in the input list is copied to the output; similarly-named attributes from earlier objects in the input list are ignored.
+
+=== Examples
+
+[[obj-concat2-ex,OBJECT_CONCAT2() Example]]
+====
+.Query
+[source,sqlpp]
+----
+SELECT OBJECT_CONCAT2({"abc": 1}, {"def": 2}, {"ghi": 3}, {"ghi": 4}, {"ghi": [5, 6, 7]},{"jkl": [{"mno": 8}, {"pqr": 9}]} );
+----
+
+.Results
+[source,json]
+----
+[
+  {
+    "$1": {
+      "abc": 1,
+      "def": 2,
+      "ghi": [
+        5,
+        6,
+        7
+      ],
+      "jkl": [
+        {
+          "mno": 8
+        },
+        {
+          "pqr": 9
+        }
+      ]
+    }
+  }
+]
+----
+====
+
 [[fn-obj-field,OBJECT_FIELD()]]
 == OBJECT_FIELD(`object`, `field`)
 

--- a/modules/n1ql/pages/n1ql-language-reference/objectfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/objectfun.adoc
@@ -135,9 +135,12 @@ If any of the input objects contain the same attribute name, the attribute from 
 .Query
 [source,sqlpp]
 ----
-SELECT OBJECT_CONCAT2({"abc": 1}, {"def": 2}, {"ghi": 3}, {"ghi": 4},
-              {"ghi": [5, 6, 7]}, 
-              {"jkl": [{"mno": 8}, {"pqr": 9}]} 
+SELECT OBJECT_CONCAT2({"employee_id":1}, 
+            [ {"name": "John Doe"}, 
+              {"department": "Engineering"}, 
+              {"location": "New York"},
+              {"location":"California"}
+            ]
 );
 ----
 
@@ -147,21 +150,10 @@ SELECT OBJECT_CONCAT2({"abc": 1}, {"def": 2}, {"ghi": 3}, {"ghi": 4},
 [
   {
     "$1": {
-      "abc": 1,
-      "def": 2,
-      "ghi": [
-        5,
-        6,
-        7
-      ],
-      "jkl": [
-        {
-          "mno": 8
-        },
-        {
-          "pqr": 9
-        }
-      ]
+      "department": "Engineering",
+      "employee_id": 1,
+      "location": "California",
+      "name": "John Doe"
     }
   }
 ]

--- a/modules/n1ql/pages/n1ql-language-reference/objectfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/objectfun.adoc
@@ -135,7 +135,10 @@ If any of the input objects contain the same attribute name, the attribute from 
 .Query
 [source,sqlpp]
 ----
-SELECT OBJECT_CONCAT2({"abc": 1}, {"def": 2}, {"ghi": 3}, {"ghi": 4}, {"ghi": [5, 6, 7]},{"jkl": [{"mno": 8}, {"pqr": 9}]} );
+SELECT OBJECT_CONCAT2({"abc": 1}, {"def": 2}, {"ghi": 3}, {"ghi": 4},
+              {"ghi": [5, 6, 7]}, 
+              {"jkl": [{"mno": 8}, {"pqr": 9}]} 
+);
 ----
 
 .Results

--- a/modules/n1ql/pages/n1ql-language-reference/objectfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/objectfun.adoc
@@ -87,7 +87,12 @@ If any of the input objects contain the same attribute name, the attribute from 
 .Query
 [source,sqlpp]
 ----
-SELECT OBJECT_CONCAT({"abc": 1}, {"def": 2}, {"ghi": 3}, {"ghi": 4}, {"ghi": [5, 6, 7]});
+SELECT OBJECT_CONCAT({"flight": "AF198"}, 
+    {"utc": "4:44:44"},
+    {"code": "green"}, 
+    {"code": "yellow"},
+    {"passengers": ["Corrine Hill", "Vallie Ryan"]}
+);       
 ----
 
 .Results
@@ -96,12 +101,12 @@ SELECT OBJECT_CONCAT({"abc": 1}, {"def": 2}, {"ghi": 3}, {"ghi": 4}, {"ghi": [5,
 [
   {
     "$1": {
-      "abc": 1,
-      "def": 2,
-      "ghi": [
-        5,
-        6,
-        7
+      "flight": "AF198",
+      "utc": "4:44:44",
+      "code": "yellow",
+      "passengers": [
+        "Corrine Hill",
+        "Vallie Ryan"
       ]
     }
   }
@@ -135,12 +140,13 @@ If any of the input objects contain the same attribute name, the attribute from 
 .Query
 [source,sqlpp]
 ----
-SELECT OBJECT_CONCAT2({"employee_id":1}, 
-            [ {"name": "John Doe"}, 
-              {"department": "Engineering"}, 
-              {"location": "New York"},
-              {"location":"California"}
-            ]
+SELECT OBJECT_CONCAT2(
+    {"flight": "AF198"},
+    [ {"utc": "4:44:44"},
+      {"code": "green"},
+      {"airline": "Air France"},
+      {"airline": "Delta"}
+    ]
 );
 ----
 
@@ -150,10 +156,10 @@ SELECT OBJECT_CONCAT2({"employee_id":1},
 [
   {
     "$1": {
-      "department": "Engineering",
-      "employee_id": 1,
-      "location": "California",
-      "name": "John Doe"
+      "flight": "AF198",
+      "utc": "4:44:44",
+      "code": "green",
+      "airline": "Delta"
     }
   }
 ]


### PR DESCRIPTION
[DOC-10871]

Added a new OBJECT_CONTACT2 function that takes both plain objects and arrays of objects as inputs. 

Preview: https://preview.docs-test.couchbase.com/DOC-10871-object-concat2/server/current/n1ql/n1ql-language-reference/objectfun.html#fn-obj-concat2

Credentials: [Preview docs for internal review](https://couchbasecloud.atlassian.net/wiki/x/dYF_dQ#Preview-docs-for-internal-review)

[DOC-10871]: https://couchbasecloud.atlassian.net/browse/DOC-10871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ