### PR TITLE
[DOC-12755] FTS Additional Document Filters 

### DIFF
--- a/modules/search/examples/run-search-full-request.jsonc
+++ b/modules/search/examples/run-search-full-request.jsonc
@@ -59,6 +59,7 @@
     // tag::ctl[]
     "ctl": {
         "timeout": 10000,
+        "partition_selection": "local",
         // tag::consistency[]
         "consistency": {
             // tag::vectors[]

--- a/modules/search/pages/search-request-params.adoc
+++ b/modules/search/pages/search-request-params.adoc
@@ -1972,19 +1972,22 @@ err: query_validate: field not indexed, field: ratings.Cleanliness, type: number
 
 [.status]#Couchbase Server 8.0#
 
-If your Search index is configured with partitions, add the `partition_selection` property to choose how the Search Service selects the partitions to search for your Search query: 
+If your Search index is configured with partitions and replicas, add the `partition_selection` property to choose how the Search Service selects the partitions to search for your Search query: 
 
-* `""`: The Search Service targets only active partitions, or the partitions currently being used to serve Search requests.
-* `"local"`: The Search Service targets all available partitions. 
-If a partition for your Search index isn't available on the coordinator node, the Search Service looks for the partition within the node's xref:manage:manage-groups/manage-groups.adoc[Server Group].
-If the Search Service still cannot find the partition, then it chooses a random node.
-* `"local_only"`: The Search Service targets all available partitions.
-If a partition for your Search index isn't available on the coordinator node, the Search Service looks for the partition within the node's xref:manage:manage-groups/manage-groups.adoc[Server Group].
+* `""`: The Search Service targets only active partitions or replicas.
+Active partitions are the partitions currently being used to serve Search requests.
+* `"local"`: The Search Service targets all active or replica partitions, local to the coordinator node. 
+If the required Search index partition for a query is not available on the coordinator node, the Search Service looks for the partition within the node's xref:manage:manage-groups/manage-groups.adoc[Server Group].
+If the Search Service still cannot find the partition, then it chooses a random node in the cluster that's running the Search Service, that contains the correct active or replica partition.
+* `"local_only"`: The Search Service targets all active or replica partitions, local to the coordinator node.
+If the required Search index partition for a query is not available on the coordinator node, the Search Service looks for the partition within the node's xref:manage:manage-groups/manage-groups.adoc[Server Group].
 If the Search Service still cannot find the partition, then the query returns partial results.
-* `"random"`: The Search Service chooses a random node for the Search query, whether active or a replica.
+* `"random"`: The Search Service chooses a random node that contains the required active or replica partition needed for the Search query.
 * `"random_balanced"`: The Search Service tries to choose a node that is not already serving a Search request.
-If the Search Service cannot find a node, it defaults to a random node.
+If the Search Service cannot find an available, it defaults to a random node with the correct partition or replica.
 This mode is designed to keep the number of query handling partitions per node the same. 
+
+For more information about how to configure partitions and replicas on your Search index, see xref:set-advanced-settings.adoc[] or xref:search-index-params.adoc#planparams[planParams Object].
 
 |====
 

--- a/modules/search/pages/search-request-params.adoc
+++ b/modules/search/pages/search-request-params.adoc
@@ -137,19 +137,23 @@ Both properties are included in the example code to show the correct syntax.
 
 Use `search_after` with `from/offset` and `sort` to control pagination in search results. 
 
-Give a value for each string or JSON object in the <<sort_arr,sort array>> to the `search_after` array.
-You must provide the values in the same order that they appear in the <<sort_arr,sort array>>.
-Values in the `search_after` array must be strings.
-You cannot use `search_after` with numbers or other field data types - if your `sort` array includes fields with a `date` or `number` type, you cannot use `search_after`. 
-Only result relevancy score values can be entered as strings in the array. 
+Give a value for each string or JSON object in the <<sort_arr,sort array>> to the `search_after` array. 
+You must provide the values in the same order that they appear in the `sort` array. 
+Your `sort` array must force a total order on your search results. 
+
+Values in the `search_after` array must be strings. 
+You cannot use `search_after` with numbers or other field data types - if your `sort` array includes fields with a date or number type, you cannot use `search_after`. 
+Only result relevancy score values can be entered as strings in the array.
 
 The Search Service starts search result pagination after the document with the values you provide in the array.
 
-Use `search_after` to make the memory requirements of deeper page searches more manageable, when compared to using only `from/offset`.
-`search_after` lets you start your search results from a specific result, rather than needing to process a number of search results to skip.
+For example, if you had a set of 10 documents to sort based on `_id` values of 1-10, with `from` set to `2` and `search_after` set to `8`, documents 9-10 appear on the same page.
 
-To reduce the resource costs of deeper pagination on your Search queries, try to always include your document ID values as the final sort criteria in your <<sort_arr,sort array>>. 
-Set the `search_after` property to include the values from the last result on your previous page of search results to effectively paginate. 
+To reduce the resource costs of deeper pagination on your Search queries, try to always include your document ID values as the final sort criteria in your `sort` array. 
+Set the `search_after` property to include the values from the last result on your previous page of search results to effectively paginate.
+
+Use `search_after` to make the memory requirements of deeper page searches more manageable, when compared to using only `from`/`offset`. 
+`search_after` lets you start your search results from a specific result, rather than needing to process a number of search results to skip.
 
 |[[search_before]]search_before |Array |No a|
 
@@ -158,18 +162,23 @@ Both properties are included in the example code to show the correct syntax.
 
 Use `search_before` with `from/offset` and `sort` to control pagination in search results.
 
-Give a value for each string or JSON object in the `sort` array to the `search_before` array.
+Give a value for each string or JSON object in the <<sort_arr,sort array>> to the `search_before` array. 
 You must provide the values in the same order that they appear in the `sort` array.
+Your `sort` array must force a total order on your search results. 
+
 Values in the `search_before` array must be strings.
-You cannot use `search_before` with numbers or other field data types - if your `sort` array includes fields with a `date` or `number` type, you cannot use `search_before`. 
+You cannot use `search_before` with numbers or other field data types - if your `sort` array includes fields with a date or number type, you cannot use `search_before`.
 Only result relevancy score values can be entered as strings in the array.
 
-The Search Service starts search result pagination before the document with the values you provide in the array.   
+The Search Service starts search result pagination before the document with the values you provide in the array.
 
 For example, if you had a set of 10 documents to sort based on `_id` values of 1-10, with `from` set to `2` and `search_before` set to `8`, documents 2-6 appear on the same page.
 
-To reduce the resource costs of deeper pagination on your Search queries, try to always include your document ID values as the final sort criteria in your <<sort_arr,sort array>>. 
-Set the `search_before` property to include the values from the last result on your previous page of search results to effectively paginate. 
+To reduce the resource costs of deeper pagination on your Search queries, try to always include your document ID values as the final sort criteria in your `sort` array.
+Set the `search_before` property to include the values from the last result on your previous page of search results to effectively paginate.
+
+Use `search_before` to make the memory requirements of deeper page searches more manageable, when compared to using only `from`/`offset`.
+`search_before` lets you start your search results back from a specific result, rather than needing to process a number of search results to skip.
 
 |[[collections]]collections |Array |No |Contains an array of strings that specify the collections where you want to run the query. 
 

--- a/modules/search/pages/search-request-params.adoc
+++ b/modules/search/pages/search-request-params.adoc
@@ -39,9 +39,10 @@ For more information about how to configure the objects inside a `knn` array, se
 
 |ctl |Object |No a|
 
-An object that contains properties for query consistency. 
+An object that contains properties for query consistency.
+Depending on your version of Couchbase Server, the `ctl` object can also validate Search queries or choose specific Search index partitions for a query.
 
-For more information about how to configure Search query consistency inside the `ctl` object, see <<ctl,>>.
+For more information about how to configure the `ctl` object, see <<ctl,>>.
 
 |[[size-limit]]size/limit |Integer |No a|
 
@@ -56,7 +57,6 @@ The Search Service returns the `size` number of results:
 * Starting backward from the key specified in the <<search_before,search_before property>>.
 
 The `size` property is added by default to all Search requests, if not otherwise specified, with a value of `10`.
-
 If you do not provide a `from`, `size`, or other pagination settings in your query, the Search Service defaults to a `size` value of `10` and a `from` value of `0`.
 This means the Search Service does not offset results, and returns the first `10` matches to your query.
 
@@ -67,10 +67,10 @@ Set an offset value to change where pagination starts for search results, based 
 For example, if you set a `size` value of `5` and a `from` value of `10`, the Search query returns results 11 through 15 on a page. 
 
 If you provide both the `from` and `offset` properties, the Search Service uses the `from` value.
-If you do not provide a `from`, `size`, or other pagination settings in your query, the Search Service defaults to a `size` value of `10` and a `from` value of `0`.
-This means the Search Service does not offset results, and returns the first `10` matches to your query.
 
 The `from` property is added by default to all Search requests, if not otherwise specified, with a value of `0`.
+If you do not provide a `from`, `size`, or other pagination settings in your query, the Search Service defaults to a `size` value of `10` and a `from` value of `0`.
+This means the Search Service does not offset results, and returns the first `10` matches to your query.
 
 |highlight |Object |No a|
 
@@ -132,7 +132,8 @@ To turn on document relevancy scoring in search results, remove the `score` prop
 
 |[[search_after]]search_after |Array |No a|
 
-NOTE: If you use `search_after` in a search request, you cannot use `search_before`. Both properties are included in the example code to show the correct syntax.
+NOTE: If you use `search_after` in a search request, you cannot use `search_before`.
+Both properties are included in the example code to show the correct syntax.
 
 Use `search_after` with `from/offset` and `sort` to control pagination in search results. 
 
@@ -150,7 +151,10 @@ Use `search_after` to make the memory requirements of deeper page searches more 
 To reduce the resource costs of deeper pagination on your Search queries, try to always include your document ID values as the final sort criteria in your <<sort_arr,sort array>>. 
 Set the `search_after` property to include the values from the last result on your previous page of search results to effectively paginate. 
 
-NOTE: If you use `search_before` in a search request, you cannot use `search_after`. Both properties are included in the example code to show the correct syntax.
+|[[search_before]]search_before |Array |No a|
+
+NOTE: If you use `search_before` in a search request, you cannot use `search_after`.
+Both properties are included in the example code to show the correct syntax.
 
 Use `search_before` with `from/offset` and `sort` to control pagination in search results.
 
@@ -1920,7 +1924,8 @@ include::example$query-analytic.jsonc[tag=match_prefix_length]
 [#ctl]
 == Ctl Object 
 
-Use the `ctl` object to make sure that the Search Service runs your Search query against the latest version of the documents in your cluster. 
+Use the `ctl` object to make sure that the Search Service runs your Search query against the latest version of the documents in your database.
+As of Couchbase Server version 8.0 and later, you can also use it to control which replica partition the Search Service uses to find results for a query. 
 
 The `ctl` object and its properties cause the Search Service to run your query against the latest version of a document written to a xref:server:learn:buckets-memory-and-storage/vbuckets.adoc[vBucket].  
 The Search Service uses a consistency vector to synchronize the last document write to a vBucket from the Data Service with the Search index.
@@ -1962,6 +1967,24 @@ For example, the Search Service can tell you through the Web Console or the REST
 ----
 err: query_validate: field not indexed, field: ratings.Cleanliness, type: number
 ----
+
+|partition_selection |String |No a|
+
+[.status]#Couchbase Server 8.0#
+
+If your Search index is configured with partitions, add the `partition_selection` property to choose how the Search Service selects the partitions to search for your Search query: 
+
+* `""`: The Search Service targets only active partitions, or the partitions currently being used to serve Search requests.
+* `"local"`: The Search Service targets all available partitions. 
+If a partition for your Search index isn't available on the coordinator node, the Search Service looks for the partition within the node's xref:manage:manage-groups/manage-groups.adoc[Server Group].
+If the Search Service still cannot find the partition, then it chooses a random node.
+* `"local_only"`: The Search Service targets all available partitions.
+If a partition for your Search index isn't available on the coordinator node, the Search Service looks for the partition within the node's xref:manage:manage-groups/manage-groups.adoc[Server Group].
+If the Search Service still cannot find the partition, then the query returns partial results.
+* `"random"`: The Search Service chooses a random node for the Search query, whether active or a replica.
+* `"random_balanced"`: The Search Service tries to choose a node that is not already serving a Search request.
+If the Search Service cannot find a node, it defaults to a random node.
+This mode is designed to keep the number of query handling partitions per node the same. 
 
 |====
 

--- a/modules/search/pages/search-request-params.adoc
+++ b/modules/search/pages/search-request-params.adoc
@@ -138,13 +138,13 @@ Both properties are included in the example code to show the correct syntax.
 
 Use `search_after` with `from/offset` and `sort` to control pagination in search results. 
 
-Give a value for each string or JSON object in the <<sort_arr,sort array>> to the `search_after` array. 
-You must provide the values in the same order that they appear in the `sort` array. 
-Your `sort` array must force a total order on your search results. 
+Give a value for each string or JSON object in the <<sort_arr,sort array>> to the `search_after` array.
+You must provide the values in the same order that they appear in the <<sort_arr,sort array>>.
+Your `sort` array must force a total order on your search results.
 
-Values in the `search_after` array must be strings. 
-You cannot use `search_after` with numbers or other field data types - if your `sort` array includes fields with a date or number type, you cannot use `search_after`. 
-Only result relevancy score values can be entered as strings in the array.
+Values in the `search_after` array must be strings.
+You cannot use `search_after` with numbers or other field data types - if your `sort` array includes fields with a `date` or `number` type, you cannot use `search_after`. 
+Only result relevancy score values can be entered as strings in the array. 
 
 The Search Service starts search result pagination after the document with the values you provide in the array.
 
@@ -165,7 +165,7 @@ Use `search_before` with `from/offset` and `sort` to control pagination in searc
 
 Give a value for each string or JSON object in the <<sort_arr,sort array>> to the `search_before` array. 
 You must provide the values in the same order that they appear in the `sort` array.
-Your `sort` array must force a total order on your search results. 
+Your `sort` array must force a total order on your search results.
 
 Values in the `search_before` array must be strings.
 You cannot use `search_before` with numbers or other field data types - if your `sort` array includes fields with a date or number type, you cannot use `search_before`.
@@ -175,8 +175,8 @@ The Search Service starts search result pagination before the document with the 
 
 For example, if you had a set of 10 documents to sort based on `_id` values of 1-10, with `from` set to `2` and `search_before` set to `8`, documents 2-6 appear on the same page.
 
-To reduce the resource costs of deeper pagination on your Search queries, try to always include your document ID values as the final sort criteria in your `sort` array.
-Set the `search_before` property to include the values from the last result on your previous page of search results to effectively paginate.
+To reduce the resource costs of deeper pagination on your Search queries, try to always include your document ID values as the final sort criteria in your `sort` array. 
+Set the `search_before` property to include the values from the last result on your previous page of search results to effectively paginate. 
 
 Use `search_before` to make the memory requirements of deeper page searches more manageable, when compared to using only `from`/`offset`.
 `search_before` lets you start your search results back from a specific result, rather than needing to process a number of search results to skip.

--- a/modules/search/pages/search-request-params.adoc
+++ b/modules/search/pages/search-request-params.adoc
@@ -68,9 +68,10 @@ For example, if you set a `size` value of `5` and a `from` value of `10`, the Se
 
 If you provide both the `from` and `offset` properties, the Search Service uses the `from` value.
 
-The `from` property is added by default to all Search requests, if not otherwise specified, with a value of `0`.
 If you do not provide a `from`, `size`, or other pagination settings in your query, the Search Service defaults to a `size` value of `10` and a `from` value of `0`.
 This means the Search Service does not offset results, and returns the first `10` matches to your query.
+
+The `from` property is added by default to all Search requests, if not otherwise specified, with a value of `0`.
 
 |highlight |Object |No a|
 

--- a/preview/HEAD.yml
+++ b/preview/HEAD.yml
@@ -1,5 +1,5 @@
 sources:
   docs-server:
-    branches: [release/7.6]
+    branches: [release/8.0]
 override:
   startPage: server:introduction:intro.adoc


### PR DESCRIPTION
Adding documentation for the Server 8.0 release, for additional document filters on FTS Search indexes.

Preview site links:

https://preview.docs-test.couchbase.com/docs-devex-DOC-12754-fts-8-0-additional-filters/server/current/search/create-search-index-rest-api.html#example-search-index-with-custom-document-filter

https://preview.docs-test.couchbase.com/docs-devex-DOC-12754-fts-8-0-additional-filters/server/current/search/search-index-params.html#doc-config

https://preview.docs-test.couchbase.com/docs-devex-DOC-12754-fts-8-0-additional-filters/server/current/search/customize-index.html

https://preview.docs-test.couchbase.com/docs-devex-DOC-12754-fts-8-0-additional-filters/server/current/search/create-type-mapping.html

https://preview.docs-test.couchbase.com/docs-devex-DOC-12754-fts-8-0-additional-filters/server/current/search/set-type-identifier.html

Preview site credentials: https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords