### PR TITLE
DOC-13161 extract `preview` config

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -4,19 +4,3 @@ asciidoc:
   attributes:
     ui-name: Capella UI
     product-name: Capella
-ext:
-  preview:
-    HEAD:
-      sources:
-        docs-capella:
-          branches: [main]
-      override:
-        site:
-          startPage: cloud:get-started:intro.adoc
-    AV-68634-tutorial-feature-branch:
-      sources:
-        docs-capella:
-          branches: [AV-68634-dev-tutorial-navigation]
-      override:
-        site:
-          startPage: cloud:get-started:intro.adoc

--- a/preview/AV-68634-tutorial-feature-branch.yml
+++ b/preview/AV-68634-tutorial-feature-branch.yml
@@ -1,0 +1,6 @@
+sources:
+  docs-capella:
+    branches: [AV-68634-dev-tutorial-navigation]
+override:
+  site:
+    startPage: cloud:get-started:intro.adoc

--- a/preview/HEAD.yml
+++ b/preview/HEAD.yml
@@ -1,0 +1,6 @@
+sources:
+  docs-capella:
+    branches: [main]
+override:
+  site:
+    startPage: cloud:get-started:intro.adoc


### PR DESCRIPTION
as discussed - I think extracting the config to `preview` will be cleaner.

There was no need to add the `preview/AV-68634-tutorial-feature-branch.yml` file except as an example!
(BUT, now that it's there, there's no *pressing* need to delete it either, as it won't sit in the antora.yml anymore).

To use this, you'll want to update docs-site with `git pull` to get the change https://github.com/couchbase/docs-site/commit/6124ade85357fe687659f81623be99a747190fa9
