### PR TITLE
[DOC-13303] FTS - Create Search Index Alias with REST API

### DIFF
--- a/modules/search/examples/create-search-alias-header-global.sh
+++ b/modules/search/examples/create-search-alias-header-global.sh
@@ -1,0 +1,3 @@
+curl -s -XPUT -H "Content-Type: application/json" \
+    -u ${CB_USERNAME}:${CB_PASSWORD} http://${CB_HOSTNAME}:8094/api/index/${INDEX_NAME} 
+    -d \

--- a/modules/search/examples/create-search-alias-header-scoped.sh
+++ b/modules/search/examples/create-search-alias-header-scoped.sh
@@ -1,0 +1,3 @@
+curl -s -XPUT -H "Content-Type: application/json" \
+    -u ${CB_USERNAME}:${CB_PASSWORD} http://${CB_HOSTNAME}:8094/api/bucket/${BUCKET_NAME}/scope/${SCOPE_NAME}/index/${INDEX_NAME}
+    -d \

--- a/modules/search/examples/create-search-alias-payload-global.sh
+++ b/modules/search/examples/create-search-alias-payload-global.sh
@@ -1,0 +1,19 @@
+curl -s -XPUT -H "Content-Type: application/json" \
+  -u ${CB_USERNAME}:${CB_PASSWORD} http://localhost:8094/api/index/travel-color-alias
+  -d \
+  '{
+    "name": "travel-sample-alias",
+    "type": "fulltext-alias",
+    "params": {
+      "targets": {
+        "travel-sample.inventory.landmark-content": {},
+        "vector-sample.color.color-index": {}
+      }
+    },
+    "sourceType": "nil",
+    "sourceName": "",
+    "sourceUUID": "",
+    "sourceParams": null,
+    "planParams": {},
+    "uuid": ""
+  }'

--- a/modules/search/examples/create-search-alias-payload-scoped.sh
+++ b/modules/search/examples/create-search-alias-payload-scoped.sh
@@ -1,0 +1,20 @@
+curl -s -XPUT -H "Content-Type: application/json" \
+  -u ${CB_USERNAME}:${CB_PASSWORD} http://localhost:8094/api/bucket/travel-sample/scope/inventory/index/travel-sample-alias
+  -d \
+  '{
+    "name": "travel-sample-alias",
+    "type": "fulltext-alias",
+    "params": {
+      "targets": {
+        "travel-sample.inventory.landmark-content": {},
+        "travel-sample.inventory.hotel-reviews": {},
+        "travel-sample.inventory.routes": {}
+      }
+    },
+    "sourceType": "nil",
+    "sourceName": "",
+    "sourceUUID": "",
+    "sourceParams": null,
+    "planParams": {},
+    "uuid": ""
+  }'

--- a/modules/search/examples/create-search-alias-response-global.json
+++ b/modules/search/examples/create-search-alias-response-global.json
@@ -1,0 +1,5 @@
+{
+    "status": "ok",
+    "name": "travel-color-alias",
+    "uuid": "d630f5570437ff92"
+}

--- a/modules/search/examples/create-search-alias-response-scoped.json
+++ b/modules/search/examples/create-search-alias-response-scoped.json
@@ -1,0 +1,5 @@
+{
+    "status": "ok",
+    "name": "travel-sample.inventory.travel-sample-alias",
+    "uuid": "7e569bdb5d3a2a83"
+}

--- a/modules/search/examples/create-search-alias-targets-example.json
+++ b/modules/search/examples/create-search-alias-targets-example.json
@@ -1,0 +1,7 @@
+"params": {
+      "targets": {
+        "travel-sample.inventory.landmark-content": {},
+        "travel-sample.inventory.hotel-reviews": {},
+        "travel-sample.inventory.routes": {}
+      }
+    },

--- a/modules/search/pages/create-search-index-alias-rest-api.adoc
+++ b/modules/search/pages/create-search-index-alias-rest-api.adoc
@@ -105,4 +105,10 @@ Your own UUID might not match the value shown in the example.
 
 After you create a Search index alias, you can xref:simple-search-rest-api.adoc[] to test your alias and Search indexes. 
 
-If you want to edit your alias with another REST API call, include the xref:search-index-params.adoc#uuid[uuid] parameter with the UUID the Search Service assigned to your alias in the response to your first call.
+If you want to edit your alias with another REST API call, include the xref:search-index-params.adoc#uuid[uuid] parameter with your alias UUID.
+
+You can get the UUID from the response to your first call.
+You can also view the UUID from the Couchbase {page-ui-name} by selecting the alias, and clicking btn:[Edit Index].
+The UUID displays in the Index Definition Preview on the Edit Index page. 
+
+You can also use the xref:rest-api:rest-fts-indexing.adoc[Index Definition] endpoints provided by the Search REST API.

--- a/modules/search/pages/create-search-index-alias-rest-api.adoc
+++ b/modules/search/pages/create-search-index-alias-rest-api.adoc
@@ -30,7 +30,7 @@ To create a Search index alias with the REST API:
 . Set your header content to include `"Content-Type: application/json"`.
 . Enter your username, password, and the Search Service endpoint on port `8094` with the name of the index you want to create.
 +
-If all target Search indexes for your alias are in the same bucket and scope, use the scoped index creation endpoint: 
+If your alias's target Search indexes are all in the same bucket and scope, use the scoped index creation endpoint: 
 +
 .Scoped Index Creation Endpoint
 [source,console]

--- a/modules/search/pages/create-search-index-alias-rest-api.adoc
+++ b/modules/search/pages/create-search-index-alias-rest-api.adoc
@@ -1,0 +1,108 @@
+= Create a Search Index Alias with the REST API
+:page-topic-type: guide
+:page-ui-name: {ui-name}
+:page-product-name: {product-name}
+:description: Use the REST API to create a Search index alias. Use a Search index alias to run a Search query across multiple buckets, scopes, or Search indexes. 
+
+[abstract]
+{description}
+
+== Prerequisites
+
+* You have the Search Service enabled on a node in your cluster.
+For more information about how to deploy a new node and Services on your cluster, see xref:server:manage:manage-nodes/node-management-overview.adoc[].
+
+* You have created at least one Search index.
+For more information, see xref:create-search-index-ui.adoc[] or xref:create-search-index-rest-api.adoc[].
+
+* Your user account has the *Search Admin* role for the bucket where you want to create the alias. 
+
+* You have installed the Couchbase command-line tool (CLI).
+
+* You have the hostname or IP address for the node in your cluster where you're running the Search Service.
+For more information about where to find the IP address for your node, see xref:server:manage:manage-nodes/list-cluster-nodes.adoc[].
+
+== Procedure
+
+To create a Search index alias with the REST API: 
+
+. In your command-line tool, enter a `curl` command with the `XPUT` verb. 
+. Set your header content to include `"Content-Type: application/json"`.
+. Enter your username, password, and the Search Service endpoint on port `8094` with the name of the index you want to create.
++
+If all target Search indexes for your alias are in the same bucket and scope, use the scoped index creation endpoint: 
++
+.Scoped Index Creation Endpoint
+[source,console]
+----
+include::example$create-search-alias-header-scoped.sh[]
+----
++
+If your target Search indexes are in different buckets or scopes, use the global index creation endpoint: 
++
+.Global Index Creation Endpoint
+[source,console]
+----
+include::example$create-search-alias-header-global.sh[]
+----
++
+To use SSL, use the `https` protocol in the Search Service endpoint URL and port `18094`.
++
+[NOTE]
+====
+Your alias name must start with an alphabetic character (a-z or A-Z). It can only contain alphanumeric characters (a-z, A-Z, or 0-9), hyphens (-), or underscores (_).
+
+For Couchbase Server version 7.6 and later, if you're using the scoped endpoint, your alias name must be unique inside your selected bucket and scope.
+You cannot have 2 aliases with the same name globally or inside the same bucket and scope.
+====
+
+. Enter the JSON payload for your Search index alias. 
+Your Search index alias only requires the properties from xref:search-index-params.adoc#initial[the start of a Search index JSON payload], except where otherwise noted.
+
+== Example: Create an Alias With Targets in the Same Bucket and Scope
+
+In the following example, the JSON payload creates an index alias named `travel-sample-alias`, which contains the `landmark-content`, `hotel-reviews`, and `routes` Search indexes: 
+
+[source,console]
+----
+include::example$create-search-alias-payload-scoped.sh[]
+----
+
+All the Search indexes in the `targets` object are in the same bucket and scope, so the REST API call uses the scoped endpoint to create a scoped alias.
+
+If the REST API call is successful, the Search Service returns a `200 OK` and the following JSON response:
+
+[source,json]
+----
+include::example$create-search-alias-response-scoped.json[]
+----
+
+The `"uuid"` is randomly generated for each Search index alias you create. 
+Your own UUID might not match the value shown in the example.
+
+== Example: Create an Alias With Targets in Different Buckets
+
+In the following example, the JSON payload creates an index alias named `travel-color-alias`, which contains the `landmark-content` and `color-index` Search indexes, which are in different buckets on the cluster: 
+
+[source,console]
+----
+include::example$create-search-alias-payload-global.sh[]
+----
+
+The REST API call uses the global endpoint to create a global alias.
+
+If the REST API call is successful, the Search Service returns a `200 OK` and the following JSON response:
+
+[source,json]
+----
+include::example$create-search-alias-response-global.json[]
+----
+
+The `"uuid"` is randomly generated for each Search index alias you create. 
+Your own UUID might not match the value shown in the example.
+
+== Next Steps
+
+After you create a Search index alias, you can xref:simple-search-rest-api.adoc[] to test your alias and Search indexes. 
+
+If you want to edit your alias with another REST API call, include the xref:search-index-params.adoc#uuid[uuid] parameter with the UUID the Search Service assigned to your alias in the response to your first call.

--- a/modules/search/pages/index-aliases.adoc
+++ b/modules/search/pages/index-aliases.adoc
@@ -20,10 +20,11 @@ If you created a clone of `old-index`, then made your updates, you could replace
 
 Using a Search index alias lets you edit `old-index` without any downtime. 
 
-For more information about how to create a Search index alias, see xref:create-search-index-alias.adoc[].
+For more information about how to create a Search index alias, see xref:create-search-index-alias.adoc[] or xref:create-search-index-alias-rest-api.adoc[].
 
 == See Also
 
 * xref:create-search-index-alias.adoc[]
+* xref:create-search-index-alias-rest-api.adoc[]
 * xref:import-search-index.adoc[]
 

--- a/modules/search/pages/search-index-params.adoc
+++ b/modules/search/pages/search-index-params.adoc
@@ -32,7 +32,16 @@ All Search index payloads have the following properties:
 |====
 |Property |Type |Required? |Description
 
-|name |String |Yes |The name of the Search index. A Search index name must be unique for each cluster.
+|name |String |Yes a|
+
+The name of the Search index or index alias. 
+
+For Couchbase Server version 7.6 and later, your index name must be unique inside your selected bucket and scope.
+You cannot have 2 indexes with the same name inside the same bucket and scope.
+
+For index aliases, names must be unique within the same bucket and scope if you're using the scoped endpoint.
+Global index aliases must not share a name with another alias.
+For more information about Search index aliases, see xref:index-aliases.adoc[].
 
 |type |String |Yes a|
 
@@ -40,25 +49,33 @@ The type of index you want to create:
 
 * `fulltext-index`: Create a Search index.
 * `fulltext-alias`: Create an alias for a Search index. 
-For more information about Search index aliases, see xref:index-aliases.adoc[].
+For more information about creating Search index aliases, see xref:create-search-index-alias-rest-api.adoc[].
 
 |[[uuid]]uuid |String |No a|
 
-The UUID for the Search index. 
+The UUID for the Search index or index alias. 
 
-The Search Service automatically generates a UUID for a Search index. 
+The Search Service automatically generates a UUID for a Search index or index alias. 
 
-If you use an existing UUID, the Search Service updates the existing Search index. 
-Do not include the `uuid` property when you want to copy an index to a different cluster or create a new index.
+If you use an existing UUID, the Search Service updates the existing Search index or index alias. 
+Do not include the `uuid` property when you want to copy an index to a different cluster or create a new index or alias.
 
 View the UUID for an existing index from the Couchbase {page-ui-name} by selecting an existing index, and clicking btn:[Edit Index]. 
 The UUID displays in the Index Definition Preview on the Edit Index page. 
 
 You can also use the xref:rest-api:rest-fts-indexing.adoc[Index Definition] endpoints provided by the Search REST API.
 
-|sourceType |String |Yes |The `sourceType` is always `"gocbcore"`.
+|sourceType |String |Yes a|
 
-|sourceName |String |Yes |The name of the bucket where you want to create the Search index. 
+When you create a Search index, the `sourceType` is always `"gocbcore"`.
+
+When you create an index alias, the `sourceType` is always `"nil"`.
+
+|sourceName |String |Yes a|
+
+The name of the bucket where you want to create the Search index. 
+
+You do not need to include a value for this parameter when creating an index alias. 
 
 |[[sourceuuid]]sourceUUID |String |No a|
 
