### PR TITLE
DOC-13223 sizing guidelines, note on residentRatio

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/index-partitioning.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/index-partitioning.adoc
@@ -532,7 +532,7 @@ Non-array fields will be ignored.
 | `50`
 |===
 
-WARNING: We recommend keeping residentRatio above 10% to avoid issues like index build failures.
+NOTE: We recommend keeping residentRatio above 10 to avoid issues like index build failures.
 
 To provide sizing estimation, you can use a command similar to the following examples.
 

--- a/modules/n1ql/pages/n1ql-language-reference/index-partitioning.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/index-partitioning.adoc
@@ -532,6 +532,8 @@ Non-array fields will be ignored.
 | `50`
 |===
 
+WARNING: We recommend keeping residentRatio above 10% to avoid issues like index build failures.
+
 To provide sizing estimation, you can use a command similar to the following examples.
 
 [.server]

--- a/modules/n1ql/pages/n1ql-language-reference/index-partitioning.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/index-partitioning.adoc
@@ -532,7 +532,7 @@ Non-array fields will be ignored.
 | `50`
 |===
 
-NOTE: We recommend keeping residentRatio above 10 to avoid issues like index build failures.
+NOTE: Couchbase recommends setting the residentRatio property value over 10 to avoid issues, for example, index build failures.
 
 To provide sizing estimation, you can use a command similar to the following examples.
 


### PR DESCRIPTION
Added a note to signal that low residentRatio values can lead to issues with indexing.

Linked to the server docs change here that gives guardrails info:

https://github.com/couchbase/docs-server/pull/3808