### PR TITLE
[DOC-12753] FTS BM25 Scoring Algorithm

### DIFF
--- a/modules/search/examples/autocomplete-search-index.jsonc
+++ b/modules/search/examples/autocomplete-search-index.jsonc
@@ -54,6 +54,7 @@
         "default_type": "_default",
         "docvalues_dynamic": false,
         "index_dynamic": true,
+        "scoring_model": "tfidf",
         "store_dynamic": false,
         "type_field": "_type",
         "types": {

--- a/modules/search/examples/complex-search-index-payload.jsonc
+++ b/modules/search/examples/complex-search-index-payload.jsonc
@@ -154,6 +154,7 @@
     "default_type": "_default",
     "docvalues_dynamic": true,
     "index_dynamic": true,
+    "scoring_model": "tfidf",
     "store_dynamic": true,
     "type_field": "_type",
     "types": {

--- a/modules/search/examples/create-search-index-payload.sh
+++ b/modules/search/examples/create-search-index-payload.sh
@@ -29,6 +29,7 @@ curl -s -XPUT -H "Content-Type: application/json" \
           "default_type": "_default",
           "docvalues_dynamic": false,
           "index_dynamic": true,
+          "scoring_model": "tfidf",
           "store_dynamic": false,
           "type_field": "_type",
           "types": {

--- a/modules/search/examples/geospatial-search-index.jsonc
+++ b/modules/search/examples/geospatial-search-index.jsonc
@@ -26,6 +26,7 @@
         "default_type": "_default",
         "docvalues_dynamic": false,
         "index_dynamic": true,
+        "scoring_model": "tfidf",
         "store_dynamic": false,
         "type_field": "_type",
         "types": {

--- a/modules/search/examples/run-search-full-request.jsonc
+++ b/modules/search/examples/run-search-full-request.jsonc
@@ -73,7 +73,8 @@
             "results": "complete"
         },
         // end::consistency[]
-        "validate": true
+        "validate": true,
+        "global_scoring": true
     },
     // end::ctl[]
     "size": 10,

--- a/modules/search/examples/simple-search-index-payload.jsonc
+++ b/modules/search/examples/simple-search-index-payload.jsonc
@@ -148,6 +148,7 @@
             "default_type": "_default",
             "docvalues_dynamic": true,
             "index_dynamic": true,
+            "scoring_model": "bm25",
             "store_dynamic": true,
             "type_field": "_type",
             // tag::types[]

--- a/modules/search/pages/run-searches.adoc
+++ b/modules/search/pages/run-searches.adoc
@@ -26,8 +26,19 @@ To run a Search query against multiple Search indexes at once, xref:create-searc
 [#scoring]
 == Scoring for Search Queries 
 
-To determine a document's score in search results, the Search Service uses the https://en.wikipedia.org/wiki/Tf%E2%80%93idf[tf-idf^] algorithm. 
-`tf-idf` increases the score of a document based on term frequency, or the number of times a term appears in a document divided by the total number of terms in the document. 
+As of Couchbase Server version 8.0, you can choose between 2 scoring algorithms for your Search index: 
+
+* <<tf-idf,tf-idf>>
+* <<bm25,bm25>>
+
+TIP: Scoring can also change based on whether you're using synonyms in your Search index.
+For more information, see xref:synoynms/synonyms-search.adoc#run-synonym-search[Running a Search for Synonyms].
+
+[#tf-idf]
+=== tf-idf Search Scoring
+
+To determine a document's score in search results, the Search Service can use the https://en.wikipedia.org/wiki/Tf%E2%80%93idf[tf-idf^] algorithm. 
+`tf-idf` increases the score of a document based on term frequency, or the number of times a term occurs in a document divided by the total number of terms in the document. 
 It penalizes document frequency, or how often a term appears across all documents. 
 
 The `tf-idf` score is calculated at a partition level in a Search index. 
@@ -46,12 +57,44 @@ hit_score = (query_1_boost * query_1_hit_score) + (knn_boost * knn_distance)
 
 When running a hybrid search with the <<ui,{page-ui-name}>> or <<api,REST API>>, the Search Service displays results as a disjunct (`OR`) between your regular Search and Vector Search queries. 
 
-TIP: When running a hybrid Search query, you should add a `boost` value to your regular Search query to level the `tf-idf` score with the knn distance.
+TIP: When running a hybrid Search query and the `tf-idf` algorithm, you should add a `boost` value to your regular Search query to level the `tf-idf` score with the knn distance.
 Otherwise, you might see unexpected search results.
 This is because of the differences in the scoring algorithms between the 2 query types.
 
-Scoring can also change based on whether you're using synonyms in your Search index.
-For more information, see xref:synoynms/synonyms-search.adoc#run-synonym-search[Running a Search for Synonyms].
+[#bm25]
+=== bm25 Search Scoring
+
+[.status]#Couchbase Server version 8.0#
+
+As of Couchbase Server version 8.0, you can choose to use the https://en.wikipedia.org/wiki/Okapi_BM25[bm25^] algorithm instead of `tf-idf` for your Search index.
+
+`bm25` ranks documents based on the query terms that appear in each document, regardless of proximity.
+It calculates the number of times a term occurs in a document, with penalties for more common terms like `tf-idf`, but also includes: 
+
+* Diminishing returns for a term that continues to frequently appear in documents, based on a saturation parameter (`k1`).
+* An adjustment to the resulting score, based on the total length of the current document field, divided by a normalized average length of the field across all documents (`b`).
+
+The value of `k1` limits just how much a single query term's frequency can affect the scoring of a document.
+The Search Service chooses reasonable defaults for the value of `k1` and `b`.
+
+Unlike `tf-idf`, `bm25` rewards term frequency, but penalizes document frequency.
+
+The calculation for a basic Search query is still based on the document's score for a query multiplied by any xref:search-request-params.adoc#boost[boost] parameters: 
+
+----
+hit_score = (query_1_boost * query_1_hit_score) + (query_2_boost * query_2_hit_score)
+----
+
+The calculation when running a hybrid Search query, that includes xref:vector-search:vector-search.adoc[a Vector Search query], is still: 
+
+----
+hit_score = (query_1_boost * query_1_hit_score) + (knn_boost * knn_distance)
+----
+
+When running a hybrid search with the <<ui,{page-ui-name}>> or <<api,REST API>>, the Search Service displays results as a disjunct (`OR`) between your regular Search and Vector Search queries. 
+
+`bm25` supports better hybrid search results and richer result rankings. 
+It also gives more stable result ordering across Search index partitions, when xref:search-request-params.adoc#global-scoring[`global_scoring`] is enabled.
 
 [#ui]
 == Run a Search with the {page-ui-name}

--- a/modules/search/pages/run-searches.adoc
+++ b/modules/search/pages/run-searches.adoc
@@ -75,6 +75,9 @@ It calculates the number of times a term occurs in a document, with penalties fo
 * An adjustment to the resulting score, based on the total length of the current document field, divided by a normalized average length of the field across all documents (`b`).
 
 The value of `k1` limits just how much a single query term's frequency can affect the scoring of a document.
+`k1` reduces the effect of term repetition and the risk of documents with excessively repeated content inflating your relevance scores.
+For example, spam or clickbait content would have reduced scores in `bm25` over the same document sentence being scored with `tf-idf`.
+
 The Search Service chooses reasonable defaults for the value of `k1` and `b`.
 
 Unlike `tf-idf`, `bm25` rewards term frequency, but penalizes document frequency.

--- a/modules/search/pages/run-searches.adoc
+++ b/modules/search/pages/run-searches.adoc
@@ -94,7 +94,7 @@ hit_score = (query_1_boost * query_1_hit_score) + (knn_boost * knn_distance)
 When running a hybrid search with the <<ui,{page-ui-name}>> or <<api,REST API>>, the Search Service displays results as a disjunct (`OR`) between your regular Search and Vector Search queries. 
 
 `bm25` supports better hybrid search results and richer result rankings. 
-It also gives more stable result ordering across Search index partitions, when xref:search-request-params.adoc#global-scoring[`global_scoring`] is enabled.
+It also gives more stable result ordering across Search index partitions, when xref:search-request-params.adoc#global_scoring[`global_scoring`] is enabled.
 
 [#ui]
 == Run a Search with the {page-ui-name}

--- a/modules/search/pages/search-index-params.adoc
+++ b/modules/search/pages/search-index-params.adoc
@@ -279,7 +279,7 @@ To exclude dynamic fields from the index, set `index_dynamic` to `false`.
 
 Choose the specific scoring model you want to use for scoring search results for this Search index:
 
-* `tfidf`: The classic scoring model for the Search Service.
+* `tfidf`: The standard scoring model for the Search Service.
 A higher tf-idf score for a document places that document higher in your search results.
 * `bm25`: A scoring model better suited to hybrid searches with the Search Service.
 A hybrid Search query uses xref:vector-search:vector-search.adoc[Vector Search] together with a standard Search query.

--- a/modules/search/pages/search-index-params.adoc
+++ b/modules/search/pages/search-index-params.adoc
@@ -273,6 +273,19 @@ To index any fields in the Search index where `dynamic` is `true`, set `index_dy
 
 To exclude dynamic fields from the index, set `index_dynamic` to `false`.
 
+|scoring_model |String |Yes a|
+
+[.status]#Couchbase Server 8.0#
+
+Choose the specific scoring model you want to use for scoring search results for this Search index:
+
+* `tfidf`: The classic scoring model for the Search Service.
+A higher tf-idf score for a document places that document higher in your search results.
+* `bm25`: A scoring model better suited to hybrid searches with the Search Service.
+A hybrid Search query uses xref:vector-search:vector-search.adoc[Vector Search] together with a standard Search query.
+
+For more information about the calculations for scoring for each algorithm, see xref:run-searches.adoc#scoring[Scoring for Search Queries].
+
 |store_dynamic |Boolean |Yes a|
 
 To return the content from an indexed field in the Search index, set `store_dynamic` to `true`.

--- a/modules/search/pages/search-request-params.adoc
+++ b/modules/search/pages/search-request-params.adoc
@@ -1974,6 +1974,17 @@ For example, the Search Service can tell you through the Web Console or the REST
 err: query_validate: field not indexed, field: ratings.Cleanliness, type: number
 ----
 
+|[[global_scoring]]global_scoring |Boolean |No a|
+
+[.status]#Couchbase Server 8.0#
+
+Add the `global_scoring` property with a value of `true` to ensure consistent and stable result ordering with the xref:run-searches.adoc#bm25[bm25 scoring algorithm], when you have a large, partitioned Search index.
+`global_scoring` aggregates document scoring across partitions to help maintain relative scoring, but uses more compute resources and increases search times.
+If you do not use `global_scoring`, result ordering can change based on your Search index's partition count.
+
+You can only use `global_scoring` if you're using the xref:run-searches.adoc#bm25[bm25 scoring algorithm].
+The setting has no effect if your `scoring_model` is set to `tfidf`.
+
 |====
 
 [#consistency]

--- a/modules/search/pages/set-advanced-settings.adoc
+++ b/modules/search/pages/set-advanced-settings.adoc
@@ -42,7 +42,7 @@ To set advanced settings for a Search index with the Couchbase {page-ui-name}:
 
 Choose the specific scoring model you want to use for scoring search results for this Search index:
 
-* `tfidf`: The classic scoring model for the Search Service.
+* `tfidf`: The standard scoring model for the Search Service.
 A higher tf-idf score for a document places that document higher in your search results.
 * `bm25`: A scoring model better suited to hybrid searches with the Search Service.
 A hybrid Search query uses xref:vector-search:vector-search.adoc[Vector Search] together with a standard Search query.

--- a/modules/search/pages/set-advanced-settings.adoc
+++ b/modules/search/pages/set-advanced-settings.adoc
@@ -36,6 +36,19 @@ To set advanced settings for a Search index with the Couchbase {page-ui-name}:
 |====
 |Option |Description 
 
+|Scoring Model a| 
+
+[.status]#Couchbase Server version 8.0#
+
+Choose the specific scoring model you want to use for scoring search results for this Search index:
+
+* `tfidf`: The classic scoring model for the Search Service.
+A higher tf-idf score for a document places that document higher in your search results.
+* `bm25`: A scoring model better suited to hybrid searches with the Search Service.
+A hybrid Search query uses xref:vector-search:vector-search.adoc[Vector Search] together with a standard Search query.
+
+For more information about the calculations for scoring for each algorithm, see xref:run-searches.adoc#scoring[Scoring for Search Queries].
+
 |Default Type |Change the default type assigned to documents in the index.
 The default value is `_default`.
 

--- a/modules/search/pages/simple-search-rest-api.adoc
+++ b/modules/search/pages/simple-search-rest-api.adoc
@@ -59,14 +59,16 @@ In the following example, the JSON payload queries an index named `landmark-cont
 include::example$run-search-payload.sh[]
 ----
 
-If the request is successful, the Search Service API starts by returning a status and a summary of the query request: 
+If the request is successful, the Search Service API starts by returning a status and a summary of the query request.
+Here, the status and `request` object match the previous example query: 
 
 [source,json]
 ----
 include::example$query-sample-results.jsonc[tag=query_summary]
 ----
 
-The Search Service returns an array, called `hits`, which contains objects that describe the matches found in each document in the Search index: 
+The Search Service returns an array, called `hits`, which contains objects that describe the matches found in each document in the Search index.
+For example, the first hit for the previous query describes matches in the document with the ID value `landmark_4428`: 
 
 [source,json]
 ----
@@ -75,7 +77,8 @@ include::example$query-sample-results.jsonc[tag=first_hit]
 
 The Search query set score explanations to `true`, so the Search Service shows how it calculated the score for each document. 
 
-It also includes the locations of each match, under the `locations` object: 
+It also includes the locations of each match, under the `locations` object.
+The `locations` object finds each occurrence of `beach`, `food`, and `view` inside the `content` field: 
 
 [source,json]
 ----
@@ -105,12 +108,8 @@ include::example$query-sample-results.jsonc[tag=end_summary]
 
 For more information about the available properties for a Search query JSON payload, see xref:search-request-params.adoc[].
 
-If the REST API call is successful, the Search Service returns a `200 OK` and the following JSON response: 
-
-[source,json]
-----
-include::example$run-search-response.json[]
-----
+If the REST API call is successful, the Search Service returns a `200 OK`. 
+To view the full response, click btn:[View] on any of the previous code samples.
 
 === Example: Validate a Search Request 
 

--- a/modules/vector-search/examples/create-vector-search-index-payload.sh
+++ b/modules/vector-search/examples/create-vector-search-index-payload.sh
@@ -31,6 +31,7 @@ curl -s -XPUT -H "Content-Type: application/json" \
         "docvalues_dynamic": false,
         "index_dynamic": false,
         "store_dynamic": false,
+        "scoring_model": "bm25",
         "type_field": "_type",
         "types": {
         "color.rgb": {

--- a/modules/vector-search/examples/run-global-scoring-vector-search-payload.sh
+++ b/modules/vector-search/examples/run-global-scoring-vector-search-payload.sh
@@ -1,0 +1,29 @@
+curl -XPOST -H "Content-Type: application/json" \
+  -u ${CB_USERNAME}:${CB_PASSWORD} http://${CB_HOSTNAME}:8094/api/bucket/e-commerce/scope/products/index/products-index/query \
+-d '{
+      "fields": ["description", "price", "product_name"],
+      "query": {
+        "conjuncts": [
+          {
+            "term": "Electronics",
+            "field": "category"
+          },
+          {
+            "field": "price",
+            "min": 100.00,
+            "max": 300.00,
+            "inclusive_max": true
+          }
+        ]
+      },
+      "knn": [
+        {
+          "k": 5,
+          "field": "embedding",
+          "vector": [0.23, -0.75, 0.61, ...]
+        }
+      ],
+      "ctl": {
+        "global_scoring": true
+      }
+    }'

--- a/modules/vector-search/examples/sample-vector-search-index-payload.json
+++ b/modules/vector-search/examples/sample-vector-search-index-payload.json
@@ -19,6 +19,7 @@
       "default_type": "_default",
       "docvalues_dynamic": false,
       "index_dynamic": true,
+      "scoring_model": "bm25",
       "store_dynamic": false,
       "type_field": "_type",
       "types": {

--- a/modules/vector-search/examples/vector-search-index-payload.jsonc
+++ b/modules/vector-search/examples/vector-search-index-payload.jsonc
@@ -26,6 +26,7 @@
       "default_type": "_default",
       "docvalues_dynamic": false,
       "index_dynamic": false,
+      "scoring_model": "bm25",
       "store_dynamic": false,
       "type_field": "_type",
       "types": {

--- a/modules/vector-search/pages/run-vector-search-rest-api.adoc
+++ b/modules/vector-search/pages/run-vector-search-rest-api.adoc
@@ -3,6 +3,7 @@
 :page-ui-name: {ui-name}
 :page-product-name: {product-name}
 :description: You can use the REST API and a curl command to run a search against an FTS Vector Index and return similar vectors.
+:page-toclevels: 3
 
 [abstract]
 {description}
@@ -56,7 +57,7 @@ To use SSL, use the `https` protocol in the Search Service endpoint URL and port
 TIP: You can copy the JSON for a Query Request from the Couchbase {page-ui-name} to use in your REST API call.
 For more information about how to perform a search with the UI, see xref:search:simple-search-ui.adoc[].
 
-=== Example
+=== Example: Hybrid Search for a Color Vector
 
 In the following example, the JSON payload uses both a `query` and `knn` object to run both a Vector Search and traditional Search query on an index named `color-index`.
 
@@ -80,6 +81,27 @@ If the REST API call is successful, the Search Service returns a `200 OK` and th
 ----
 include::example$run-vector-search-response.json[]
 ----
+
+=== Example: Use global_scoring With a bm25 Search Index
+
+In the following example, the JSON payload uses both a `query` and `knn` object to run both a Vector Search and traditional Search query on an index named `products-index`.
+
+The query searches for a specific embedding vector generated from an ecommerce website's product description, for a Search vector of the phrase `long battery life wireless earbuds`.
+The `query` object specifically searches for documents that have `Electronics` as their category, with a price between `100.00` and `300.00`.
+The query returns the `description`, `price`, and `product_name` fields in results.
+Since the query is on a large, partitioned index and uses the `bm25` scoring algorithm, the query also uses `global_scoring` to keep document scores consistent across the Search index's partitions:
+
+[source,console]
+----
+include::example$run-global-scoring-vector-search-payload.sh[]
+----
+
+NOTE: The vector embedding has been truncated for this example.
+The vector embedding in your Search query must match the configured dimension and similarity metric for your Search index.
+
+If the REST API call is successful, the Search Service returns a `200 OK`.
+
+For more information about the `bm25` scoring algorithm, see xref:search:run-searches.adoc#scoring[Scoring for Search Queries].
 
 == Next Steps 
 

--- a/modules/vector-search/pages/run-vector-search-rest-api.adoc
+++ b/modules/vector-search/pages/run-vector-search-rest-api.adoc
@@ -86,7 +86,8 @@ include::example$run-vector-search-response.json[]
 
 In the following example, the JSON payload uses both a `query` and `knn` object to run both a Vector Search and traditional Search query on an index named `products-index`.
 
-The query searches for a specific embedding vector generated from an ecommerce website's product description, for a Search vector of the phrase `long battery life wireless earbuds`.
+The query searches for a specific embedding vector generated from an ecommerce website's product description.
+The Search vector is generated from the phrase `long battery life wireless earbuds`.
 The `query` object specifically searches for documents that have `Electronics` as their category, with a price between `100.00` and `300.00`.
 The query returns the `description`, `price`, and `product_name` fields in results.
 Since the query is on a large, partitioned index and uses the `bm25` scoring algorithm, the query also uses `global_scoring` to keep document scores consistent across the Search index's partitions:

--- a/modules/vector-search/pages/run-vector-search-ui.adoc
+++ b/modules/vector-search/pages/run-vector-search-ui.adoc
@@ -77,6 +77,9 @@ If the same documents match the `knn` and `query` objects, the Search Service ra
 
 The document for the color `navy` should be the first result, followed by colors that are similar and match the `brightness` field query. 
 
+TIP: If you want to run a hybrid Search query on a large, partitioned Search index, use the `bm25` scoring model for your Search index.
+For more information, see xref:search:set-advanced-settings.adoc[].
+
 [#large]
 === Example: Running a Semantic Search Query with a Large Embedding Vector
 

--- a/modules/vector-search/pages/run-vector-search-ui.adoc
+++ b/modules/vector-search/pages/run-vector-search-ui.adoc
@@ -77,7 +77,7 @@ If the same documents match the `knn` and `query` objects, the Search Service ra
 
 The document for the color `navy` should be the first result, followed by colors that are similar and match the `brightness` field query. 
 
-TIP: If you want to run a hybrid Search query on a large, partitioned Search index, use the `bm25` scoring model for your Search index.
+TIP: If you want to run a hybrid Search query on a large, partitioned Search index and your cluster is on Couchbase Server version 8.0 or later, use the `bm25` scoring model for your Search index.
 For more information, see xref:search:set-advanced-settings.adoc[].
 
 [#large]


### PR DESCRIPTION
Adding documentation for Server 8.0, the new scoring algorithm for Search indexes called bm25. 

Preview site links: 

* https://preview.docs-test.couchbase.com/docs-devex-DOC-12753-fts-8-0-bm25-scoring/server/current/search/run-searches.html#scoring

* https://preview.docs-test.couchbase.com/docs-devex-DOC-12753-fts-8-0-bm25-scoring/server/current/search/search-index-params.html#mapping

* https://preview.docs-test.couchbase.com/docs-devex-DOC-12753-fts-8-0-bm25-scoring/server/current/search/search-request-params.html#ctl

* https://preview.docs-test.couchbase.com/docs-devex-DOC-12753-fts-8-0-bm25-scoring/server/current/search/set-advanced-settings.html

* https://preview.docs-test.couchbase.com/docs-devex-DOC-12753-fts-8-0-bm25-scoring/server/current/search/simple-search-rest-api.html

* https://preview.docs-test.couchbase.com/docs-devex-DOC-12753-fts-8-0-bm25-scoring/server/current/vector-search/run-vector-search-rest-api.html#example-use-global_scoring-with-a-bm25-search-index

* https://preview.docs-test.couchbase.com/docs-devex-DOC-12753-fts-8-0-bm25-scoring/server/current/vector-search/run-vector-search-ui.html#hybrid

Preview site credentials: 

https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords