### PR TITLE
(DOC-13369) Update Java example includes for new locations

### DIFF
--- a/modules/guides/pages/bulk-operations.adoc
+++ b/modules/guides/pages/bulk-operations.adoc
@@ -100,9 +100,9 @@ Java::
 
 [source,java]
 ----
-include::java-sdk:hello-world:example$KvBulkHelloWorld.java[tag=kv-users,indent=0]
+include::java-sdk:devguide:example$java/KvBulkHelloWorld.java[tag=kv-users,indent=0]
 
-include::java-sdk:hello-world:example$KvBulkHelloWorld.java[tag=kv-bulk-insert,indent=0]
+include::java-sdk:devguide:example$java/KvBulkHelloWorld.java[tag=kv-bulk-insert,indent=0]
 
 ----
 
@@ -110,7 +110,7 @@ NOTE: A `JsonDocument` class is used to supplement the example.
 
 [source,java]
 ----
-include::java-sdk:hello-world:example$KvBulkHelloWorld.java[tag=kv-bulk-class,indent=0]
+include::java-sdk:devguide:example$java/KvBulkHelloWorld.java[tag=kv-bulk-class,indent=0]
 ----
 
 {github}
@@ -242,9 +242,9 @@ Using the `reactor.core.publisher.Flux` reactive library, call the `fromIterable
 
 [source,java]
 ----
-include::java-sdk:hello-world:example$KvBulkHelloWorld.java[tag=kv-users,indent=0]
+include::java-sdk:devguide:example$java/KvBulkHelloWorld.java[tag=kv-users,indent=0]
 
-include::java-sdk:hello-world:example$KvBulkHelloWorld.java[tag=kv-bulk-get,indent=0]
+include::java-sdk:devguide:example$java/KvBulkHelloWorld.java[tag=kv-bulk-get,indent=0]
 
 ----
 
@@ -378,9 +378,9 @@ Java::
 
 [source,java]
 ----
-include::java-sdk:hello-world:example$KvBulkHelloWorld.java[tag=kv-users,indent=0]
+include::java-sdk:devguide:example$java/KvBulkHelloWorld.java[tag=kv-users,indent=0]
 
-include::java-sdk:hello-world:example$KvBulkHelloWorld.java[tag=kv-bulk-upsert,indent=0]
+include::java-sdk:devguide:example$java/KvBulkHelloWorld.java[tag=kv-bulk-upsert,indent=0]
 
 ----
 
@@ -512,9 +512,9 @@ Using the `reactor.core.publisher.Flux` reactive library, call the `fromIterable
 
 [source,java]
 ----
-include::java-sdk:hello-world:example$KvBulkHelloWorld.java[tag=kv-users,indent=0]
+include::java-sdk:devguide:example$java/KvBulkHelloWorld.java[tag=kv-users,indent=0]
 
-include::java-sdk:hello-world:example$KvBulkHelloWorld.java[tag=kv-bulk-remove,indent=0]
+include::java-sdk:devguide:example$java/KvBulkHelloWorld.java[tag=kv-bulk-remove,indent=0]
 
 ----
 

--- a/modules/guides/pages/create-index.adoc
+++ b/modules/guides/pages/create-index.adoc
@@ -126,14 +126,14 @@ The following example creates an unnamed primary index.
 
 [source,java]
 ----
-include::java-sdk:hello-world:example$IndexHelloWorld.java[tag=primary,indent=0]
+include::java-sdk:devguide:example$java/IndexHelloWorld.java[tag=primary,indent=0]
 ----
 
 The following example creates a named primary index on the specified keyspace.
 
 [source,java]
 ----
-include::java-sdk:hello-world:example$IndexHelloWorld.java[tag=named-primary,indent=0]
+include::java-sdk:devguide:example$java/IndexHelloWorld.java[tag=named-primary,indent=0]
 ----
 
 {github}
@@ -302,7 +302,7 @@ The following example creates a secondary index on the `name` field in the speci
 
 [source,java]
 ----
-include::java-sdk:hello-world:example$IndexHelloWorld.java[tag=secondary,indent=0]
+include::java-sdk:devguide:example$java/IndexHelloWorld.java[tag=secondary,indent=0]
 ----
 
 {github}
@@ -420,7 +420,7 @@ The following example creates a secondary index on the `name`, `id`, `icao`, and
 
 [source,java]
 ----
-include::java-sdk:hello-world:example$IndexHelloWorld.java[tag=composite,indent=0]
+include::java-sdk:devguide:example$java/IndexHelloWorld.java[tag=composite,indent=0]
 ----
 
 {github}

--- a/modules/guides/pages/creating-data.adoc
+++ b/modules/guides/pages/creating-data.adoc
@@ -102,7 +102,7 @@ A `MutationResult` object is returned containing the result and metadata relevan
 
 [source,java]
 ----
-include::java-sdk:hello-world:example$KvHelloWorldScoped.java[tag=kv-insert,indent=0]
+include::java-sdk:devguide:example$java/KvHelloWorldScoped.java[tag=kv-insert,indent=0]
 ----
 
 NOTE: If the document already exists, the SDK returns a `DocumentExistsException` error.
@@ -240,7 +240,7 @@ Java::
 
 [source,java]
 ----
-include::java-sdk:hello-world:example$KvHelloWorldScoped.java[tag=kv-insert-with-opts,indent=0]
+include::java-sdk:devguide:example$java/KvHelloWorldScoped.java[tag=kv-insert-with-opts,indent=0]
 ----
 
 {github}

