### PR TITLE
[DOC-10618] Additional Date Formats

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/datefun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/datefun.adoc
@@ -509,23 +509,23 @@ The elements are given in the table below.
 | `2021-06-28`
 
 | `r`
-| 12-hour time, including AM/PM (hh:mm:ss AM/PM)
-| `07:22:59 PM`
+| 12-hour time in the format, hh:mm:ss am/pm
+| `07:22:59 am`
 
 | `X`
 | Same as `%T`
 | `19:22:59`
 
 | `:z`
-|  Time zone or UTC offset in the format, +HH:MM
+|  UTC offset in the format, +HH:MM
 |  `+05:30`
 
 | `::z`
-| Time zone or UTC offset in the format, +HH:MM:SS
+|  UTC offset in the format, +HH:MM:SS
 | `+05:30:00`
 
 | `:::z`
-| Time zone with minimum precision as required
+| UTC offset with minimum precision as required for the time zone
 | `+05:30` or `+05:30:00`
 
 | `V`
@@ -533,7 +533,7 @@ The elements are given in the table below.
 | `27`
 
 | `G`
-| Year for ISO week number
+| Year corresponding to the ISO week number
 | `2025`
 
 | `j`
@@ -541,15 +541,15 @@ The elements are given in the table below.
 | `179`
 
 | `q`
-| Quarter (1...4)
+| Quarter of the year, 1-4
 | `2`
 
 | `w`
-| Weekday (Sunday == 0)
+| Day of the week (Sunday=0)
 | `1`
 
 | `u`
-| Weekday (Monday == 1, Sunday == 7)
+| Day of the week (Monday=1, Sunday=7)
 | `2`
 
 
@@ -562,11 +562,11 @@ The elements are given in the table below.
 | `27`
 
 | `#`
-| Time since the Epoch time in the format [total hours]h:mm:ss
+| Time since Epoch in the format, <total hours>h:mm:ss
 | `12345h:27:15`
 
 | `@`
-| Time since the Epoch time in the format [total hours]h:mm:ss.fff
+| Time since Epoch in the format, <total hours>h:mm:ss.fff
 | `12345h:27:15.123`
 
 |====

--- a/modules/n1ql/pages/n1ql-language-reference/datefun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/datefun.adoc
@@ -509,8 +509,8 @@ The elements are given in the table below.
 | `2021-06-28`
 
 | `r`
-| 12-hour time, hh:mm:ss am/pm
-| `07:22:59 am`
+| 12-hour time, hh:mm:ss AM/PM
+| `07:22:59 AM`
 
 | `X`
 | Same as `%T`
@@ -562,12 +562,13 @@ The elements are given in the table below.
 | `27`
 
 | `#`
-| Time since Epoch in the format, <total hours>h:mm:ss
-| `12345h:27:15`
+| Time since Epoch in the format, [total hours]:mm:ss 
+| `406464:27:15`
+
 
 | `@`
-| Time since Epoch in the format, <total hours>h:mm:ss.fff
-| `12345h:27:15.123`
+| Time since Epoch in the format, [total hours]:mm:ss.fff
+| `406464:27:15.123`
 
 |====
 

--- a/modules/n1ql/pages/n1ql-language-reference/datefun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/datefun.adoc
@@ -509,7 +509,7 @@ The elements are given in the table below.
 | `2021-06-28`
 
 | `r`
-| 12-hour time in the format, hh:mm:ss am/pm
+| 12-hour time, hh:mm:ss am/pm
 | `07:22:59 am`
 
 | `X`

--- a/modules/n1ql/pages/n1ql-language-reference/datefun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/datefun.adoc
@@ -504,6 +504,71 @@ The elements are given in the table below.
 | Seconds since 1970-01-01 00:00:00 UTC
 | `1624904579`
 
+| `x`
+| Same as `%D`
+| `2021-06-28`
+
+| `r`
+| 12-hour time, including AM/PM (hh:mm:ss AM/PM)
+| `07:22:59 PM`
+
+| `X`
+| Same as `%T`
+| `19:22:59`
+
+| `:z`
+|  Time zone or UTC offset in the format, +HH:MM
+|  `+05:30`
+
+| `::z`
+| Time zone or UTC offset in the format, +HH:MM:SS
+| `+05:30:00`
+
+| `:::z`
+| Time zone with minimum precision as required
+| `+05:30` or `+05:30:00`
+
+| `V`
+| ISO week number
+| `27`
+
+| `G`
+| Year for ISO week number
+| `2025`
+
+| `j`
+| Day of the year
+| `179`
+
+| `q`
+| Quarter (1...4)
+| `2`
+
+| `w`
+| Weekday (Sunday == 0)
+| `1`
+
+| `u`
+| Weekday (Monday == 1, Sunday == 7)
+| `2`
+
+
+| `U`
+| Week number of year (Sunday is first day of the week)
+| `27`
+
+| `W`
+| Week number of year (Monday is first day of the week)
+| `27`
+
+| `#`
+| Time since the Epoch time in the format [total hours]h:mm:ss
+| `12345h:27:15`
+
+| `@`
+| Time since the Epoch time in the format [total hours]h:mm:ss.fff
+| `12345h:27:15.123`
+
 |====
 
 To specify a date format, you can put the format specifiers together in any order, along with any other characters as required.


### PR DESCRIPTION
Added some additional percent-style date formatting options to the Date function. 

Jira: DOC-10618
Preview: Go to [Date String Formats](https://preview.docs-test.couchbase.com/docs-devex-DOC-10618-additional-date-formats/server/current/n1ql/n1ql-language-reference/datefun.html#date-string) and select the Percent-Style Dates tab
Preview credentials: [Preview docs for internal review](https://couchbasecloud.atlassian.net/wiki/x/dYF_dQ#Preview-docs-for-internal-review)