### PR TITLE
DOC-13161 extract `preview` config (server 7.6)

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -4,11 +4,3 @@ asciidoc:
   attributes:
     ui-name: Server Web Console
     product-name: Server
-ext:
-  preview:
-    HEAD:
-      sources:
-        docs-server:
-          branches: [release/7.6]
-      override:
-        startPage: server:introduction:intro.adoc

--- a/preview/HEAD.yml
+++ b/preview/HEAD.yml
@@ -1,0 +1,5 @@
+sources:
+  docs-server:
+    branches: [release/7.6]
+override:
+  startPage: server:introduction:intro.adoc


### PR DESCRIPTION
Update `docs-site` with `git pull` to use this.

Extracts the preview from antora.yml to a `preview/{branch}.yml` config instead to tidy things up.