--- a/modules/guides/pages/deleting-data.adoc
+++ b/modules/guides/pages/deleting-data.adoc
@@ -86,7 +86,7 @@ Use the `remove()` method to delete a document from the database.
 
 [source,java]
 ----
-include::java-sdk:hello-world:example$KvHelloWorldScoped.java[tag=kv-remove,indent=0]
+include::java-sdk:devguide:example$java/KvHelloWorldScoped.java[tag=kv-remove,indent=0]
 ----
 
 NOTE: If the document doesn't exist, the SDK will return a `DocumentNotFoundException` error.
@@ -220,7 +220,7 @@ A `MutateInResult` object is returned, containing the result and metadata releva
 
 [source,java]
 ----
-include::java-sdk:hello-world:example$KvHelloWorldScoped.java[tag=kv-remove-subdoc,indent=0]
+include::java-sdk:devguide:example$java/KvHelloWorldScoped.java[tag=kv-remove-subdoc,indent=0]
 ----
 
 NOTE: If the path doesn't exist, the SDK will return a `PathNotFoundException` error.

--- a/modules/guides/pages/drop-index.adoc
+++ b/modules/guides/pages/drop-index.adoc
@@ -120,7 +120,7 @@ The following example drops an unnamed primary index from the specified keyspace
 
 [source,java]
 ----
-include::java-sdk:hello-world:example$IndexHelloWorld.java[tag=drop-primary,indent=0]
+include::java-sdk:devguide:example$java/IndexHelloWorld.java[tag=drop-primary,indent=0]
 ----
 
 {github}
@@ -276,7 +276,7 @@ The following example drops a named index from the specified keyspace.
 
 [source,java]
 ----
-include::java-sdk:hello-world:example$IndexHelloWorld.java[tag=drop-secondary,indent=0]
+include::java-sdk:devguide:example$java/IndexHelloWorld.java[tag=drop-secondary,indent=0]
 ----
 
 {github}

--- a/modules/guides/pages/reading-data.adoc
+++ b/modules/guides/pages/reading-data.adoc
@@ -98,7 +98,7 @@ A `GetResult` object is returned, which includes the `content`, `cas` value, and
 
 [source,java]
 ----
-include::java-sdk:hello-world:example$KvHelloWorldScoped.java[tag=kv-get,indent=0]
+include::java-sdk:devguide:example$java/KvHelloWorldScoped.java[tag=kv-get,indent=0]
 ----
 
 NOTE: If the document doesn't exist, the SDK returns a `DocumentNotFoundException` error.
@@ -253,7 +253,7 @@ A `GetResult` object is returned, which may include extra metadata, depending on
 
 [source,java]
 ----
-include::java-sdk:hello-world:example$KvHelloWorldScoped.java[tag=kv-get-with-opts,indent=0]
+include::java-sdk:devguide:example$java/KvHelloWorldScoped.java[tag=kv-get-with-opts,indent=0]
 ----
 
 {github}
@@ -401,7 +401,7 @@ A `LookupInResult` object is returned, containing the result and metadata releva
 
 [source,java]
 ----
-include::java-sdk:hello-world:example$KvHelloWorldScoped.java[tag=kv-get-subdoc,indent=0]
+include::java-sdk:devguide:example$java/KvHelloWorldScoped.java[tag=kv-get-subdoc,indent=0]
 ----
 
 NOTE: If the document path can't be found, the SDK returns a `PathNotFoundException` error.

--- a/modules/guides/pages/select.adoc
+++ b/modules/guides/pages/select.adoc
@@ -70,7 +70,7 @@ The result object includes each row found.
 
 [source,java]
 ----
-include::java-sdk:hello-world:example$StartUsing.java[tag=n1ql-query,indent=0]
+include::java-sdk:devguide:example$java/StartUsing.java[tag=n1ql-query,indent=0]
 ----
 
 {github}

--- a/modules/guides/pages/updating-data.adoc
+++ b/modules/guides/pages/updating-data.adoc
@@ -92,7 +92,7 @@ If it doesn't exist, Couchbase Capella creates a new document.
 
 [source,java]
 ----
-include::java-sdk:hello-world:example$KvHelloWorldScoped.java[tag=kv-update-upsert,indent=0]
+include::java-sdk:devguide:example$java/KvHelloWorldScoped.java[tag=kv-update-upsert,indent=0]
 ----
 
 {github}
@@ -222,7 +222,7 @@ A new `CAS` value is provided in the returned `MutationResult` object.
 
 [source,java]
 ----
-include::java-sdk:hello-world:example$KvHelloWorldScoped.java[tag=kv-update-replace,indent=0]
+include::java-sdk:devguide:example$java/KvHelloWorldScoped.java[tag=kv-update-replace,indent=0]
 ----
 
 NOTE: If the document doesn't exist, the SDK will return a `DocumentNotFoundException` error.
@@ -364,7 +364,7 @@ A `MutateInResult` object is returned, containing the result and metadata releva
 
 [source,java]
 ----
-include::java-sdk:hello-world:example$KvHelloWorldScoped.java[tag=kv-update-subdoc,indent=0]
+include::java-sdk:devguide:example$java/KvHelloWorldScoped.java[tag=kv-update-subdoc,indent=0]
 ----
 
 {github}


### PR DESCRIPTION
There are several spots where the code examples are broken after the Java code examples were moved around. This change fixes those includes. 