### PR TITLE
[AV-105751] 8.0 on Capella - Document Search Index `Store` Object

### DIFF
--- a/modules/search/examples/simple-search-index-payload.jsonc
+++ b/modules/search/examples/simple-search-index-payload.jsonc
@@ -185,9 +185,22 @@
             }
             // end::types[]
         },
+        // tag::store[]
         "store": {
             "indexType": "scorch",
-            "segmentVersion": 15
+            // tag::scorch_persister[]
+            "scorchPersisterOptions": {
+                "maxSizeInMemoryMergePerWorker": 20971520,
+                "numPersisterWorkers": 4
+            },
+            // end::scorch_persister[]
+            // tag::scorch_merge[]
+            "scorchMergePlanOptions":{
+                "floorSegmentFileSize": 3495253
+            },
+            // end::scorch_merge[]
+            "segmentVersion": 16
         }
+        // end::store[]
     }
 }

--- a/modules/search/pages/search-index-params.adoc
+++ b/modules/search/pages/search-index-params.adoc
@@ -4,6 +4,7 @@
 :page-product-name: {product-name}
 :description: Use a JSON payload to control the settings for a Search index. 
 :page-toclevels: 2
+:stem:
 
 [abstract]
 {description}
@@ -89,6 +90,14 @@ For more information, see <<params,>>.
 
 For a xref:index-aliases.adoc[Search index alias], this object contains the <<targets,targets object>>.
 