@@ -68,16 +85,27 @@ The Search Service automatically finds the UUID for the bucket.
 
 Do not include the `sourceUUID` property when you want to copy an index to a different cluster, or create a new index.
 
+You do not need to include a value for this parameter when creating an index alias.
+
 |sourceParams |Object |No a|
 
 This object contains advanced settings for index behavior.
 
 Do not add content into this object unless instructed by Couchbase Support.
 
-|planParams |Object |Yes |An object that sets the Search index's partitions and replications. 
+|planParams |Object |Yes a|
+
+An object that sets the Search index's partitions and replications. 
 For more information, see <<planparams,>>.
 
-|params |Object |Yes |An object that sets the Search index's type identifier, type mappings, and analyzers. 
+For an index alias, set this to an empty object.
+
+|params |Object |Yes a|
+
+An object that sets the Search index's type identifier, type mappings, and analyzers. 
+
+For an index alias, this sets the target Search indexes to include in the alias. 
+
 For more information, see <<params,>>.
 
 |====
@@ -134,6 +162,22 @@ For more information, see <<doc-config,>>.
 
 |mapping |Object |Yes |An object that sets the analyzers and type mappings for a Search index. 
 For more information, see <<mapping,>>.
+
+|targets |Object |Index Alias Only a|
+
+When creating an index alias, an object that lists each Search index you want to include in the alias. 
+
+The `targets` object should include a named object for each Search index you want to include in the alias. 
+Make sure to use the scoped index name for each Search index.
+
+For example: 
+
+[source,json]
+----
+include::example$create-search-alias-targets-example.json[]
+----
+
+For more information about creating aliases, see xref:create-search-index-alias.adoc[] or xref:create-search-index-alias-rest-api.adoc[].
 
 |====
 

--- a/modules/search/pages/search-index-params.adoc
+++ b/modules/search/pages/search-index-params.adoc
@@ -26,6 +26,8 @@ include::example$simple-search-index-payload.jsonc[tag=json-snippet]
 
 TIP: To view the entire JSON payload, click btn:[View].
 
+When you xref:create-search-index-alias-rest-api.adoc[], the properties in this section are the only properties you need to include in your alias definition.
+
 All Search index payloads have the following properties: 
 
 [cols="1,1,1,2"]

--- a/modules/search/pages/simple-search-rest-api.adoc
+++ b/modules/search/pages/simple-search-rest-api.adoc
@@ -15,7 +15,7 @@ For more information about how the Search Service scores documents in search res
 * You have the Search Service enabled on a node in your cluster.
 For more information about how to deploy a new node and Services on your cluster, see xref:server:manage:manage-nodes/node-management-overview.adoc[].
 
-* Your user account has the *Search Admin* or *Search Reader* role. 
+* Your user account has the *Search Admin* or *Search Reader* role for the bucket or buckets that contain the Search indexes you want to search.
 
 * You installed the Couchbase command-line tool (CLI).
 

--- a/modules/search/pages/simple-search-ui.adoc
+++ b/modules/search/pages/simple-search-ui.adoc
@@ -22,7 +22,7 @@ For more information about how to create a bucket, see xref:server:manage:manage
 +
 For more information about how to create a Search index, see xref:create-search-indexes.adoc[].
 
-* Your user account has the *Search Admin* or *Search Reader* role. 
+* Your user account has the *Search Admin* or *Search Reader* role for the bucket or buckets that contain the Search indexes you want to search.. 
 
 * You have logged in to the Couchbase {page-ui-name}. 
 

--- a/modules/search/partials/nav.adoc
+++ b/modules/search/partials/nav.adoc
@@ -21,6 +21,7 @@
     *** xref:7.6@server:search:search-query-auto-complete-code.adoc[]
   ** xref:7.6@server:search:index-aliases.adoc[]
     *** xref:7.6@server:search:create-search-index-alias.adoc[]
+    *** xref:7.6@server:search:create-search-index-alias-rest-api.adoc[]
   ** xref:7.6@server:search:customize-index.adoc[]
     *** xref:7.6@server:search:set-type-identifier.adoc[]
     *** xref:7.6@server:search:create-type-mapping.adoc[]


### PR DESCRIPTION
Adding examples and a new topic to the Search documentation around how to use the REST API to create Search index aliases. 

Preview site: https://preview.docs-test.couchbase.com/docs-devex-DOC-13303-fts-aliases-rest-examples/server/current/search/index-aliases.html

Preview site credentials: https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords