### PR TITLE
[DOC-10909] Add 'Errors' Logging Qualifier

### DIFF
--- a/modules/n1ql/pages/n1ql-manage/monitoring-n1ql-query.adoc
+++ b/modules/n1ql/pages/n1ql-manage/monitoring-n1ql-query.adoc
@@ -717,6 +717,8 @@ A completed request is logged if _any_ of the qualifiers are met (logical OR).
 `client`:: Log requests from this IP address.
 `user`:: Log requests with this user name.
 `context`:: Log requests with this client context ID.
+`errors`:: Log requests with at least this many errors. 
+
 
 For full details, see xref:n1ql-rest-admin:index.adoc#Logging_Parameters[Logging Parameters].
 

--- a/preview/DOC-10909-add-errors-qualifier.yml
+++ b/preview/DOC-10909-add-errors-qualifier.yml
@@ -1,6 +1,6 @@
 sources:
-    url: ../cb-swagger
-    branches: [DOC-10909-new-logging-qualifier]  
-    start_path: docs
+  cb-swagger:
+    branches: [DOC-10909-new-logging-qualifier]
+    start_path: docs  
 override:
   startPage: server:introduction:intro.adoc

--- a/preview/DOC-10909-add-errors-qualifier.yml
+++ b/preview/DOC-10909-add-errors-qualifier.yml
@@ -1,0 +1,6 @@
+sources:
+    url: ../cb-swagger
+    branches: [DOC-10909-new-logging-qualifier]  
+    start_path: docs
+override:
+  startPage: server:introduction:intro.adoc

--- a/preview/DOC-10909-add-errors-qualifier.yml
+++ b/preview/DOC-10909-add-errors-qualifier.yml
@@ -1,8 +1,0 @@
-sources:
-  docs-server:
-    branches: [release/7.6]
-  cb-swagger:
-    branches: [DOC-10909-new-logging-qualifier]
-    start_path: docs  
-override:
-  startPage: server:introduction:intro.adoc

--- a/preview/DOC-10909-add-errors-qualifier.yml
+++ b/preview/DOC-10909-add-errors-qualifier.yml
@@ -1,4 +1,6 @@
 sources:
+  docs-server:
+    branches: [release/7.6]
   cb-swagger:
     branches: [DOC-10909-new-logging-qualifier]
     start_path: docs  

--- a/preview/HEAD.yml
+++ b/preview/HEAD.yml
@@ -1,5 +1,8 @@
 sources:
   docs-server:
     branches: [release/7.6]
+  cb-swagger:
+    branches: [DOC-10909-new-logging-qualifier]
+    start_path: docs  
 override:
   startPage: server:introduction:intro.adoc

--- a/preview/HEAD.yml
+++ b/preview/HEAD.yml
@@ -1,8 +1,5 @@
 sources:
   docs-server:
-    branches: [release/7.6]
-  cb-swagger:
-    branches: [DOC-10909-new-logging-qualifier]
-    start_path: docs  
+    branches: [release/7.6] 
 override:
   startPage: server:introduction:intro.adoc


### PR DESCRIPTION
Add 'Errors' logging qualifier to system:completed_requests. 

Doc Jira: DOC-10909

Doc preview: [Logging Qualifiers](https://preview.docs-test.couchbase.com/docs-devex-DOC-10909-errors-logging-qualifier/server/current/n1ql/n1ql-manage/monitoring-n1ql-query.html#sys-completed-config)
Preview credentials: [Preview docs for internal review](https://couchbasecloud.atlassian.net/wiki/x/dYF_dQ#Preview-docs-for-internal-review)

Linked PR: https://github.com/couchbaselabs/cb-swagger/pull/170