+|store |Object |No a|
+
+An object that controls merge policy, concurrent persister behavior, and file format version for the Search index.
+
+The Search Service can automatically set these to reasonable default values, based on the other settings in your Search index definition.
+
+For more information, see <<store,>>.
+
 |====
 
 [#planparams]
@@ -112,13 +121,13 @@ The `planParams` object contains the following properties:
 |Property |Type |Required? |Description
 
 |maxPartitionsPerPIndex |n/a |No |This setting is deprecated. Use `indexPartitions`, instead.
-|indexPartitions |Number |Yes a|The number of partitions to split the Search index into, across the nodes you have available in your cluster with the Search Service enabled.
+|indexPartitions |Integer |Yes a|The number of partitions to split the Search index into, across the nodes you have available in your cluster with the Search Service enabled.
 Use index partitions to increase index and query performance on large datasets.
 
 NOTE: The scoring calculation for regular Search queries can be affected by the number of partitions in your Search index, and how the Search Service distributes documents across partitions.
 This is a limitation of the https://en.wikipedia.org/wiki/Tf%E2%80%93idf[tf-idf^] weighting scheme.
 
-|numReplicas |Number |Yes a|
+|numReplicas |Integer |Yes a|
 
 For high-availability, set the number of replicas the Search Service creates for the Search index. 
 
@@ -1041,7 +1050,7 @@ If the document field's `type` is `text`, set the analyzer to use for the docume
 
 NOTE: If you want to use the default analyzer for the content of this document field, you do not need to include an `analyzer` property.  
 
-|[[dims]]dims |Number |Vector Only a|
+|[[dims]]dims |Integer |Vector Only a|
 
 include::partial$vector-search-field-descriptions.adoc[tag=dimension]
 
@@ -1107,5 +1116,137 @@ For more information about the available field data types, see xref:field-data-t
 |[#vector-index-optimized-param]#vector_index_optimized_for# |String |Vector Only a|
 
 include::partial$vector-search-field-descriptions.adoc[tag=optimized_for] 
+
+|====
+
+[#store]
+== Store Object 
+
+The `store` object can change settings for merge policy, concurrent persister behavior, and file format version on your Search index.
+Depending on your performance needs and specific Search use case, you may want to adjust these values, or leave them as default. 
+
+You do not need to provide this object when creating a Search index.
+
+[source,json]
+----
+include::example$simple-search-index-payload.jsonc[tag=store]
+----
+
+TIP: To view the entire JSON payload, click btn:[View].
+
+The `store` object contains the following properties: 
+
+[cols="1,1,1,2"]
+|====
+|Property |Type |Required? |Description
+
+|indexType |String |No |The `indexType` is always `scorch`.
+
+|scorchPersisterOptions |Object |No a|
+
+[.status]#Couchbase Server 8.0#
+
+An object that contains settings for in-memory buffer processing in your Search index.
+
+For more information, see <<scorch-persister,>>.
+
+|scorchMergePlanOptions |Object |No a|
+
+[.status]#Couchbase Server 8.0#
+
+An object that contains settings for background merging behavior in your Search index.
+
+For more information, see <<scorch-merge,>>.
+
+|segmentVersion |Integer |No |The `segmentVersion` is always `16`.
+
+|====
+
+[#scorch-persister]
+=== ScorchPersisterOptions Object
+
+[.status]#Couchbase Server 8.0#
+
+The `scorchPersisterOptions` object controls in-memory buffer processing on your Search index.
+
+[source,json]
+----
+include::example$simple-search-index-payload.jsonc[tag=scorch_persister]
+----
+
+TIP: To view the entire JSON payload, click btn:[View].
+
+The `scorchPersisterOptions` object contains the following properties: 
+
+[cols="1,1,1,2"]
+|====
+|Property |Type |Required? |Description
+
+|[[max_size_memory_merge]]maxSizeInMemoryMergePerWorker |Integer |No |
+
+Set a value, in bytes, for how much data from the in-memory buffers each worker should process and flush to disk. 
+
+A higher value means healthier data flushing from memory to disk, but longer flushing times for each worker, because of the higher data volume.
+
+For a FTS Vector Index, set `maxSizeInMemoryMergePerWorker` to 400 MB.
+
+For a regular Search index, set `maxSizeInMemoryMergePerWorker` to 20 MB.
+
+You may want to change these recommended values based on your specific use case. 
+
+|numPersisterWorkers |Integer |No |
+
+Set a value for the total number of workers you want to use to process data from in-memory buffers. 
+
+More workers increases the rate of memory being flushed to disk, but increases the number of files on disk and your disk I/O. 
+
+For a FTS Vector Index, set `numPersisterWorkers` to `4`.
+
+For a regular Search index, set `numPersisterWorkers` to `4`.
+
+You may want to change these recommended values based on your specific use case.
+If you increase your workers, make sure to increase the <<floor_segment_size,floorSegmentFileSize>>, to keep your number of segment files low.
+
+|====
+
+[#scorch-merge]
+=== ScorchMergePlanOptions Object
+
+[.status]#Couchbase Server 8.0#
+
+The `scorchMergePlanOptions` object controls the background merging behavior for segment files in your Search index. 
+
+[source,json]
+----
+include::example$simple-search-index-payload.jsonc[tag=scorch_merge]
+----
+
+TIP: To view the entire JSON payload, click btn:[View].
+
+The `scorchMergePlanOptions` object contains the following properties: 
+
+[cols="1,1,1,2"]
+|====
+|Property |Type |Required? |Description
+
+|[[floor_segment_size]]floorSegmentFileSize |Integer |No a|
+
+Set a value, in bytes, for the Search Service's minimum segment file size.
+The Search Service merges segments to improve query performance and storage.
+If a segment is smaller than this minimum file size, the Search Service will merge it during its background merging.
+
+A higher value for the minimum segment file size means more aggressive merging behavior and better query performance, at the cost of increased disk I/O and longer merge cycles, with more resource usage.
+
+For a FTS Vector Index, set `floorSegmentFileSize` to:
+
+stem:[(\m\a\x\SizeInMem\o\r\yMer\g\ePerW\o\r\ker)/3]
+
+If you want to improve I/O and indexing performance at the cost of query performance, set `floorSegmentFileSize` to: 
+
+stem:[(\m\a\x\SizeInMem\o\r\yMer\g\ePerW\o\r\ker)/6]
+
+For a regular Search index, set `floorSegmentFileSize` to the same value as <<max_size_memory_merge,maxSizeInMemoryMergePerWorker>>.
+
+You may want to change these recommended values based on your specific use case. 
 
 |====

--- a/preview/HEAD.yml
+++ b/preview/HEAD.yml
@@ -1,0 +1,6 @@
+sources:
+  docs-capella:
+    branches: [8-0-docs-uptake]
+override:
+  site:
+    startPage: cloud:get-started:intro.adoc


### PR DESCRIPTION
Adding documentation on the `store` object for a Search index, which also had some new parameters added to it for 8.0 

Preview site link: https://preview.docs-test.couchbase.com/docs-devex-AV-105751-8-0-fts-additional-store-params-capella/cloud/search/search-index-params.html#store

Preview site credentials: https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords