### PR TITLE
DOC-13306: Add documentation for indexer level scan timeout

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
@@ -440,25 +440,8 @@ In Couchbase Server 7.6.2 and later, you can change the default setting for the 
 
 If you change the default setting for `defer_build` to `true`, index creation operates in deferred build mode by default.
 
-To change the default setting for deferred builds, use the REST API to set the `indexer.settings.defer_build` property.
-For example,
-
-[source,sh]
-----
-curl http://$BASEURL:9102/settings -u $USER:$PASSWORD \
--d '{"indexer.settings.defer_build": true}'
-----
-
-Use the following command to retrieve the indexer settings:
-
-[source,sh]
-----
-curl -X GET http://$BASEURL:9102/settings -u $USER:$PASSWORD
-----
-
-* `$BASEURL` is the base URL for the API call, for example: `localhost`.
-* `$USER` is the username, for example: `Administrator`.
-* `$PASSWORD` is the password.
+To change the default setting for deferred builds, use the Index Settings REST API to set the `indexer.settings.defer_build` property.
+For an example, see xref:index-rest-settings:index.adoc#ex-defer-build[Defer Index Builds by Default].
 
 == Examples
 

--- a/modules/n1ql/pages/n1ql-language-reference/insert.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/insert.adoc
@@ -380,21 +380,8 @@ If you are inserting multiple documents, the statement aborts at the first error
 * Timeouts can affect the completion of an INSERT statement, especially when performing bulk inserts.
 Ensure that the timeout is set to a reasonable value that allows the bulk insert operation to complete.
 +
-To set the indexer timeout, use the REST API to set the `indexer.settings.scan_timeout` property.
-For example,
-+
-[source,sh]
-----
-curl http://localhost:9102/settings -u Administrator:password \
--d '{"indexer.settings.scan_timeout": 1200}'
-----
-+
-Use the following command to retrieve the indexer settings:
-+
-[source,sh]
-----
-curl -X GET http://localhost:9102/settings -u Administrator:password
-----
+To set the indexer timeout, use the Index Settings REST API to set the `indexer.settings.scan_timeout` property.
+For an example, see xref:index-rest-settings:index.adoc#ex-scan-timeout[Set the Indexer Scan Timeout].
 
 * When inserting multiple documents, no cleanup or rollback is done for the already inserted documents if the INSERT operations hits an error.
 This means, when you are inserting 10 documents, if the INSERT operation fails when inserting the 6th document, the operator quits and exits.


### PR DESCRIPTION
Docs issue: DOC-13306

Replaces Index Settings REST API examples with links to the new Index Settings REST API documentation.

Docs preview:
- [CREATE INDEX › Usage › Defer Index Builds by Default](https://preview.docs-test.couchbase.com/cb-swagger-DOC-13306/server/current/n1ql/n1ql-language-reference/createindex.html#defer-index-builds-by-default)
- [INSERT › Restrictions](https://preview.docs-test.couchbase.com/cb-swagger-DOC-13306/server/current/n1ql/n1ql-language-reference/insert.html#insert-restrictions)

Credentials: [Preview docs for internal review](https://couchbasecloud.atlassian.net/wiki/x/dYF_dQ#Preview-docs-for-internal-review)

Must be merged at the same time as the following PRs:

- https://github.com/couchbaselabs/cb-swagger/pull/177
- https://github.com/couchbase/docs-server/pull/3863