### PR TITLE
[DOC-12755] FTS Searching Replica Partitions

### DIFF
--- a/modules/search/examples/run-search-full-request.jsonc
+++ b/modules/search/examples/run-search-full-request.jsonc
@@ -59,6 +59,7 @@
     // tag::ctl[]
     "ctl": {
         "timeout": 10000,
+        "partition_selection": "local",
         // tag::consistency[]
         "consistency": {
             // tag::vectors[]

--- a/modules/search/pages/search-request-params.adoc
+++ b/modules/search/pages/search-request-params.adoc
@@ -1993,17 +1993,18 @@ The setting has no effect if your `scoring_model` is set to `tfidf`.
 
 If your Search index is configured with partitions and replicas, add the `partition_selection` property to choose how the Search Service selects the partitions to search for your Search query: 
 
-* `""`: The Search Service targets only active partitions or replicas.
+* `""`: The Search Service targets only active partitions.
 Active partitions are the partitions currently being used to serve Search requests.
+This is the default setting.
 * `"local"`: The Search Service targets all active or replica partitions, local to the coordinator node. 
 If the required Search index partition for a query is not available on the coordinator node, the Search Service looks for the partition within the node's xref:manage:manage-groups/manage-groups.adoc[Server Group].
 If the Search Service still cannot find the partition, then it chooses a random node in the cluster that's running the Search Service, that contains the correct active or replica partition.
 * `"local_only"`: The Search Service targets all active or replica partitions, local to the coordinator node.
 If the required Search index partition for a query is not available on the coordinator node, the Search Service looks for the partition within the node's xref:manage:manage-groups/manage-groups.adoc[Server Group].
 If the Search Service still cannot find the partition, then the query returns partial results.
-* `"random"`: The Search Service chooses a random node that contains the required active or replica partition needed for the Search query.
+* `"random"`: The Search Service chooses a random selection of partitions from local and remote nodes for the Search query.
 * `"random_balanced"`: The Search Service tries to choose a node that is not already serving a Search request.
-If the Search Service cannot find an available, it defaults to a random node with the correct partition or replica.
+If the Search Service cannot find an available node, it defaults to a random node with the correct partition or replica.
 This mode is designed to keep the number of query handling partitions per node the same. 
 
 For more information about how to configure partitions and replicas on your Search index, see xref:set-advanced-settings.adoc[] or xref:search-index-params.adoc#planparams[planParams Object].

--- a/modules/search/pages/search-request-params.adoc
+++ b/modules/search/pages/search-request-params.adoc
@@ -1994,19 +1994,22 @@ The setting has no effect if your `scoring_model` is set to `tfidf`.
 
 [.status]#Couchbase Server 8.0#
 
-If your Search index is configured with partitions, add the `partition_selection` property to choose how the Search Service selects the partitions to search for your Search query: 
+If your Search index is configured with partitions and replicas, add the `partition_selection` property to choose how the Search Service selects the partitions to search for your Search query: 
 
-* `""`: The Search Service targets only active partitions, or the partitions currently being used to serve Search requests.
-* `"local"`: The Search Service targets all available partitions. 
-If a partition for your Search index isn't available on the coordinator node, the Search Service looks for the partition within the node's xref:manage:manage-groups/manage-groups.adoc[Server Group].
-If the Search Service still cannot find the partition, then it chooses a random node.
-* `"local_only"`: The Search Service targets all available partitions.
-If a partition for your Search index isn't available on the coordinator node, the Search Service looks for the partition within the node's xref:manage:manage-groups/manage-groups.adoc[Server Group].
+* `""`: The Search Service targets only active partitions or replicas.
+Active partitions are the partitions currently being used to serve Search requests.
+* `"local"`: The Search Service targets all active or replica partitions, local to the coordinator node. 
+If the required Search index partition for a query is not available on the coordinator node, the Search Service looks for the partition within the node's xref:manage:manage-groups/manage-groups.adoc[Server Group].
+If the Search Service still cannot find the partition, then it chooses a random node in the cluster that's running the Search Service, that contains the correct active or replica partition.
+* `"local_only"`: The Search Service targets all active or replica partitions, local to the coordinator node.
+If the required Search index partition for a query is not available on the coordinator node, the Search Service looks for the partition within the node's xref:manage:manage-groups/manage-groups.adoc[Server Group].
 If the Search Service still cannot find the partition, then the query returns partial results.
-* `"random"`: The Search Service chooses a random node for the Search query, whether active or a replica.
+* `"random"`: The Search Service chooses a random node that contains the required active or replica partition needed for the Search query.
 * `"random_balanced"`: The Search Service tries to choose a node that is not already serving a Search request.
-If the Search Service cannot find a node, it defaults to a random node.
+If the Search Service cannot find an available, it defaults to a random node with the correct partition or replica.
 This mode is designed to keep the number of query handling partitions per node the same. 
+
+For more information about how to configure partitions and replicas on your Search index, see xref:set-advanced-settings.adoc[] or xref:search-index-params.adoc#planparams[planParams Object].
 
 |====
 

--- a/modules/search/pages/search-request-params.adoc
+++ b/modules/search/pages/search-request-params.adoc
@@ -57,6 +57,7 @@ The Search Service returns the `size` number of results:
 * Starting backward from the key specified in the <<search_before,search_before property>>.
 
 The `size` property is added by default to all Search requests, if not otherwise specified, with a value of `10`.
+
 If you do not provide a `from`, `size`, or other pagination settings in your query, the Search Service defaults to a `size` value of `10` and a `from` value of `0`.
 This means the Search Service does not offset results, and returns the first `10` matches to your query.
 
@@ -67,10 +68,10 @@ Set an offset value to change where pagination starts for search results, based 
 For example, if you set a `size` value of `5` and a `from` value of `10`, the Search query returns results 11 through 15 on a page. 
 
 If you provide both the `from` and `offset` properties, the Search Service uses the `from` value.
-
-The `from` property is added by default to all Search requests, if not otherwise specified, with a value of `0`.
 If you do not provide a `from`, `size`, or other pagination settings in your query, the Search Service defaults to a `size` value of `10` and a `from` value of `0`.
 This means the Search Service does not offset results, and returns the first `10` matches to your query.
+
+The `from` property is added by default to all Search requests, if not otherwise specified, with a value of `0`.
 
 |highlight |Object |No a|
 
@@ -132,8 +133,7 @@ To turn on document relevancy scoring in search results, remove the `score` prop
 
 |[[search_after]]search_after |Array |No a|
 
-NOTE: If you use `search_after` in a search request, you cannot use `search_before`.
-Both properties are included in the example code to show the correct syntax.
+NOTE: If you use `search_after` in a search request, you cannot use `search_before`. Both properties are included in the example code to show the correct syntax.
 
 Use `search_after` with `from/offset` and `sort` to control pagination in search results. 
 
@@ -157,10 +157,7 @@ Use `search_after` to make the memory requirements of deeper page searches more 
 
 |[[search_before]]search_before |Array |No a|
 
-|[[search_before]]search_before |Array |No a|
-
-NOTE: If you use `search_before` in a search request, you cannot use `search_after`.
-Both properties are included in the example code to show the correct syntax.
+NOTE: If you use `search_before` in a search request, you cannot use `search_after`. Both properties are included in the example code to show the correct syntax.
 
 Use `search_before` with `from/offset` and `sort` to control pagination in search results.
 
@@ -1935,7 +1932,7 @@ include::example$query-analytic.jsonc[tag=match_prefix_length]
 [#ctl]
 == Ctl Object 
 
-Use the `ctl` object to make sure that the Search Service runs your Search query against the latest version of the documents in your database.
+Use the `ctl` object to make sure that the Search Service runs your Search query against the latest version of the documents in your cluster.
 As of Couchbase Server version 8.0 and later, you can also use it to control which replica partition the Search Service uses to find results for a query. 
 
 The `ctl` object and its properties cause the Search Service to run your query against the latest version of a document written to a xref:server:learn:buckets-memory-and-storage/vbuckets.adoc[vBucket].  

--- a/modules/search/pages/search-request-params.adoc
+++ b/modules/search/pages/search-request-params.adoc
@@ -39,9 +39,10 @@ For more information about how to configure the objects inside a `knn` array, se
 
 |ctl |Object |No a|
 
-An object that contains properties for query consistency. 
+An object that contains properties for query consistency.
+Depending on your version of Couchbase Server, the `ctl` object can also validate Search queries or choose specific Search index partitions for a query.
 
-For more information about how to configure Search query consistency inside the `ctl` object, see <<ctl,>>.
+For more information about how to configure the `ctl` object, see <<ctl,>>.
 
 |[[size-limit]]size/limit |Integer |No a|
 
@@ -56,7 +57,6 @@ The Search Service returns the `size` number of results:
 * Starting backward from the key specified in the <<search_before,search_before property>>.
 
 The `size` property is added by default to all Search requests, if not otherwise specified, with a value of `10`.
-
 If you do not provide a `from`, `size`, or other pagination settings in your query, the Search Service defaults to a `size` value of `10` and a `from` value of `0`.
 This means the Search Service does not offset results, and returns the first `10` matches to your query.
 
@@ -67,10 +67,10 @@ Set an offset value to change where pagination starts for search results, based 
 For example, if you set a `size` value of `5` and a `from` value of `10`, the Search query returns results 11 through 15 on a page. 
 
 If you provide both the `from` and `offset` properties, the Search Service uses the `from` value.
-If you do not provide a `from`, `size`, or other pagination settings in your query, the Search Service defaults to a `size` value of `10` and a `from` value of `0`.
-This means the Search Service does not offset results, and returns the first `10` matches to your query.
 
 The `from` property is added by default to all Search requests, if not otherwise specified, with a value of `0`.
+If you do not provide a `from`, `size`, or other pagination settings in your query, the Search Service defaults to a `size` value of `10` and a `from` value of `0`.
+This means the Search Service does not offset results, and returns the first `10` matches to your query.
 
 |highlight |Object |No a|
 
@@ -132,7 +132,8 @@ To turn on document relevancy scoring in search results, remove the `score` prop
 
 |[[search_after]]search_after |Array |No a|
 
-NOTE: If you use `search_after` in a search request, you cannot use `search_before`. Both properties are included in the example code to show the correct syntax.
+NOTE: If you use `search_after` in a search request, you cannot use `search_before`.
+Both properties are included in the example code to show the correct syntax.
 
 Use `search_after` with `from/offset` and `sort` to control pagination in search results. 
 
@@ -156,7 +157,10 @@ Use `search_after` to make the memory requirements of deeper page searches more 
 
 |[[search_before]]search_before |Array |No a|
 
-NOTE: If you use `search_before` in a search request, you cannot use `search_after`. Both properties are included in the example code to show the correct syntax.
+|[[search_before]]search_before |Array |No a|
+
+NOTE: If you use `search_before` in a search request, you cannot use `search_after`.
+Both properties are included in the example code to show the correct syntax.
 
 Use `search_before` with `from/offset` and `sort` to control pagination in search results.
 
@@ -1931,7 +1935,8 @@ include::example$query-analytic.jsonc[tag=match_prefix_length]
 [#ctl]
 == Ctl Object 
 
-Use the `ctl` object to make sure that the Search Service runs your Search query against the latest version of the documents in your cluster. 
+Use the `ctl` object to make sure that the Search Service runs your Search query against the latest version of the documents in your database.
+As of Couchbase Server version 8.0 and later, you can also use it to control which replica partition the Search Service uses to find results for a query. 
 
 The `ctl` object and its properties cause the Search Service to run your query against the latest version of a document written to a xref:server:learn:buckets-memory-and-storage/vbuckets.adoc[vBucket].  
 The Search Service uses a consistency vector to synchronize the last document write to a vBucket from the Data Service with the Search index.
@@ -1984,6 +1989,24 @@ If you do not use `global_scoring`, result ordering can change based on your Sea
 
 You can only use `global_scoring` if you're using the xref:run-searches.adoc#bm25[bm25 scoring algorithm].
 The setting has no effect if your `scoring_model` is set to `tfidf`.
+
+|partition_selection |String |No a|
+
+[.status]#Couchbase Server 8.0#
+
+If your Search index is configured with partitions, add the `partition_selection` property to choose how the Search Service selects the partitions to search for your Search query: 
+
+* `""`: The Search Service targets only active partitions, or the partitions currently being used to serve Search requests.
+* `"local"`: The Search Service targets all available partitions. 
+If a partition for your Search index isn't available on the coordinator node, the Search Service looks for the partition within the node's xref:manage:manage-groups/manage-groups.adoc[Server Group].
+If the Search Service still cannot find the partition, then it chooses a random node.
+* `"local_only"`: The Search Service targets all available partitions.
+If a partition for your Search index isn't available on the coordinator node, the Search Service looks for the partition within the node's xref:manage:manage-groups/manage-groups.adoc[Server Group].
+If the Search Service still cannot find the partition, then the query returns partial results.
+* `"random"`: The Search Service chooses a random node for the Search query, whether active or a replica.
+* `"random_balanced"`: The Search Service tries to choose a node that is not already serving a Search request.
+If the Search Service cannot find a node, it defaults to a random node.
+This mode is designed to keep the number of query handling partitions per node the same. 
 
 |====
 


### PR DESCRIPTION
Adding documentation for Server 8.0 updates, changing functionality around searching specific index partitions. 

Preview site: 

* https://preview.docs-test.couchbase.com/docs-devex-DOC-12755-fts-8-0-search-replica-partitions/server/current/search/search-request-params.html#ctl

Preview site credentials: 
https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords