### PR TITLE
[DOC-10001] Add new logging qualifiers to system:completed_requests

### DIFF
--- a/modules/n1ql/pages/n1ql-manage/monitoring-n1ql-query.adoc
+++ b/modules/n1ql/pages/n1ql-manage/monitoring-n1ql-query.adoc
@@ -717,6 +717,8 @@ A completed request is logged if _any_ of the qualifiers are met (logical OR).
 `client`:: Log requests from this IP address.
 `user`:: Log requests with this user name.
 `context`:: Log requests with this client context ID.
+`statement`:: Log requests that match the specified LIKE search pattern in the query text.
+`plan`:: Log requests where the specified plan field values appear in the query plan.
 
 For full details, see xref:n1ql-rest-admin:index.adoc#Logging_Parameters[Logging Parameters].
 

--- a/preview/DOC-10001-add-new-logging-qualifiers.yml
+++ b/preview/DOC-10001-add-new-logging-qualifiers.yml
@@ -1,10 +1,19 @@
 sources:
   docs-server:
     branches: [release/8.0]
-  docs-devex:
-    branches: [DOC-10001-add-new-logging-qualifiers]
-  cb-swagger:
-    branches: [DOC-10001-add-logging-params]
-    start_path: docs  
-override:
+  override:
   startPage: server:introduction:intro.adoc
+DOC-10001-add-new-logging-qualifiers:
+  sources:
+    docs-devex:
+      branches: [DOC-10001-add-new-logging-qualifiers]
+  override:
+    site:
+      startPage: server:develop:intro.adoc
+DOC-10001-add-logging-params:
+  sources:
+    cb-swagger:
+      branches: [DOC-10001-add-logging-params]
+  override:
+    site:
+      startPage: server:rest-api:rest-intro.adoc

--- a/preview/DOC-10001-add-new-logging-qualifiers.yml
+++ b/preview/DOC-10001-add-new-logging-qualifiers.yml
@@ -1,12 +1,7 @@
 sources:
-  docs-server:
-    branches: [release/8.0]
-  override:
-  startPage: server:introduction:intro.adoc
-DOC-10001-add-logging-params:
-  sources:
-    cb-swagger:
-      branches: [DOC-10001-add-logging-params]
-  override:
-    site:
-      startPage: server:rest-api:rest-intro.adoc
+  cb-swagger:
+    branches: [DOC-10001-add-logging-params]
+    start_path: docs
+override:
+  site:
+    startPage: server:introduction:intro.adoc

--- a/preview/DOC-10001-add-new-logging-qualifiers.yml
+++ b/preview/DOC-10001-add-new-logging-qualifiers.yml
@@ -1,0 +1,10 @@
+sources:
+  docs-server:
+    branches: [release/8.0]
+  docs-devex:
+    branches: [DOC-10001-add-new-logging-qualifiers]
+  cb-swagger:
+    branches: [DOC-10001-add-logging-params]
+    start_path: docs  
+override:
+  startPage: server:introduction:intro.adoc

--- a/preview/DOC-10001-add-new-logging-qualifiers.yml
+++ b/preview/DOC-10001-add-new-logging-qualifiers.yml
@@ -1,8 +1,0 @@
-sources:
-  docs-server:
-    branches: [release/8.0]
-  cb-swagger: 
-    branches: [DOC-10001-add-logging-params]
-    start_path: docs 
-override:
-  startPage: server:introduction:intro.adoc

--- a/preview/DOC-10001-add-new-logging-qualifiers.yml
+++ b/preview/DOC-10001-add-new-logging-qualifiers.yml
@@ -3,13 +3,6 @@ sources:
     branches: [release/8.0]
   override:
   startPage: server:introduction:intro.adoc
-DOC-10001-add-new-logging-qualifiers:
-  sources:
-    docs-devex:
-      branches: [DOC-10001-add-new-logging-qualifiers]
-  override:
-    site:
-      startPage: server:develop:intro.adoc
 DOC-10001-add-logging-params:
   sources:
     cb-swagger:

--- a/preview/DOC-10001-add-new-logging-qualifiers.yml
+++ b/preview/DOC-10001-add-new-logging-qualifiers.yml
@@ -1,7 +1,8 @@
 sources:
-  cb-swagger:
+  docs-server:
+    branches: [release/8.0]
+  cb-swagger: 
     branches: [DOC-10001-add-logging-params]
-    start_path: docs
+    start_path: docs 
 override:
-  site:
-    startPage: server:introduction:intro.adoc
+  startPage: server:introduction:intro.adoc

--- a/preview/HEAD.yml
+++ b/preview/HEAD.yml
@@ -1,5 +1,5 @@
 sources:
   docs-server:
-    branches: [release/8.0]
+    branches: [release/7.6]
 override:
   startPage: server:introduction:intro.adoc

--- a/preview/HEAD.yml
+++ b/preview/HEAD.yml
@@ -1,5 +1,5 @@
 sources:
   docs-server:
-    branches: [release/7.6]
+    branches: [release/8.0]
 override:
   startPage: server:introduction:intro.adoc


### PR DESCRIPTION
Add the following logging qualifiers to system:completed_requests:
- statement
- plan

Doc Jira: DOC-10001
Preview link: [Logging Qualifiers ](https://preview.docs-test.couchbase.com/docs-devex-DOC-10001-add-new-logging-qualifiers/server/current/n1ql/n1ql-manage/monitoring-n1ql-query.html#logging-qualifiers)
Preview credentials: [Preview docs for internal review](https://couchbasecloud.atlassian.net/wiki/x/dYF_dQ#Preview-docs-for-internal-review)

Linked PR: https://github.com/couchbaselabs/cb-swagger/pull/167
