### PR TITLE
Removing single reference to memcached buckets

### DIFF
--- a/modules/eventing/pages/eventing-faq.adoc
+++ b/modules/eventing/pages/eventing-faq.adoc
@@ -47,7 +47,7 @@ This means that the event entry points of *OnUpdate* and *OnDelete* to the Event
 
 * Can a Function listen to all changes across Couchbase Server?
 +
-A defined Function listens only to changes that are exposed using the DCP for the source collection (Couchbase and Ephemeral) in the data-nodes.
+A defined Function listens only to changes that are exposed using the DCP for the source collection in the data-nodes.
 The Function cannot listen to changes happening in other Couchbase components, such as FTS, Views, or GSI; nor can it listen to system events.
 
 

--- a/modules/eventing/pages/eventing-faq.adoc
+++ b/modules/eventing/pages/eventing-faq.adoc
@@ -48,7 +48,6 @@ This means that the event entry points of *OnUpdate* and *OnDelete* to the Event
 * Can a Function listen to all changes across Couchbase Server?
 +
 A defined Function listens only to changes that are exposed using the DCP for the source collection (Couchbase and Ephemeral) in the data-nodes.
-Memcached buckets (and thus underlying collections) are not supported.
 The Function cannot listen to changes happening in other Couchbase components, such as FTS, Views, or GSI; nor can it listen to system events.
 
 


### PR DESCRIPTION
Associated with DOC-12483, which removes all references t the now removed memcached buckets.