### PR TITLE
[AV-104692] 8.0 on Capella - FTS Scoring Models

### DIFF
--- a/modules/search/examples/autocomplete-search-index.jsonc
+++ b/modules/search/examples/autocomplete-search-index.jsonc
@@ -52,6 +52,7 @@
         "default_type": "_default",
         "docvalues_dynamic": false,
         "index_dynamic": true,
+        "scoring_model": "tfidf",
         "store_dynamic": false,
         "type_field": "_type",
         "types": {

--- a/modules/search/examples/complex-search-index-payload.jsonc
+++ b/modules/search/examples/complex-search-index-payload.jsonc
@@ -154,6 +154,7 @@
     "default_type": "_default",
     "docvalues_dynamic": true,
     "index_dynamic": true,
+    "scoring_model": "tfidf",
     "store_dynamic": true,
     "type_field": "_type",
     "types": {

--- a/modules/search/examples/geospatial-search-index.jsonc
+++ b/modules/search/examples/geospatial-search-index.jsonc
@@ -26,6 +26,7 @@
         "default_type": "_default",
         "docvalues_dynamic": false,
         "index_dynamic": true,
+        "scoring_model": "tfidf",
         "store_dynamic": false,
         "type_field": "_type",
         "types": {

--- a/modules/search/examples/run-search-full-request.jsonc
+++ b/modules/search/examples/run-search-full-request.jsonc
@@ -78,7 +78,8 @@
             "results": "complete"
         },
         // end::consistency[]
-        "validate": true
+        "validate": true,
+        "global_scoring": true
     },
     // end::ctl[]
     "size": 10,

--- a/modules/search/examples/simple-search-index-payload.jsonc
+++ b/modules/search/examples/simple-search-index-payload.jsonc
@@ -204,11 +204,12 @@
             "default_type": "_default",
             "docvalues_dynamic": true,
             "index_dynamic": true,
+            "scoring_model": "bm25",
             "store_dynamic": true,
             "type_field": "_type",
             // tag::types[]
             "types": {
-                // end::mapping[]
+            // end::mapping[]
                 // tag::scope_collection[]
                 "inventory.hotel": {
                     "dynamic": false,

--- a/modules/search/pages/create-search-index-ui.adoc
+++ b/modules/search/pages/create-search-index-ui.adoc
@@ -49,23 +49,26 @@ If you select specific collections, you can only use documents from these collec
 . Click *Index everything from: $COLLECTION_NAME*.
 . Click btn:[Index All Fields].
 . Click btn:[Add to Index].
-. (Optional) <<configure-settings,Configure Global Index settings>>.
+. (Optional) <<configure-settings,>>.
 . (Optional) Expand *Replicas & Partitions* and configure your *Number of Replicas* and *Number of Partitions*. 
 +
 For more information, see xref:customize-index.adoc#replica[Replica and Partition Settings].
 . Click btn:[Create Index].
 
 [#configure-settings]
-=== Configure Global Search Index Settings 
+=== Configure Additional Search Index Settings 
 
-To configure global settings for your Search index: 
+To configure additional settings for your Search index: 
 
-. Expand *Global Index Settings*:
-.. [[default-analyzer]]In the *Default Analyzer* list, select the xref:customize-index.adoc#analyzers[default analyzer] to assign to new xref:customize-index.adoc#type-mappings[type mappings] in your index. 
-.. [[date-time]]In the *Default Date/Time Parser* list, select the xref:customize-index.adoc#date-time[default date/time parser] to use for date data in your index. 
+. [[default-analyzer]]In the *Default Analyzer* list, select the xref:customize-index.adoc#analyzers[default analyzer] to assign to new xref:customize-index.adoc#type-mappings[type mappings] in your index. 
+. [[date-time]]In the *Default Date/Time Parser* list, select the xref:customize-index.adoc#date-time[default date/time parser] to use for date data in your index. 
 +
 TIP: If you're editing your index in xref:create-search-indexes.adoc#advanced-mode[Advanced Mode Editing], you can also choose to xref:create-custom-analyzer.adoc[] or xref:create-custom-date-time-parser.adoc[]. 
-. (Advanced Mode Only) In the *Configured Type Mappings* pane, under *Choose Document Filter*, xref:set-type-identifier.adoc[configure a document filter] for your Search index. 
+. (Advanced Mode Only) Under *Document Filter*, xref:set-type-identifier.adoc[configure a document filter] for your Search index.
+. (Advanced Mode Only) Under *Scoring Model*, choose the scoring model to use for your Search index.
+For more information, see xref:run-searches.adoc#scoring[Scoring for Search Queries] or xref:customize-index.adoc#scoring-model[Scoring Model].
++
+TIP: If you choose the `bm25` scoring model, make sure to include the xref:search-request-params.adoc#global_scoring[`global_scoring`] property in Search queries for this index.
 
 == Next Steps 
 

--- a/modules/search/pages/create-search-indexes.adoc
+++ b/modules/search/pages/create-search-indexes.adoc
@@ -44,6 +44,7 @@ If you select *Enable Advanced Options* to enable Advanced Mode in the Search in
 * Creating xref:customize-index.adoc#type-mappings[mappings] for objects and fields that do not yet exist in your document schema
 * Configuring a xref:customize-index.adoc#type-identifiers[document filter]
 * As of Couchbase Server version 8.0, configuring a xref:synonyms/synonyms-search.adoc[synonym source]
+* Changing your Search index's xref:customize-index.adoc#scoring-model[scoring model]
 
 All initial editing options remain available in Advanced Mode editing. 
 

--- a/modules/search/pages/create-search-indexes.adoc
+++ b/modules/search/pages/create-search-indexes.adoc
@@ -44,7 +44,7 @@ If you select *Enable Advanced Options* to enable Advanced Mode in the Search in
 * Creating xref:customize-index.adoc#type-mappings[mappings] for objects and fields that do not yet exist in your document schema
 * Configuring a xref:customize-index.adoc#type-identifiers[document filter]
 * As of Couchbase Server version 8.0, configuring a xref:synonyms/synonyms-search.adoc[synonym source]
-* Changing your Search index's xref:customize-index.adoc#scoring-model[scoring model]
+* As of Couchbase Server version 8.0, changing your Search index's xref:customize-index.adoc#scoring-model[scoring model]
 
 All initial editing options remain available in Advanced Mode editing. 
 

--- a/modules/search/pages/customize-index.adoc
+++ b/modules/search/pages/customize-index.adoc
@@ -14,6 +14,7 @@ You can add the following components and configure the following options for a S
 * <<analyzers,>>
 * <<date-time,>>
 * <<type-identifiers,>>
+* <<scoring-model,>>
 * <<type-mappings,>>
 * <<synonyms,>>
 * <<replica,>>
@@ -36,6 +37,23 @@ When you create a custom analyzer, you can choose these components.
 For more information about Search analyzer components, see <<custom-filters,>>.
 
 For more information about how to create a custom analyzer, see xref:create-custom-analyzer.adoc[].
+
+[#scoring-model]
+== Scoring Model
+
+[.status]#Couchbase Server version 8.0#
+
+As of Couchbase Server version 8.0, in Advanced Mode editing, you can choose the specific scoring model you want to use for a Search index. 
+Your scoring model changes the calculation the Search Service uses for scoring documents and ranking them in your search results. 
+
+The following scoring model algorithms are available: 
+
+* `tfidf`: The standard scoring model for the Search Service.
+A higher tf-idf score for a document places that document higher in your search results.
+* `bm25`: A scoring model better suited to hybrid searches with the Search Service.
+A hybrid Search query uses xref:vector-search:vector-search.adoc[Vector Search] together with a standard Search query.
+
+For more information about the calculations for scoring for each algorithm, see xref:run-searches.adoc#scoring[Scoring for Search Queries].
  
 [#date-time]
 == Default Date/Time Parser

--- a/modules/search/pages/run-searches.adoc
+++ b/modules/search/pages/run-searches.adoc
@@ -26,7 +26,18 @@ To run a Search query against multiple Search indexes at once, xref:create-searc
 [#scoring]
 == Scoring for Search Queries 
 
-To determine a document's score in search results, the Search Service uses the https://en.wikipedia.org/wiki/Tf%E2%80%93idf[tf-idf^] algorithm. 
+As of Couchbase Server version 8.0, you can choose between 2 scoring algorithms for your Search index: 
+
+* <<tf-idf,tf-idf>>
+* <<bm25,bm25>>
+
+TIP: Scoring can also change based on whether you're using synonyms in your Search index.
+For more information, see xref:synonyms/synonyms-search.adoc#run-synonym-search[Running a Search for Synonyms].
+
+[#tf-idf]
+=== tf-idf Search Scoring
+
+To determine a document's score in search results, the Search Service can use the https://en.wikipedia.org/wiki/Tf%E2%80%93idf[tf-idf^] algorithm. 
 `tf-idf` increases the score of a document based on term frequency, or the number of times a term appears in a document divided by the total number of terms in the document. 
 It penalizes document frequency, or how often a term appears across all documents. 
 
@@ -46,12 +57,43 @@ hit_score = (query_1_boost * query_1_hit_score) + (knn_boost * knn_distance)
 
 When running a hybrid search with the <<ui,Web Console>> or <<api,REST API>>, the Search Service displays results as a disjunct (`OR`) between your regular Search and Vector Search queries. 
 
-TIP: When running a hybrid Search query, you should add a `boost` value to your regular Search query to level the `tf-idf` score with the `knn` distance.
+TIP: When running a hybrid Search query and the `tf-idf` algorithm, you should add a `boost` value to your regular Search query to level the `tf-idf` score with the knn distance.
 Otherwise, you might see unexpected search results.
 This is because of the differences in the scoring algorithms between the 2 query types.
 
-Scoring can also change based on whether you're using synonyms in your Search index.
-For more information, see xref:synonyms/synonyms-search.adoc#run-synonym-search[Running a Search for Synonyms].
+[#bm25]
+=== bm25 Search Scoring
+
+[.status]#Couchbase Server version 8.0#
+
+As of Couchbase Server version 8.0, you can choose to use the https://en.wikipedia.org/wiki/Okapi_BM25[bm25^] algorithm instead of `tf-idf` for your Search index.
+
+`bm25` ranks documents based on the query terms that appear in each document, regardless of proximity.
+It calculates the number of times a term appears in a document, with penalties for more common terms like `tf-idf`, but also includes: 
+
+* Diminishing returns for a term that continues to frequently appear in documents, based on a saturation parameter (`k1`).
+* An adjustment to the resulting score, based on the total length of the current document field, divided by a normalized average length of the field across all documents (`b`).
+The value of `k1` limits just how much a single query term's frequency can affect the scoring of a document.
+The Search Service chooses reasonable defaults for the value of `k1` and `b`.
+
+Unlike `tf-idf`, `bm25` rewards term frequency, but penalizes document frequency.
+
+The calculation for a basic Search query is still based on the document's score for a query multiplied by any xref:search-request-params.adoc#boost[boost] parameters: 
+
+----
+hit_score = (query_1_boost * query_1_hit_score) + (query_2_boost * query_2_hit_score)
+----
+
+The calculation when running a hybrid Search query, that includes xref:vector-search:vector-search.adoc[a Vector Search query], is still: 
+
+----
+hit_score = (query_1_boost * query_1_hit_score) + (knn_boost * knn_distance)
+----
+
+When running a hybrid search with the <<ui,{page-ui-name}>> or <<api,REST API>>, the Search Service displays results as a disjunct (`OR`) between your regular Search and Vector Search queries. 
+
+`bm25` supports better hybrid search results and richer result rankings. 
+It also gives more stable result ordering across Search index partitions, when xref:search-request-params.adoc#global_scoring[`global_scoring`] is enabled.
 
 [#ui]
 == Run a Search with the {page-ui-name}

--- a/modules/search/pages/run-searches.adoc
+++ b/modules/search/pages/run-searches.adoc
@@ -73,7 +73,11 @@ It calculates the number of times a term appears in a document, with penalties f
 
 * Diminishing returns for a term that continues to frequently appear in documents, based on a saturation parameter (`k1`).
 * An adjustment to the resulting score, based on the total length of the current document field, divided by a normalized average length of the field across all documents (`b`).
+
 The value of `k1` limits just how much a single query term's frequency can affect the scoring of a document.
+`k1` reduces the effect of term repetition and the risk of documents with excessively repeated content inflating your relevance scores.
+For example, spam or clickbait content would have reduced scores in `bm25` over the same document sentence being scored with `tf-idf`.
+
 The Search Service chooses reasonable defaults for the value of `k1` and `b`.
 
 Unlike `tf-idf`, `bm25` rewards term frequency, but penalizes document frequency.

--- a/modules/search/pages/search-index-params.adoc
+++ b/modules/search/pages/search-index-params.adoc
@@ -679,6 +679,18 @@ To index any fields in the Search index where `dynamic` is `true`, set `index_dy
 
 To exclude dynamic fields from the index, set `index_dynamic` to `false`.
 
+|scoring_model |String |Yes a|
+
+[.status]#Couchbase Server 8.0#
+
+Choose the specific scoring model you want to use for scoring search results for this Search index:
+
+* `tfidf`: The standard scoring model for the Search Service.
+A higher tf-idf score for a document places that document higher in your search results.
+* `bm25`: A scoring model better suited to hybrid searches with the Search Service.
+A hybrid Search query uses xref:vector-search:vector-search.adoc[Vector Search] together with a standard Search query.
+For more information about the calculations for scoring for each algorithm, see xref:run-searches.adoc#scoring[Scoring for Search Queries].
+
 |store_dynamic |Boolean |Yes a|
 
 To return the content from an indexed field in the Search index, set `store_dynamic` to `true`.

--- a/modules/search/pages/search-request-params.adoc
+++ b/modules/search/pages/search-request-params.adoc
@@ -1977,6 +1977,17 @@ This mode is designed to keep the number of query handling partitions per node t
 
 For more information about how to configure partitions and replicas on your Search index, see xref:create-search-index-ui.adoc[] or xref:search-index-params.adoc#planparams[planParams Object].
 
+|[[global_scoring]]global_scoring |Boolean |No a|
+
+[.status]#Couchbase Server 8.0#
+
+Add the `global_scoring` property with a value of `true` to ensure consistent and stable result ordering with the xref:run-searches.adoc#bm25[bm25 scoring algorithm], when you have a large, partitioned Search index.
+`global_scoring` aggregates document scoring across partitions to help maintain relative scoring, but uses more compute resources and increases search times.
+If you do not use `global_scoring`, result ordering can change based on your Search index's partition count.
+
+You can only use `global_scoring` if you're using the xref:run-searches.adoc#bm25[bm25 scoring algorithm].
+The setting has no effect if your `scoring_model` is set to `tfidf`.
+
 |====
 
 [#consistency]

--- a/modules/vector-search/examples/run-global-scoring-vector-search-payload-ui.jsonc
+++ b/modules/vector-search/examples/run-global-scoring-vector-search-payload-ui.jsonc
@@ -1,0 +1,27 @@
+{
+    "fields": ["description", "price", "product_name"],
+    "query": {
+      "conjuncts": [
+        {
+          "term": "Electronics",
+          "field": "category"
+        },
+        {
+          "field": "price",
+          "min": 100.00,
+          "max": 300.00,
+          "inclusive_max": true
+        }
+      ]
+    },
+    "knn": [
+      {
+        "k": 5,
+        "field": "embedding",
+        "vector": [0.23, -0.75, 0.61, ...]
+      }
+    ],
+    "ctl": {
+      "global_scoring": true
+    }
+}

--- a/modules/vector-search/examples/sample-vector-search-index-payload.json
+++ b/modules/vector-search/examples/sample-vector-search-index-payload.json
@@ -19,6 +19,7 @@
       "default_type": "_default",
       "docvalues_dynamic": false,
       "index_dynamic": true,
+      "scoring_model": "bm25",
       "store_dynamic": false,
       "type_field": "_type",
       "types": {

--- a/modules/vector-search/examples/vector-search-index-payload.jsonc
+++ b/modules/vector-search/examples/vector-search-index-payload.jsonc
@@ -26,6 +26,7 @@
       "default_type": "_default",
       "docvalues_dynamic": false,
       "index_dynamic": false,
+      "scoring_model": "bm25",
       "store_dynamic": false,
       "type_field": "_type",
       "types": {

--- a/modules/vector-search/pages/run-vector-search-ui.adoc
+++ b/modules/vector-search/pages/run-vector-search-ui.adoc
@@ -127,7 +127,8 @@ You cannot search for and return vectors you indexed as arrays with the *vector*
 
 In the following example, the Search query uses both a `query` and `knn` object to run both a Vector Search and traditional Search query on an index named `products-index`.
 
-The query searches for a specific embedding vector generated from an ecommerce website's product description, for a Search vector of the phrase `long battery life wireless earbuds`.
+The query searches for a specific embedding vector generated from an ecommerce website's product description. 
+The Search vector is generated from the phrase `long battery life wireless earbuds`.
 The `query` object specifically searches for documents that have `Electronics` as their category, with a price between `100.00` and `300.00`.
 The query returns the `description`, `price`, and `product_name` fields in results.
 Since the query is on a large, partitioned index and uses the `bm25` scoring algorithm, the query also uses `global_scoring` to keep document scores consistent across the Search index's partitions:

--- a/modules/vector-search/pages/run-vector-search-ui.adoc
+++ b/modules/vector-search/pages/run-vector-search-ui.adoc
@@ -72,6 +72,9 @@ If the same documents match the `knn` and `query` objects, the Search Service ra
 
 The document for the color `navy` should be the first result, followed by colors that are similar and match the `brightness` field query. 
 
+TIP: If you want to run a hybrid Search query on a large, partitioned Search index and your cluster is on Couchbase Server version 8.0 or later, use the `bm25` scoring model for your Search index.
+For more information, see xref:search:create-search-index-ui.adoc#configure-settings[Configure Additional Search Index Settings], xref:run-searches.adoc#scoring[Scoring for Search Queries], or xref:customize-index.adoc#scoring-model[Scoring Model].
+
 [#large]
 === Example: Running a Semantic Search Query with a Large Embedding Vector
 
@@ -119,6 +122,25 @@ include::example$run-vector-search-payload-base64-ui.jsonc[]
 
 NOTE: You can only use base64 encoded strings in your Vector Search queries if your documents use base64 encoded strings, indexed with the *vector_base64* field data type.
 You cannot search for and return vectors you indexed as arrays with the *vector* field data type by using a Search query with a base64 encoded string. 
+
+=== Example: Use global_scoring With a bm25 Search Index
+
+In the following example, the Search query uses both a `query` and `knn` object to run both a Vector Search and traditional Search query on an index named `products-index`.
+
+The query searches for a specific embedding vector generated from an ecommerce website's product description, for a Search vector of the phrase `long battery life wireless earbuds`.
+The `query` object specifically searches for documents that have `Electronics` as their category, with a price between `100.00` and `300.00`.
+The query returns the `description`, `price`, and `product_name` fields in results.
+Since the query is on a large, partitioned index and uses the `bm25` scoring algorithm, the query also uses `global_scoring` to keep document scores consistent across the Search index's partitions:
+
+[source,json]
+----
+include::example$run-global-scoring-vector-search-payload-ui.jsonc[]
+----
+
+NOTE: The vector embedding has been truncated for this example.
+The vector embedding in your Search query must match the configured dimension and similarity metric for your Search index.
+
+For more information about the `bm25` scoring algorithm, see xref:search:run-searches.adoc#scoring[Scoring for Search Queries].
 
 == Next Steps 
 


### PR DESCRIPTION
Adding documentation for new FTS feature in 8.0 on Capella, changing the scoring model for a Search index.

Preview site links: 

* https://preview.docs-test.couchbase.com/docs-devex-AV-104692-8-0-fts-bm25-scoring-capella/cloud/search/create-search-indexes.html#ui

* https://preview.docs-test.couchbase.com/docs-devex-AV-104692-8-0-fts-bm25-scoring-capella/cloud/search/customize-index.html#scoring-model

* https://preview.docs-test.couchbase.com/docs-devex-AV-104692-8-0-fts-bm25-scoring-capella/cloud/search/create-search-index-ui.html#configure-settings

* https://preview.docs-test.couchbase.com/docs-devex-AV-104692-8-0-fts-bm25-scoring-capella/cloud/search/search-index-params.html#mapping

* https://preview.docs-test.couchbase.com/docs-devex-AV-104692-8-0-fts-bm25-scoring-capella/cloud/search/run-searches.html#scoring

* https://preview.docs-test.couchbase.com/docs-devex-AV-104692-8-0-fts-bm25-scoring-capella/cloud/search/search-request-params.html#ctl

* https://preview.docs-test.couchbase.com/docs-devex-AV-104692-8-0-fts-bm25-scoring-capella/cloud/vector-search/run-vector-search-ui.html#example-use-global_scoring-with-a-bm25-search-index

Preview site credentials: https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords