### PR TITLE
[DOC-11953] New options for INFER - 8.0

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/infer.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/infer.adoc
@@ -99,10 +99,6 @@ The default value is 0.6, which means two documents are considered similar if 60
 If set to a non-negative value, the statement skips fields that are at a nesting depth greater than or equal to this value.
 The resulting field includes a `nestingDepth` property indicating the depth of the field, with `0` indicating a top-level field.
 
-For this functionality we now track the depth of every field we have visit. 
-Using this depth information, if a non-negative "max_nesting_depth" value is provided we stop visiting fields that are at a nesting depth which is greater than or equal to this value. 
-The depth information is included as "nestingDepth" in the field's information with 0 indicating a top-level field.
-
 [[infer-flags]]
 [.var]`flags`:: Flags control the behavior of the INFER statement. 
 It can be a string or an array of strings.
@@ -567,357 +563,82 @@ WITH {"sample_size": 1500, "num_sample_values": 5, "similarity_metric": 0.0};
         "abv": {
           "#docs": 1209,
           "%docs": 80.6,
-          "nestingDepth": 0,
-          "samples": [
-            0,
-            4,
-            4.9,
-            5.8,
-            6
-          ],
+          "samples": [0, 4, ...],
           "type": "number"
         },
         "address": {
           "#docs": 291,
           "%docs": 19.4,
-          "items": {
-            "type": "string"
-          },
-          "maxItems": 1,
-          "minItems": 0,
-          "nestingDepth": 0,
-          "sampleSize": 0,
-          "samples": [
-            [],
-            [
-              "1201 First Avenue South"
-            ],
-            [
-              "2 Pinchy Lane"
-            ],
-            [
-              "4257 North Lincoln Avenue"
-            ],
-            [
-              "Great Barton Farm"
-            ]
-          ],
+          "samples": [["1201 First Avenue South"], ...],
           "type": "array"
         },
         "brewery_id": {
           "#docs": 1209,
           "%docs": 80.6,
-          "nestingDepth": 0,
-          "samples": [
-            "boston_beer_company",
-            "boulevard_brewing_company",
-            "bullfrog_brewery",
-            "grumpy_troll_restaurant_and_br...",
-            "hops_grillhouse_brewery_cherry..."
-          ],
+          "samples": ["boston_beer_company", ...],
           "type": "string"
         },
         "category": {
           "#docs": 914,
           "%docs": 60.93,
-          "nestingDepth": 0,
-          "samples": [
-            "British Ale",
-            "German Lager",
-            "Irish Ale",
-            "North American Ale",
-            "North American Lager"
-          ],
-          "type": "string"
-        },
-        "city": {
-          "#docs": 291,
-          "%docs": 19.4,
-          "nestingDepth": 0,
-          "samples": [
-            "Belfast",
-            "Dorchester",
-            "Exeter",
-            "Seattle",
-            "Uji"
-          ],
-          "type": "string"
-        },
-        "code": {
-          "#docs": 291,
-          "%docs": 19.4,
-          "nestingDepth": 0,
-          "samples": [
-            "98134",
-            "28801-3128",
-            "4915",
-            "60618",
-            ""
-          ],
-          "type": "string"
-        },
-        "country": {
-          "#docs": 291,
-          "%docs": 19.4,
-          "nestingDepth": 0,
-          "samples": [
-            "Czech Republic",
-            "Germany",
-            "Japan",
-            "United Kingdom",
-            "United States"
-          ],
-          "type": "string"
-        },
-        "description": {
-          "#docs": 1500,
-          "%docs": 100,
-          "nestingDepth": 0,
-          "samples": [
-            "The Wedge Brewing Co. is locat...",
-            "(No longer brewing)",
-            "New Jersey Beer Co. is dedicat...",
-            "The Catawba Valley Brewing Com...",
-            ""
-          ],
+          "samples": ["British Ale", ...],
           "type": "string"
         },
         "geo": {
           "#docs": 261,
           "%docs": 17.4,
-          "nestingDepth": 0,
           "properties": {
             "accuracy": {
               "#docs": 261,
               "%docs": 100,
-              "nestingDepth": 1,
-              "samples": [
-                "APPROXIMATE",
-                "GEOMETRIC_CENTER",
-                "RANGE_INTERPOLATED",
-                "ROOFTOP"
-              ],
+              "samples": ["APPROXIMATE", ...],
               "type": "string"
             },
             "lat": {
               "#docs": 261,
               "%docs": 100,
-              "nestingDepth": 1,
-              "samples": [
-                8.4841,
-                37.7702,
-                37.7825,
-                40.5843,
-                50.7767
-              ],
+              "samples": [8.4841, ...],
               "type": "number"
             },
             "lon": {
               "#docs": 261,
               "%docs": 100,
-              "nestingDepth": 1,
-              "samples": [
-                -122.445,
-                -122.393,
-                -98.3912,
-                -13.2287,
-                3.2785
-              ],
+              "samples": [-122.445, ...],
               "type": "number"
             }
           },
-          "samples": [
-            {
-              "accuracy": "APPROXIMATE",
-              "lat": 8.4841,
-              "lon": -13.2287
-            },
-            {
-              "accuracy": "RANGE_INTERPOLATED",
-              "lat": 37.7702,
-              "lon": -122.445
-            },
-            {
-              "accuracy": "RANGE_INTERPOLATED",
-              "lat": 40.5843,
-              "lon": -98.3912
-            },
-            {
-              "accuracy": "RANGE_INTERPOLATED",
-              "lat": 50.7767,
-              "lon": 3.2785
-            },
-            {
-              "accuracy": "ROOFTOP",
-              "lat": 37.7825,
-              "lon": -122.393
-            }
-          ],
           "type": "object"
-        },
-        "ibu": {
-          "#docs": 1209,
-          "%docs": 80.6,
-          "nestingDepth": 0,
-          "samples": [
-            0,
-            25,
-            41,
-            55,
-            65
-          ],
-          "type": "number"
         },
         "name": {
           "#docs": 1500,
           "%docs": 100,
-          "nestingDepth": 0,
-          "samples": [
-            "Eldridge, Pope and Co.",
-            "Keihan Uji Kotsu",
-            "Marshall Wharf Brewing Company",
-            "O'Hanlon's Brewing Company Ltd...",
-            "Pyramid Alehouse, Brewery and ..."
-          ],
-          "type": "string"
-        },
-        "phone": {
-          "#docs": 291,
-          "%docs": 19.4,
-          "nestingDepth": 0,
-          "samples": [
-            "81-0774-22-2359",
-            "1-206-682-3377",
-            "207-338-1707",
-            "44-(01404)-822412",
-            ""
-          ],
-          "type": "string"
-        },
-        "srm": {
-          "#docs": 1209,
-          "%docs": 80.6,
-          "nestingDepth": 0,
-          "samples": [
-            0,
-            6,
-            12.5,
-            13,
-            13.5
-          ],
-          "type": "number"
-        },
-        "state": {
-          "#docs": 291,
-          "%docs": 19.4,
-          "nestingDepth": 0,
-          "samples": [
-            "Devon",
-            "Dorset",
-            "Kinki",
-            "Maine",
-            "Washington"
-          ],
+          "samples": ["Eldridge, Pope and Co.", ...],
           "type": "string"
         },
         "style": {
           "#docs": 914,
           "%docs": 60.93,
-          "nestingDepth": 0,
-          "samples": [
-            "American-Style Amber/Red Ale",
-            "English-Style Pale Mild Ale",
-            "German-Style Oktoberfest",
-            "Irish-Style Red Ale",
-            "Porter"
-          ],
+          "samples": ["American-Style Amber/Red Ale", ...],
           "type": "string"
         },
         "type": {
           "#docs": 1500,
           "%docs": 100,
-          "nestingDepth": 0,
-          "samples": [
-            "beer",
-            "brewery"
-          ],
-          "type": "string"
-        },
-        "upc": {
-          "#docs": 1209,
-          "%docs": 80.6,
-          "nestingDepth": 0,
-          "samples": [
-            0,
-            7,
-            2147483647
-          ],
-          "type": "number"
-        },
-        "updated": {
-          "#docs": 1500,
-          "%docs": 100,
-          "nestingDepth": 0,
-          "samples": [
-            "2010-07-22 20:00:20",
-            "2010-11-14 11:17:07",
-            "2010-11-17 14:11:59",
-            "2010-12-20 16:17:52",
-            "2011-05-23 10:34:59"
-          ],
-          "type": "string"
-        },
-        "website": {
-          "#docs": 291,
-          "%docs": 19.4,
-          "nestingDepth": 0,
-          "samples": [
-            "http://www.wvwinery.com",
-            "http://inyourguts.blogspot.com...",
-            "http://wedgebrewing.com/",
-            "http://www.marshallwharf.com",
-            ""
-          ],
+          "samples": ["beer", "brewery"],
           "type": "string"
         },
         "~meta": {
           "#docs": 1500,
           "%docs": 100,
-          "nestingDepth": 0,
           "properties": {
             "id": {
-              "#docs": 1500,
-              "%docs": 100,
-              "nestingDepth": 1,
-              "samples": [
-                "eldridge_pope_and_co",
-                "keihan_uji_kotsu",
-                "marshall_wharf_brewing_company",
-                "o_hanlon_s_brewing_company_ltd",
-                "pyramid_alehouse_brewery_and_r..."
-              ],
+              "samples": ["eldridge_pope_and_co", ...],
               "type": "string"
             }
           },
-          "samples": [
-            {
-              "id": "eldridge_pope_and_co"
-            },
-            {
-              "id": "keihan_uji_kotsu"
-            },
-            {
-              "id": "marshall_wharf_brewing_company"
-            },
-            {
-              "id": "o_hanlon_s_brewing_company_ltd"
-            },
-            {
-              "id": "pyramid_alehouse_brewery_and_restaurant_seattle"
-            }
-          ],
           "type": "object"
-        }
+        },
+        ...
       },
       "type": "object"
     }
@@ -926,6 +647,7 @@ WITH {"sample_size": 1500, "num_sample_values": 5, "similarity_metric": 0.0};
 ----
 ====
 
+[[]ex-3]]
 .Infer metadata for a keyspace using flags
 ====
 include::ROOT:partial$query-context.adoc[tag=unset]
@@ -948,325 +670,65 @@ WITH {"sample_size": 1500, "num_sample_values": 5, "similarity_metric": 0.0,
         "abv": {
           "#docs": 806,
           "%docs": 80.6,
-          "nestingDepth": 0,
-          "samples": [
-            0,
-            5.3,
-            5.5,
-            6.7,
-            9
-          ],
+          "samples": [0, 5.3, ...],
           "type": "number"
         },
         "address": {
           "#docs": 194,
           "%docs": 19.4,
-          "items": {
-            "type": "string"
-          },
-          "maxItems": 1,
-          "minItems": 0,
-          "nestingDepth": 0,
-          "sampleSize": 0,
-          "samples": [
-            [],
-            [
-              "107 North Lincoln Avenue"
-            ],
-            [
-              "115 S. Fifth St."
-            ],
-            [
-              "Dominikanerstrae 6"
-            ],
-            [
-              "Piazza V Luglio, 15"
-            ]
-          ],
+          "samples": [["107 North Lincoln Avenue"], ...],
           "type": "array"
         },
         "brewery_id": {
           "#docs": 806,
           "%docs": 80.6,
-          "nestingDepth": 0,
-          "samples": [
-            "anheuser_busch",
-            "beach_brewing",
-            "crane_river_brewpub_and_cafe",
-            "duck_rabbit_craft_brewery",
-            "fish_brewing_company_fish_tail..."
-          ],
+          "samples": ["anheuser_busch", ...],
           "type": "string"
         },
         "category": {
           "#docs": 595,
           "%docs": 59.5,
-          "nestingDepth": 0,
-          "samples": [
-            "British Ale",
-            "German Lager",
-            "Irish Ale",
-            "North American Ale",
-            "North American Lager"
-          ],
-          "type": "string"
-        },
-        "city": {
-          "#docs": 194,
-          "%docs": 19.4,
-          "nestingDepth": 0,
-          "samples": [
-            "Bamberg",
-            "Cincinnati",
-            "Columbia",
-            "Hastings",
-            "Piozzo"
-          ],
-          "type": "string"
-        },
-        "code": {
-          "#docs": 194,
-          "%docs": 19.4,
-          "nestingDepth": 0,
-          "samples": [
-            "68901",
-            "0",
-            "18931",
-            "65201",
-            ""
-          ],
-          "type": "string"
-        },
-        "country": {
-          "#docs": 194,
-          "%docs": 19.4,
-          "nestingDepth": 0,
-          "samples": [
-            "Germany",
-            "Ireland",
-            "Italy",
-            "United Kingdom",
-            "United States"
-          ],
-          "type": "string"
-        },
-        "description": {
-          "#docs": 1000,
-          "%docs": 100,
-          "nestingDepth": 0,
-          "samples": [
-            "Fish Tale Organic India Pale A...",
-            "Brilliantly golden, Jasperilla...",
-            "Dogtoberfest are shrouded in m...",
-            "Duck-Rabbit Amber Ale is a med...",
-            ""
-          ],
+          "samples": ["British Ale", ...],
           "type": "string"
         },
         "geo": {
           "#docs": 180,
           "%docs": 18,
-          "nestingDepth": 0,
           "properties": {
             "accuracy": {
               "#docs": 180,
               "%docs": 100,
-              "nestingDepth": 1,
-              "samples": [
-                "APPROXIMATE",
-                "GEOMETRIC_CENTER",
-                "RANGE_INTERPOLATED",
-                "ROOFTOP"
-              ],
+              "samples": ["APPROXIMATE", ...],
               "type": "string"
             },
             "lat": {
               "#docs": 180,
               "%docs": 100,
-              "nestingDepth": 1,
-              "samples": [
-                38.95,
-                39.1361,
-                40.5843,
-                44.5153,
-                49.892
-              ],
+              "samples": [38.95, ...],
               "type": "number"
             },
             "lon": {
               "#docs": 180,
               "%docs": 100,
-              "nestingDepth": 1,
-              "samples": [
-                -98.3912,
-                -92.3323,
-                -84.5031,
-                7.8922,
-                10.8853
-              ],
+              "samples": [-98.3912, ...],
               "type": "number"
             }
           },
-          "samples": [
-            {
-              "accuracy": "APPROXIMATE",
-              "lat": 39.1361,
-              "lon": -84.5031
-            },
-            {
-              "accuracy": "RANGE_INTERPOLATED",
-              "lat": 40.5843,
-              "lon": -98.3912
-            },
-            {
-              "accuracy": "RANGE_INTERPOLATED",
-              "lat": 44.5153,
-              "lon": 7.8922
-            },
-            {
-              "accuracy": "ROOFTOP",
-              "lat": 38.95,
-              "lon": -92.3323
-            },
-            {
-              "accuracy": "ROOFTOP",
-              "lat": 49.892,
-              "lon": 10.8853
-            }
-          ],
           "type": "object"
-        },
-        "ibu": {
-          "#docs": 806,
-          "%docs": 80.6,
-          "nestingDepth": 0,
-          "samples": [
-            0,
-            65.5
-          ],
-          "type": "number"
         },
         "name": {
           "#docs": 1000,
           "%docs": 100,
-          "nestingDepth": 0,
-          "samples": [
-            "Duck-Rabbit Amber Ale",
-            "Green Valley Wild Hop Lager",
-            "Magic Brew",
-            "Organic India Pale Ale",
-            "Porter"
-          ],
-          "type": "string"
-        },
-        "phone": {
-          "#docs": 194,
-          "%docs": 19.4,
-          "nestingDepth": 0,
-          "samples": [
-            "49-(0)951-/-56060",
-            "(573) 499-0400",
-            "1-402-463-3011",
-            "39-0173-795431",
-            ""
-          ],
-          "type": "string"
-        },
-        "srm": {
-          "#docs": 806,
-          "%docs": 80.6,
-          "nestingDepth": 0,
-          "samples": [
-            0,
-            22
-          ],
-          "type": "number"
-        },
-        "state": {
-          "#docs": 194,
-          "%docs": 19.4,
-          "nestingDepth": 0,
-          "samples": [
-            "Ohio",
-            "Bayern",
-            "Missouri",
-            "Nebraska",
-            ""
-          ],
-          "type": "string"
-        },
-        "style": {
-          "#docs": 595,
-          "%docs": 59.5,
-          "nestingDepth": 0,
-          "samples": [
-            "American-Style Amber/Red Ale",
-            "American-Style Brown Ale",
-            "American-Style India Pale Ale",
-            "American-Style Lager",
-            "Porter"
-          ],
-          "type": "string"
-        },
-        "type": {
-          "#docs": 1000,
-          "%docs": 100,
-          "nestingDepth": 0,
-          "samples": [
-            "beer",
-            "brewery"
-          ],
-          "type": "string"
-        },
-        "upc": {
-          "#docs": 806,
-          "%docs": 80.6,
-          "nestingDepth": 0,
-          "samples": [
-            0,
-            2147483647
-          ],
-          "type": "number"
-        },
-        "updated": {
-          "#docs": 1000,
-          "%docs": 100,
-          "nestingDepth": 0,
-          "samples": [
-            "2010-07-22 20:00:20",
-            "2010-12-03 17:58:29",
-            "2010-12-20 15:55:46",
-            "2010-12-20 16:14:15",
-            "2011-08-15 11:46:53"
-          ],
-          "type": "string"
-        },
-        "website": {
-          "#docs": 194,
-          "%docs": 19.4,
-          "nestingDepth": 0,
-          "samples": [
-            "http://www.realalebrewing.com/",
-            "http://www.diageo.ie/Company/B...",
-            "http://www.flatbranch.com",
-            "http://www.peteswicked.com/",
-            ""
-          ],
+          "samples": ["Duck-Rabbit Amber Ale", ...],
           "type": "string"
         },
         "xattrs": {
           "#docs": 1000,
           "%docs": 100,
-          "nestingDepth": 0,
-          "samples": [
-            null,
-            null,
-            null,
-            null,
-            null
-          ],
+          "samples": [null, ...],
           "type": "missing"
-        }
+        },
+        ...
       },
       "type": "object"
     }

--- a/modules/n1ql/pages/n1ql-language-reference/infer.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/infer.adoc
@@ -91,6 +91,77 @@ The `similarity_metric` is the degree of similarity that two schemas must have t
 You can specify a real number between 0 and 1 indicating the percentage match (of attributes) required to establish similarity between two documents.
 The default value is 0.6, which means two documents are considered similar if 60% of the top-level attributes are the same.
 
+[.var]`flags`:: A set of flags that control the behavior of the INFER statement.
+The following flags are supported: 
++
+[cols="1,2", options="header"]
+|===
+| Flag | Description
+
+| `NO_FLAGS`
+| No specific flags are set.
+
+| `SINGLE_INDEX`
+| Restricts the operation to use only a single index.
+
+| `LIMIT_2_INDEXES`
+| Limits the operation to use at most two indexes.
+
+| `LIMIT_5_INDEXES`
+| Limits the operation to use at most five indexes.
+
+| `NO_RANDOM_ENTRY`
+| Disables the use of random entries in the operation.
+
+| `NO_PRIMARY_INDEX`
+| Excludes the primary index from being used.
+
+| `NO_SECONDARY_INDEX`
+| Excludes secondary indexes from being used.
+
+| `NO_RANDOM_INDEX_SAMPLE`
+| Disables random sampling of indexes.
+
+| `ALLOW_DUPLICATED_LEADING_KEY`
+| Allows duplicate leading keys in the operation.
+
+| `ALLOW_ARRAY_INDEXES`
+| Enables the use of array indexes.
+
+| `NO_LIMIT_RANDOM`
+| Removes any limit on random sampling.
+
+| `ALLOW_CONDITIONAL`
+| Enables conditional logic in the operation.
+
+| `ALLOW_SUPERSET_CONDITIONS`
+| Allows superset conditions in the operation.
+
+| `CACHE_KEYS`
+| Enables caching of keys during the operation.
+
+| `RANDOM_ENTRY_LAST`
+| Ensures that random entries are processed last.
+
+| `NO_RANDOM_SCAN`
+| Disables random scanning of documents.
+
+| `SAMPLE_ALL_DOCS`
+| Samples all documents in the dataset.
+
+| `SAMPLE_ALLOW_EXTRA`
+| Allows additional documents to be included in the sample beyond the specified limit.
+
+| `FULL_SCAN`
+| Forces a full scan of the dataset.
+
+| `ALLOW_DUPS`
+| Allows duplicate documents to be included in the operation.
+
+| `INCLUDE_KEY`
+| Includes the `~meta` attribute in the output, which contains the `id` property describing document keys.
+|===
+
 [.var]`dictionary_threshold`:: Sometimes JSON documents follow the dictionary pattern, where a field has sub-fields that are key-value pairs, instead of general field-name and value pairs.
 For example, consider a sub-document called "ratings", where the name of each rating object is a user ID:
 +

--- a/modules/n1ql/pages/n1ql-language-reference/infer.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/infer.adoc
@@ -647,7 +647,7 @@ WITH {"sample_size": 1500, "num_sample_values": 5, "similarity_metric": 0.0};
 ----
 ====
 
-[[]ex-3]]
+[[ex-3]]
 .Infer metadata for a keyspace using flags
 ====
 include::ROOT:partial$query-context.adoc[tag=unset]

--- a/modules/n1ql/pages/n1ql-language-reference/infer.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/infer.adoc
@@ -100,8 +100,7 @@ If set to a non-negative value, the statement skips fields that are at a nesting
 The resulting field includes a `nestingDepth` property indicating the depth of the field, with `0` indicating a top-level field.
 
 [[infer-flags]]
-[.var]`flags`:: Flags control the behavior of the INFER statement. 
-It can be a string or an array of strings.
+[.var]`flags`:: An array of strings representing flags that can control the behavior of the INFER statement. 
 You can specify one or more of the following flags:
 +
 [cols="1,2", options="header"]
@@ -111,12 +110,14 @@ You can specify one or more of the following flags:
 | `allow_dups`
 | Allows including duplicate documents in the infer analysis.
 
+When multiple retrieval methods (such as secondary index, primary index, sequential scan, random scan, or random entry provider) are used, this flag prevents deduplication and ensures all retrieved documents are included, even if they share the same key. 
+
 | `include_xattrs`
-| Includes extended attributes (xattrs) in the output.
+| Includes schema information for the extended attributes (xattrs) of each document in the output.
 
 | `include_key`
-| Includes the `~meta` attribute in the output. 
-It contains the `id` property that holds the document keys.
+| Includes schema information for the document keys in the output. 
+If specified, it adds a `~meta` attribute, which contains the `id` property representing the document keys.
 |===
 
 [.var]`dictionary_threshold`:: Sometimes JSON documents follow the dictionary pattern, where a field has sub-fields that are key-value pairs, instead of general field-name and value pairs.

--- a/modules/n1ql/pages/n1ql-language-reference/infer.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/infer.adoc
@@ -91,6 +91,7 @@ The `similarity_metric` is the degree of similarity that two schemas must have t
 You can specify a real number between 0 and 1 indicating the percentage match (of attributes) required to establish similarity between two documents.
 The default value is 0.6, which means two documents are considered similar if 60% of the top-level attributes are the same.
 
+[[infer-flags]]
 [.var]`flags`:: A set of flags that control the behavior of the INFER statement.
 The following flags are supported: 
 +
@@ -218,6 +219,11 @@ Each property is described by a key-value pair, in which the key is the name of 
 Details for Documents and Subdocuments::
 [.out]`$schema`;; Specifies the version of the JSON Schema standard.
 [.out]`Flavor`;; Specifies the flavor of a document or sub-document.
+
+NOTE: From Couchbase Server 8.0 onwards, the `~meta` attribute is included in the output of the INFER statement by default. 
+This attribute contains the `id` property that describes the document keys.
+However, if you use the `flags` option to customize the behavior of the INFER analysis, you must explicitly set the `INCLUDE_KEY` flag to include the `~meta` attribute in the output. 
+For more information about the available flags, see <<infer-flags,flags>>.
 
 == Examples
 
@@ -535,6 +541,175 @@ WITH {"sample_size": 10000, "num_sample_values": 5, "similarity_metric": 0.0};
               }
           }
       ]
+]
+----
+====
+
+[[ex-3]]
+.Infer metadata for a keyspace using the `INCLUDE_KEY` flag
+====
+include::ROOT:partial$query-context.adoc[tag=example]
+
+[source,sqlpp]
+----
+INFER `travel-sample`.inventory.hotel WITH {"flags": ["INCLUDE_KEY"]};
+----
+.Results
+[source,json]
+----
+[
+  [
+    {
+      "#docs": 187,
+      "$schema": "http://json-schema.org/draft-06/schema",
+      "Flavor": "`type` = \"airline\"",
+      "properties": {
+        "callsign": {
+          "#docs": [
+            53,
+            134
+          ],
+          "%docs": [
+            28.34,
+            71.65
+          ],
+          "samples": [
+            [
+              null
+            ],
+            [
+              "AIR WISCONSIN",
+              "FLYSTAR",
+              "NIGHT CARGO",
+              "REGIONAL EUROPE",
+              "WESTERN"
+            ]
+          ],
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "country": {
+          "#docs": 187,
+          "%docs": 100,
+          "samples": [
+            "France",
+            "United Kingdom",
+            "United States"
+          ],
+          "type": "string"
+        },
+        "iata": {
+          "#docs": [
+            32,
+            155
+          ],
+          "%docs": [
+            17.11,
+            82.88
+          ],
+          "samples": [
+            [
+              null
+            ],
+            [
+              "-+",
+              "H1",
+              "WP",
+              "YE",
+              "YX"
+            ]
+          ],
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "icao": {
+          "#docs": 187,
+          "%docs": 100,
+          "samples": [
+            "--+",
+            "HA1",
+            "MEP",
+            "MKU",
+            "YEL"
+          ],
+          "type": "string"
+        },
+        "id": {
+          "#docs": 187,
+          "%docs": 100,
+          "samples": [
+            3497,
+            8809,
+            13391,
+            16735,
+            18239
+          ],
+          "type": "number"
+        },
+        "name": {
+          "#docs": 187,
+          "%docs": 100,
+          "samples": [
+            "Hankook Air US",
+            "Island Air (WP)",
+            "Midwest Airlines",
+            "U.S. Air",
+            "Yellowtail"
+          ],
+          "type": "string"
+        },
+        "type": {
+          "#docs": 187,
+          "%docs": 100,
+          "samples": [
+            "airline"
+          ],
+          "type": "string"
+        },
+        "~meta": {
+          "#docs": 187,
+          "%docs": 100,
+          "properties": {
+            "id": {
+              "#docs": 187,
+              "%docs": 100,
+              "samples": [
+                "airline_13391",
+                "airline_16735",
+                "airline_18239",
+                "airline_3497",
+                "airline_8809"
+              ],
+              "type": "string"
+            }
+          },
+          "samples": [
+            {
+              "id": "airline_13391"
+            },
+            {
+              "id": "airline_16735"
+            },
+            {
+              "id": "airline_18239"
+            },
+            {
+              "id": "airline_3497"
+            },
+            {
+              "id": "airline_8809"
+            }
+          ],
+          "type": "object"
+        }
+      },
+      "type": "object"
+    }
+  ]
 ]
 ----
 ====

--- a/modules/n1ql/pages/n1ql-language-reference/infer.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/infer.adoc
@@ -82,6 +82,10 @@ An object with one or more of the following properties to guide the INFER statem
 The default sample size is 1000 documents.
 If a keyspace contains fewer documents than the specified [.var]`sample_size`, then all the documents in the keyspace will be used.
 
+[.var]`array_sample_size`:: Specifies the number of array elements to sample when inferring an array attribute.
+If set to a non-negative value, the statement trims the array samples to this value when their length exceeds it.
+The resulting array includes a `sampleSize` field indicating that this option was applied.
+
 [.var]`num_sample_values`:: Specifies the number of sample values for each attributes to be returned.
 The sample values provide examples of the data format.
 The default value is 5.
@@ -90,6 +94,14 @@ The default value is 5.
 The `similarity_metric` is the degree of similarity that two schemas must have to be considered part of the same flavor.
 You can specify a real number between 0 and 1 indicating the percentage match (of attributes) required to establish similarity between two documents.
 The default value is 0.6, which means two documents are considered similar if 60% of the top-level attributes are the same.
+
+[.var]`max_nesting_depth`:: Specifies the maximum depth of nested fields to explore during schema inference.
+If set to a non-negative value, the statement skips fields that are at a nesting depth greater than or equal to this value.
+The resulting field includes a `nestingDepth` property indicating the depth of the field, with `0` indicating a top-level field.
+
+For this functionality we now track the depth of every field we have visit. 
+Using this depth information, if a non-negative "max_nesting_depth" value is provided we stop visiting fields that are at a nesting depth which is greater than or equal to this value. 
+The depth information is included as "nestingDepth" in the field's information with 0 indicating a top-level field.
 
 [[infer-flags]]
 [.var]`flags`:: Flags control the behavior of the INFER statement. 
@@ -107,7 +119,8 @@ You can specify one or more of the following flags:
 | Includes extended attributes (xattrs) in the output.
 
 | `include_key`
-| Includes the `~meta` attribute in the output, which contains the `id` property describing document keys.
+| Includes the `~meta` attribute in the output. 
+It contains the `id` property that holds the document keys.
 |===
 
 [.var]`dictionary_threshold`:: Sometimes JSON documents follow the dictionary pattern, where a field has sub-fields that are key-value pairs, instead of general field-name and value pairs.
@@ -167,19 +180,17 @@ Details for Documents and Subdocuments::
 [.out]`$schema`;; Specifies the version of the JSON Schema standard.
 [.out]`Flavor`;; Specifies the flavor of a document or sub-document.
 
-Metadata Details:: 
+Details for Document Keys:: 
 [.out]`~meta`;; Contains the `id` property that holds the document keys.
 +
 By default, the INFER statement includes this attribute in the output. 
 However, you can control this behavior using the `flags` option in the WITH clause.
 +
 --
-* If you do not use the `flags` option, INFER automatically includes the `~meta` attribute.
-* If you use the `flags` option, INFER will not return `~meta` unless you specify the `include_key` flag.
---
-+
+* If you do not use `flags`, INFER automatically includes the `~meta` attribute.
+* If you add any value for `flags`, INFER will not return `~meta` unless you explicitly specify the `include_key` flag.
 For more information about the available flags, see <<infer-flags,flags>>.
-+
+--
 NOTE: The `~meta` attribute is only available in Couchbase Server 8.0 and later.
 
 == Examples
@@ -193,151 +204,340 @@ include::ROOT:partial$query-context.adoc[tag=example]
 [source,sqlpp]
 ----
 INFER route
-WITH {"sample_size": 10000, "num_sample_values": 2, "similarity_metric": 0.1};
+WITH {"sample_size": 1000, "num_sample_values": 2, "similarity_metric": 0.1};
 ----
 
 .Results
 [source,json]
 ----
 [
-  [
-    {
-      "#docs": 10000,
-      "$schema": "http://json-schema.org/draft-06/schema",
-      "Flavor": "`type` = \"route\"",
-      "properties": {
-        "airline": {
-          "#docs": 10000,
-          "%docs": 100,
-          "samples": [
-            "DL",
-            "WS"
-          ],
-          "type": "string"
-        },
-        "airlineid": {
-          "#docs": 10000,
-          "%docs": 100,
-          "samples": [
-            "airline_2009",
-            "airline_5416"
-          ],
-          "type": "string"
-        },
-        "destinationairport": {
-          "#docs": 10000,
-          "%docs": 100,
-          "samples": [
-            "DFW",
-            "JFK"
-          ],
-          "type": "string"
-        },
-        "distance": {
-          "#docs": 10000,
-          "%docs": 100,
-          "samples": [
-            682.2052742100271,
-            2819.371084516147
-          ],
-          "type": "number"
-        },
-        "equipment": {
-          "#docs": [
-            9,
-            9991
-          ],
-          "%docs": [
-            0.09,
-            99.91
-          ],
-          "samples": [
-            [
-              null
-            ],
-            [
-              "738",
-              "ERJ"
-            ]
-          ],
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "id": {
-          "#docs": 10000,
-          "%docs": 100,
-          "samples": [
-            20436,
-            64755
-          ],
-          "type": "number"
-        },
-        "schedule": {
-          "#docs": 10000,
-          "%docs": 100,
-          "items": {
-            "#docs": 210598,
-            "$schema": "http://json-schema.org/draft-06/schema",
-            "properties": {
-              "day": {
-                "type": "number"
-              },
-              "flight": {
+    [{
+        "#docs": 1000,
+        "$schema": "http://json-schema.org/draft-06/schema",
+        "Flavor": "`stops` = 0, `type` = \"route\"",
+        "properties": {
+            "airline": {
+                "#docs": 1000,
+                "%docs": 100,
+                "nestingDepth": 0,
+                "samples": [
+                    "AS",
+                    "DY"
+                ],
                 "type": "string"
-              },
-              "utc": {
-                "type": "string"
-              }
             },
-            "type": "object"
-          },
-          "maxItems": 34,
-          "minItems": 9,
-          "samples": [
-            [
-              {
-                "day": 0,
-                "flight": "DL070",
-                "utc": "07:46:00"
-              },
-              ...
-            ],
-            ...
-          ],
-          "type": "array"
+            "airlineid": {
+                "#docs": 1000,
+                "%docs": 100,
+                "nestingDepth": 0,
+                "samples": [
+                    "airline_3737",
+                    "airline_439"
+                ],
+                "type": "string"
+            },
+            "destinationairport": {
+                "#docs": 1000,
+                "%docs": 100,
+                "nestingDepth": 0,
+                "samples": [
+                    "ANC",
+                    "PDX"
+                ],
+                "type": "string"
+            },
+            "distance": {
+                "#docs": 1000,
+                "%docs": 100,
+                "nestingDepth": 0,
+                "samples": [
+                    527.1102210477263,
+                    787.4315848714039
+                ],
+                "type": "number"
+            },
+            "equipment": {
+                "#docs": [
+                    1,
+                    999
+                ],
+                "%docs": [
+                    0.1,
+                    99.9
+                ],
+                "nestingDepth": 0,
+                "samples": [
+                    [
+                        null
+                    ],
+                    [
+                        "DH4",
+                        "SF3"
+                    ]
+                ],
+                "type": [
+                    "null",
+                    "string"
+                ]
+            },
+            "id": {
+                "#docs": 1000,
+                "%docs": 100,
+                "nestingDepth": 0,
+                "samples": [
+                    11629,
+                    12027
+                ],
+                "type": "number"
+            },
+            "schedule": {
+                "#docs": 1000,
+                "%docs": 100,
+                "items": {
+                    "#docs": 21104,
+                    "$schema": "http://json-schema.org/draft-06/schema",
+                    "properties": {
+                        "day": {
+                            "nestingDepth": 2,
+                            "type": "number"
+                        },
+                        "flight": {
+                            "nestingDepth": 2,
+                            "type": "string"
+                        },
+                        "utc": {
+                            "nestingDepth": 2,
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "maxItems": 31,
+                "minItems": 9,
+                "nestingDepth": 0,
+                "sampleSize": 0,
+                "samples": [
+                    [{
+                            "day": 0,
+                            "flight": "AS801",
+                            "utc": "02:11:00"
+                        },
+                        {
+                            "day": 0,
+                            "flight": "AS337",
+                            "utc": "22:04:00"
+                        },
+                        {
+                            "day": 0,
+                            "flight": "AS194",
+                            "utc": "00:57:00"
+                        },
+                        {
+                            "day": 1,
+                            "flight": "AS415",
+                            "utc": "13:27:00"
+                        },
+                        {
+                            "day": 1,
+                            "flight": "AS036",
+                            "utc": "08:47:00"
+                        },
+                        {
+                            "day": 1,
+                            "flight": "AS787",
+                            "utc": "06:06:00"
+                        },
+                        {
+                            "day": 2,
+                            "flight": "AS054",
+                            "utc": "09:31:00"
+                        },
+                        {
+                            "day": 2,
+                            "flight": "AS629",
+                            "utc": "11:16:00"
+                        },
+                        {
+                            "day": 3,
+                            "flight": "AS662",
+                            "utc": "05:27:00"
+                        },
+                        {
+                            "day": 3,
+                            "flight": "AS025",
+                            "utc": "15:24:00"
+                        },
+                        {
+                            "day": 4,
+                            "flight": "AS671",
+                            "utc": "09:52:00"
+                        },
+                        {
+                            "day": 4,
+                            "flight": "AS391",
+                            "utc": "18:28:00"
+                        },
+                        {
+                            "day": 5,
+                            "flight": "AS624",
+                            "utc": "21:10:00"
+                        },
+                        {
+                            "day": 5,
+                            "flight": "AS162",
+                            "utc": "14:11:00"
+                        },
+                        {
+                            "day": 6,
+                            "flight": "AS547",
+                            "utc": "16:24:00"
+                        },
+                        {
+                            "day": 6,
+                            "flight": "AS154",
+                            "utc": "05:07:00"
+                        }
+                    ],
+                    [{
+                            "day": 0,
+                            "flight": "AS844",
+                            "utc": "23:22:00"
+                        },
+                        {
+                            "day": 0,
+                            "flight": "AS611",
+                            "utc": "22:13:00"
+                        },
+                        {
+                            "day": 0,
+                            "flight": "AS181",
+                            "utc": "16:33:00"
+                        },
+                        {
+                            "day": 1,
+                            "flight": "AS944",
+                            "utc": "16:11:00"
+                        },
+                        {
+                            "day": 2,
+                            "flight": "AS855",
+                            "utc": "01:18:00"
+                        },
+                        {
+                            "day": 3,
+                            "flight": "AS763",
+                            "utc": "22:32:00"
+                        },
+                        {
+                            "day": 3,
+                            "flight": "AS463",
+                            "utc": "21:54:00"
+                        },
+                        {
+                            "day": 3,
+                            "flight": "AS010",
+                            "utc": "09:15:00"
+                        },
+                        {
+                            "day": 3,
+                            "flight": "AS186",
+                            "utc": "06:48:00"
+                        },
+                        {
+                            "day": 4,
+                            "flight": "AS652",
+                            "utc": "18:43:00"
+                        },
+                        {
+                            "day": 5,
+                            "flight": "AS204",
+                            "utc": "15:30:00"
+                        },
+                        {
+                            "day": 5,
+                            "flight": "AS450",
+                            "utc": "09:03:00"
+                        },
+                        {
+                            "day": 6,
+                            "flight": "AS135",
+                            "utc": "04:46:00"
+                        },
+                        {
+                            "day": 6,
+                            "flight": "AS673",
+                            "utc": "23:17:00"
+                        },
+                        {
+                            "day": 6,
+                            "flight": "AS436",
+                            "utc": "02:48:00"
+                        },
+                        {
+                            "day": 6,
+                            "flight": "AS174",
+                            "utc": "03:47:00"
+                        }
+                    ]
+                ],
+                "type": "array"
+            },
+            "sourceairport": {
+                "#docs": 1000,
+                "%docs": 100,
+                "nestingDepth": 0,
+                "samples": [
+                    "DLG",
+                    "STS"
+                ],
+                "type": "string"
+            },
+            "stops": {
+                "#docs": 1000,
+                "%docs": 100,
+                "nestingDepth": 0,
+                "samples": [
+                    0
+                ],
+                "type": "number"
+            },
+            "type": {
+                "#docs": 1000,
+                "%docs": 100,
+                "nestingDepth": 0,
+                "samples": [
+                    "route"
+                ],
+                "type": "string"
+            },
+            "~meta": {
+                "#docs": 1000,
+                "%docs": 100,
+                "nestingDepth": 0,
+                "properties": {
+                    "id": {
+                        "#docs": 1000,
+                        "%docs": 100,
+                        "nestingDepth": 1,
+                        "samples": [
+                            "route_11629",
+                            "route_12027"
+                        ],
+                        "type": "string"
+                    }
+                },
+                "samples": [{
+                        "id": "route_11629"
+                    },
+                    {
+                        "id": "route_12027"
+                    }
+                ],
+                "type": "object"
+            }
         },
-        "sourceairport": {
-          "#docs": 10000,
-          "%docs": 100,
-          "samples": [
-            "CLE",
-            "YVR"
-          ],
-          "type": "string"
-        },
-        "stops": {
-          "#docs": 10000,
-          "%docs": 100,
-          "samples": [
-            0,
-            1
-          ],
-          "type": "number"
-        },
-        "type": {
-          "#docs": 10000,
-          "%docs": 100,
-          "samples": [
-            "route"
-          ],
-          "type": "string"
-        }
-      },
-      "type": "object"
-    }
-  ]
+        "type": "object"
+    }]
 ]
 ----
 ====
@@ -351,165 +551,389 @@ include::ROOT:partial$query-context.adoc[tag=unset]
 [source,sqlpp]
 ----
 INFER `beer-sample`
-WITH {"sample_size": 10000, "num_sample_values": 5, "similarity_metric": 0.0};
+WITH {"sample_size": 1500, "num_sample_values": 5, "similarity_metric": 0.0};
 ----
 
 .Results
 [source,json]
 ----
 [
-    [
-        {
-            "#docs": 823,
-            "$schema": "http://json-schema.org/draft-06/schema",
-            "Flavor": "type = \"beer\"",
-            "properties": {
-                "abv": {
-                    "#docs": 823,
-                    "%docs": 100,
-                    "samples": [
-                        0,
-                        9,
-                        9.5,
-                        8,
-                        7.7
-                    ],
-                    "type": "number"
-                },
-                "brewery_id": {
-                    "#docs": 823,
-                    "%docs": 100,
-                    "samples": [
-                        "san_diego_brewing",
-                        "drake_s_brewing",
-                        "brouwerij_de_achelse_kluis",
-                        "niagara_falls_brewing",
-                        "brasserie_des_cimes"
-                    ],
-                    "type": "string"
-                  },
-                  "category": {
-                      "#docs": 612,
-                      "%docs": 74.36,
-                      "samples": [
-                          "North American Ale",
-                          "British Ale",
-                          "German Lager",
-                          "Belgian and French Ale",
-                          "Irish Ale"
-                      ],
-                      "type": "string"
-                  },
-                  "description": {
-                      "#docs": 823,
-                      "%docs": 100,
-                      "samples": [
-                          "Robust, Dark and Smooth, ho...",
-                          "\"Pride of Milford\" is a very s...",
-                          "Mogul is a complex blend of 5 ...",
-                          "Just like our Porter but multi...",
-                          ""
-                      ],
-                      "type": "string"
-                  },
-                  "ibu": {
-                      "#docs": 823,
-                      "%docs": 100,
-                      "samples": [
-                          0,
-                          55,
-                          35,
-                          20
-                      ],
-                      "type": "number"
-                  },
-                  "name": {
-                      "#docs": 823,
-                      "%docs": 100,
-                      "samples": [
-                          "Old 395 Barleywine",
-                          "Jolly Roger",
-                          "Trappist Extra",
-                          "Maple Wheat",
-                          "Yeti"
-                      ],
-                      "type": "string"
-                  },
-                  "srm": {
-                      "#docs": 823,
-                      "%docs": 100,
-                      "samples": [
-                          0,
-                          6,
-                          45,
-                          30
-                      ],
-                      "type": "number"
-                  },
-                  "style": {
-                      "#docs": 612,
-                      "%docs": 74.36,
-                      "samples": [
-                          "American-Style Pale Ale",
-                          "Classic English-Style Pale Ale",
-                          "American-Style India Pale Ale",
-                          "German-Style Pilsener",
-                          "Other Belgian-Style Ales"
-                      ],
-                      "type": "string"
-                  },
-                  "type": {
-                      "#docs": 823,
-                      "%docs": 100,
-                      "samples": [
-                          "beer"
-                      ],
-                      "type": "string"
-                  },
-                  "upc": {
-                      "#docs": 823,
-                      "%docs": 100,
-                      "samples": [
-                          0,
-                          2147483647
-                      ],
-                      "type": "number"
-                  },
-                  "updated": {
-                      "#docs": 823,
-                      "%docs": 100,
-                      "samples": [
-                          "2010-07-22 20:00:20",
-                          "2010-12-13 19:33:36",
-                          "2011-05-17 03:27:08",
-                          "2011-04-17 12:25:31",
-                          "2011-04-17 12:33:50"
-                      ],
-                      "type": "string"
-                  }
-              }
+  [
+    {
+      "#docs": 1500,
+      "$schema": "http://json-schema.org/draft-06/schema",
+      "Flavor": "",
+      "properties": {
+        "abv": {
+          "#docs": 1209,
+          "%docs": 80.6,
+          "nestingDepth": 0,
+          "samples": [
+            0,
+            4,
+            4.9,
+            5.8,
+            6
+          ],
+          "type": "number"
+        },
+        "address": {
+          "#docs": 291,
+          "%docs": 19.4,
+          "items": {
+            "type": "string"
           },
-          {
-              "#docs": 177,
-              "$schema": "http://json-schema.org/draft-06/schema",
-              "Flavor": "type = \"brewery\"",
-              "properties": {
-                  ...
-              }
-          }
-      ]
+          "maxItems": 1,
+          "minItems": 0,
+          "nestingDepth": 0,
+          "sampleSize": 0,
+          "samples": [
+            [],
+            [
+              "1201 First Avenue South"
+            ],
+            [
+              "2 Pinchy Lane"
+            ],
+            [
+              "4257 North Lincoln Avenue"
+            ],
+            [
+              "Great Barton Farm"
+            ]
+          ],
+          "type": "array"
+        },
+        "brewery_id": {
+          "#docs": 1209,
+          "%docs": 80.6,
+          "nestingDepth": 0,
+          "samples": [
+            "boston_beer_company",
+            "boulevard_brewing_company",
+            "bullfrog_brewery",
+            "grumpy_troll_restaurant_and_br...",
+            "hops_grillhouse_brewery_cherry..."
+          ],
+          "type": "string"
+        },
+        "category": {
+          "#docs": 914,
+          "%docs": 60.93,
+          "nestingDepth": 0,
+          "samples": [
+            "British Ale",
+            "German Lager",
+            "Irish Ale",
+            "North American Ale",
+            "North American Lager"
+          ],
+          "type": "string"
+        },
+        "city": {
+          "#docs": 291,
+          "%docs": 19.4,
+          "nestingDepth": 0,
+          "samples": [
+            "Belfast",
+            "Dorchester",
+            "Exeter",
+            "Seattle",
+            "Uji"
+          ],
+          "type": "string"
+        },
+        "code": {
+          "#docs": 291,
+          "%docs": 19.4,
+          "nestingDepth": 0,
+          "samples": [
+            "98134",
+            "28801-3128",
+            "4915",
+            "60618",
+            ""
+          ],
+          "type": "string"
+        },
+        "country": {
+          "#docs": 291,
+          "%docs": 19.4,
+          "nestingDepth": 0,
+          "samples": [
+            "Czech Republic",
+            "Germany",
+            "Japan",
+            "United Kingdom",
+            "United States"
+          ],
+          "type": "string"
+        },
+        "description": {
+          "#docs": 1500,
+          "%docs": 100,
+          "nestingDepth": 0,
+          "samples": [
+            "The Wedge Brewing Co. is locat...",
+            "(No longer brewing)",
+            "New Jersey Beer Co. is dedicat...",
+            "The Catawba Valley Brewing Com...",
+            ""
+          ],
+          "type": "string"
+        },
+        "geo": {
+          "#docs": 261,
+          "%docs": 17.4,
+          "nestingDepth": 0,
+          "properties": {
+            "accuracy": {
+              "#docs": 261,
+              "%docs": 100,
+              "nestingDepth": 1,
+              "samples": [
+                "APPROXIMATE",
+                "GEOMETRIC_CENTER",
+                "RANGE_INTERPOLATED",
+                "ROOFTOP"
+              ],
+              "type": "string"
+            },
+            "lat": {
+              "#docs": 261,
+              "%docs": 100,
+              "nestingDepth": 1,
+              "samples": [
+                8.4841,
+                37.7702,
+                37.7825,
+                40.5843,
+                50.7767
+              ],
+              "type": "number"
+            },
+            "lon": {
+              "#docs": 261,
+              "%docs": 100,
+              "nestingDepth": 1,
+              "samples": [
+                -122.445,
+                -122.393,
+                -98.3912,
+                -13.2287,
+                3.2785
+              ],
+              "type": "number"
+            }
+          },
+          "samples": [
+            {
+              "accuracy": "APPROXIMATE",
+              "lat": 8.4841,
+              "lon": -13.2287
+            },
+            {
+              "accuracy": "RANGE_INTERPOLATED",
+              "lat": 37.7702,
+              "lon": -122.445
+            },
+            {
+              "accuracy": "RANGE_INTERPOLATED",
+              "lat": 40.5843,
+              "lon": -98.3912
+            },
+            {
+              "accuracy": "RANGE_INTERPOLATED",
+              "lat": 50.7767,
+              "lon": 3.2785
+            },
+            {
+              "accuracy": "ROOFTOP",
+              "lat": 37.7825,
+              "lon": -122.393
+            }
+          ],
+          "type": "object"
+        },
+        "ibu": {
+          "#docs": 1209,
+          "%docs": 80.6,
+          "nestingDepth": 0,
+          "samples": [
+            0,
+            25,
+            41,
+            55,
+            65
+          ],
+          "type": "number"
+        },
+        "name": {
+          "#docs": 1500,
+          "%docs": 100,
+          "nestingDepth": 0,
+          "samples": [
+            "Eldridge, Pope and Co.",
+            "Keihan Uji Kotsu",
+            "Marshall Wharf Brewing Company",
+            "O'Hanlon's Brewing Company Ltd...",
+            "Pyramid Alehouse, Brewery and ..."
+          ],
+          "type": "string"
+        },
+        "phone": {
+          "#docs": 291,
+          "%docs": 19.4,
+          "nestingDepth": 0,
+          "samples": [
+            "81-0774-22-2359",
+            "1-206-682-3377",
+            "207-338-1707",
+            "44-(01404)-822412",
+            ""
+          ],
+          "type": "string"
+        },
+        "srm": {
+          "#docs": 1209,
+          "%docs": 80.6,
+          "nestingDepth": 0,
+          "samples": [
+            0,
+            6,
+            12.5,
+            13,
+            13.5
+          ],
+          "type": "number"
+        },
+        "state": {
+          "#docs": 291,
+          "%docs": 19.4,
+          "nestingDepth": 0,
+          "samples": [
+            "Devon",
+            "Dorset",
+            "Kinki",
+            "Maine",
+            "Washington"
+          ],
+          "type": "string"
+        },
+        "style": {
+          "#docs": 914,
+          "%docs": 60.93,
+          "nestingDepth": 0,
+          "samples": [
+            "American-Style Amber/Red Ale",
+            "English-Style Pale Mild Ale",
+            "German-Style Oktoberfest",
+            "Irish-Style Red Ale",
+            "Porter"
+          ],
+          "type": "string"
+        },
+        "type": {
+          "#docs": 1500,
+          "%docs": 100,
+          "nestingDepth": 0,
+          "samples": [
+            "beer",
+            "brewery"
+          ],
+          "type": "string"
+        },
+        "upc": {
+          "#docs": 1209,
+          "%docs": 80.6,
+          "nestingDepth": 0,
+          "samples": [
+            0,
+            7,
+            2147483647
+          ],
+          "type": "number"
+        },
+        "updated": {
+          "#docs": 1500,
+          "%docs": 100,
+          "nestingDepth": 0,
+          "samples": [
+            "2010-07-22 20:00:20",
+            "2010-11-14 11:17:07",
+            "2010-11-17 14:11:59",
+            "2010-12-20 16:17:52",
+            "2011-05-23 10:34:59"
+          ],
+          "type": "string"
+        },
+        "website": {
+          "#docs": 291,
+          "%docs": 19.4,
+          "nestingDepth": 0,
+          "samples": [
+            "http://www.wvwinery.com",
+            "http://inyourguts.blogspot.com...",
+            "http://wedgebrewing.com/",
+            "http://www.marshallwharf.com",
+            ""
+          ],
+          "type": "string"
+        },
+        "~meta": {
+          "#docs": 1500,
+          "%docs": 100,
+          "nestingDepth": 0,
+          "properties": {
+            "id": {
+              "#docs": 1500,
+              "%docs": 100,
+              "nestingDepth": 1,
+              "samples": [
+                "eldridge_pope_and_co",
+                "keihan_uji_kotsu",
+                "marshall_wharf_brewing_company",
+                "o_hanlon_s_brewing_company_ltd",
+                "pyramid_alehouse_brewery_and_r..."
+              ],
+              "type": "string"
+            }
+          },
+          "samples": [
+            {
+              "id": "eldridge_pope_and_co"
+            },
+            {
+              "id": "keihan_uji_kotsu"
+            },
+            {
+              "id": "marshall_wharf_brewing_company"
+            },
+            {
+              "id": "o_hanlon_s_brewing_company_ltd"
+            },
+            {
+              "id": "pyramid_alehouse_brewery_and_restaurant_seattle"
+            }
+          ],
+          "type": "object"
+        }
+      },
+      "type": "object"
+    }
+  ]
 ]
 ----
 ====
 
-[[ex-3]]
-.Infer metadata for a keyspace using the `INCLUDE_KEY` flag
+.Infer metadata for a keyspace using flags
 ====
-include::ROOT:partial$query-context.adoc[tag=example]
-
+include::ROOT:partial$query-context.adoc[tag=unset]
 [source,sqlpp]
 ----
-INFER `travel-sample`.inventory.hotel WITH {"flags": ["INCLUDE_KEY"]};
+INFER `beer-sample`
+WITH {"sample_size": 1500, "num_sample_values": 5, "similarity_metric": 0.0, 
+      "flags": ["include_key", "include_xattrs"]};
 ----
 .Results
 [source,json]
@@ -517,151 +941,331 @@ INFER `travel-sample`.inventory.hotel WITH {"flags": ["INCLUDE_KEY"]};
 [
   [
     {
-      "#docs": 187,
+      "#docs": 1000,
       "$schema": "http://json-schema.org/draft-06/schema",
-      "Flavor": "`type` = \"airline\"",
+      "Flavor": "",
       "properties": {
-        "callsign": {
-          "#docs": [
-            53,
-            134
-          ],
-          "%docs": [
-            28.34,
-            71.65
-          ],
+        "abv": {
+          "#docs": 806,
+          "%docs": 80.6,
+          "nestingDepth": 0,
           "samples": [
+            0,
+            5.3,
+            5.5,
+            6.7,
+            9
+          ],
+          "type": "number"
+        },
+        "address": {
+          "#docs": 194,
+          "%docs": 19.4,
+          "items": {
+            "type": "string"
+          },
+          "maxItems": 1,
+          "minItems": 0,
+          "nestingDepth": 0,
+          "sampleSize": 0,
+          "samples": [
+            [],
             [
-              null
+              "107 North Lincoln Avenue"
             ],
             [
-              "AIR WISCONSIN",
-              "FLYSTAR",
-              "NIGHT CARGO",
-              "REGIONAL EUROPE",
-              "WESTERN"
+              "115 S. Fifth St."
+            ],
+            [
+              "Dominikanerstrae 6"
+            ],
+            [
+              "Piazza V Luglio, 15"
             ]
           ],
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": "array"
+        },
+        "brewery_id": {
+          "#docs": 806,
+          "%docs": 80.6,
+          "nestingDepth": 0,
+          "samples": [
+            "anheuser_busch",
+            "beach_brewing",
+            "crane_river_brewpub_and_cafe",
+            "duck_rabbit_craft_brewery",
+            "fish_brewing_company_fish_tail..."
+          ],
+          "type": "string"
+        },
+        "category": {
+          "#docs": 595,
+          "%docs": 59.5,
+          "nestingDepth": 0,
+          "samples": [
+            "British Ale",
+            "German Lager",
+            "Irish Ale",
+            "North American Ale",
+            "North American Lager"
+          ],
+          "type": "string"
+        },
+        "city": {
+          "#docs": 194,
+          "%docs": 19.4,
+          "nestingDepth": 0,
+          "samples": [
+            "Bamberg",
+            "Cincinnati",
+            "Columbia",
+            "Hastings",
+            "Piozzo"
+          ],
+          "type": "string"
+        },
+        "code": {
+          "#docs": 194,
+          "%docs": 19.4,
+          "nestingDepth": 0,
+          "samples": [
+            "68901",
+            "0",
+            "18931",
+            "65201",
+            ""
+          ],
+          "type": "string"
         },
         "country": {
-          "#docs": 187,
-          "%docs": 100,
+          "#docs": 194,
+          "%docs": 19.4,
+          "nestingDepth": 0,
           "samples": [
-            "France",
+            "Germany",
+            "Ireland",
+            "Italy",
             "United Kingdom",
             "United States"
           ],
           "type": "string"
         },
-        "iata": {
-          "#docs": [
-            32,
-            155
-          ],
-          "%docs": [
-            17.11,
-            82.88
-          ],
-          "samples": [
-            [
-              null
-            ],
-            [
-              "-+",
-              "H1",
-              "WP",
-              "YE",
-              "YX"
-            ]
-          ],
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "icao": {
-          "#docs": 187,
+        "description": {
+          "#docs": 1000,
           "%docs": 100,
+          "nestingDepth": 0,
           "samples": [
-            "--+",
-            "HA1",
-            "MEP",
-            "MKU",
-            "YEL"
+            "Fish Tale Organic India Pale A...",
+            "Brilliantly golden, Jasperilla...",
+            "Dogtoberfest are shrouded in m...",
+            "Duck-Rabbit Amber Ale is a med...",
+            ""
           ],
           "type": "string"
         },
-        "id": {
-          "#docs": 187,
-          "%docs": 100,
-          "samples": [
-            3497,
-            8809,
-            13391,
-            16735,
-            18239
-          ],
-          "type": "number"
-        },
-        "name": {
-          "#docs": 187,
-          "%docs": 100,
-          "samples": [
-            "Hankook Air US",
-            "Island Air (WP)",
-            "Midwest Airlines",
-            "U.S. Air",
-            "Yellowtail"
-          ],
-          "type": "string"
-        },
-        "type": {
-          "#docs": 187,
-          "%docs": 100,
-          "samples": [
-            "airline"
-          ],
-          "type": "string"
-        },
-        "~meta": {
-          "#docs": 187,
-          "%docs": 100,
+        "geo": {
+          "#docs": 180,
+          "%docs": 18,
+          "nestingDepth": 0,
           "properties": {
-            "id": {
-              "#docs": 187,
+            "accuracy": {
+              "#docs": 180,
               "%docs": 100,
+              "nestingDepth": 1,
               "samples": [
-                "airline_13391",
-                "airline_16735",
-                "airline_18239",
-                "airline_3497",
-                "airline_8809"
+                "APPROXIMATE",
+                "GEOMETRIC_CENTER",
+                "RANGE_INTERPOLATED",
+                "ROOFTOP"
               ],
               "type": "string"
+            },
+            "lat": {
+              "#docs": 180,
+              "%docs": 100,
+              "nestingDepth": 1,
+              "samples": [
+                38.95,
+                39.1361,
+                40.5843,
+                44.5153,
+                49.892
+              ],
+              "type": "number"
+            },
+            "lon": {
+              "#docs": 180,
+              "%docs": 100,
+              "nestingDepth": 1,
+              "samples": [
+                -98.3912,
+                -92.3323,
+                -84.5031,
+                7.8922,
+                10.8853
+              ],
+              "type": "number"
             }
           },
           "samples": [
             {
-              "id": "airline_13391"
+              "accuracy": "APPROXIMATE",
+              "lat": 39.1361,
+              "lon": -84.5031
             },
             {
-              "id": "airline_16735"
+              "accuracy": "RANGE_INTERPOLATED",
+              "lat": 40.5843,
+              "lon": -98.3912
             },
             {
-              "id": "airline_18239"
+              "accuracy": "RANGE_INTERPOLATED",
+              "lat": 44.5153,
+              "lon": 7.8922
             },
             {
-              "id": "airline_3497"
+              "accuracy": "ROOFTOP",
+              "lat": 38.95,
+              "lon": -92.3323
             },
             {
-              "id": "airline_8809"
+              "accuracy": "ROOFTOP",
+              "lat": 49.892,
+              "lon": 10.8853
             }
           ],
           "type": "object"
+        },
+        "ibu": {
+          "#docs": 806,
+          "%docs": 80.6,
+          "nestingDepth": 0,
+          "samples": [
+            0,
+            65.5
+          ],
+          "type": "number"
+        },
+        "name": {
+          "#docs": 1000,
+          "%docs": 100,
+          "nestingDepth": 0,
+          "samples": [
+            "Duck-Rabbit Amber Ale",
+            "Green Valley Wild Hop Lager",
+            "Magic Brew",
+            "Organic India Pale Ale",
+            "Porter"
+          ],
+          "type": "string"
+        },
+        "phone": {
+          "#docs": 194,
+          "%docs": 19.4,
+          "nestingDepth": 0,
+          "samples": [
+            "49-(0)951-/-56060",
+            "(573) 499-0400",
+            "1-402-463-3011",
+            "39-0173-795431",
+            ""
+          ],
+          "type": "string"
+        },
+        "srm": {
+          "#docs": 806,
+          "%docs": 80.6,
+          "nestingDepth": 0,
+          "samples": [
+            0,
+            22
+          ],
+          "type": "number"
+        },
+        "state": {
+          "#docs": 194,
+          "%docs": 19.4,
+          "nestingDepth": 0,
+          "samples": [
+            "Ohio",
+            "Bayern",
+            "Missouri",
+            "Nebraska",
+            ""
+          ],
+          "type": "string"
+        },
+        "style": {
+          "#docs": 595,
+          "%docs": 59.5,
+          "nestingDepth": 0,
+          "samples": [
+            "American-Style Amber/Red Ale",
+            "American-Style Brown Ale",
+            "American-Style India Pale Ale",
+            "American-Style Lager",
+            "Porter"
+          ],
+          "type": "string"
+        },
+        "type": {
+          "#docs": 1000,
+          "%docs": 100,
+          "nestingDepth": 0,
+          "samples": [
+            "beer",
+            "brewery"
+          ],
+          "type": "string"
+        },
+        "upc": {
+          "#docs": 806,
+          "%docs": 80.6,
+          "nestingDepth": 0,
+          "samples": [
+            0,
+            2147483647
+          ],
+          "type": "number"
+        },
+        "updated": {
+          "#docs": 1000,
+          "%docs": 100,
+          "nestingDepth": 0,
+          "samples": [
+            "2010-07-22 20:00:20",
+            "2010-12-03 17:58:29",
+            "2010-12-20 15:55:46",
+            "2010-12-20 16:14:15",
+            "2011-08-15 11:46:53"
+          ],
+          "type": "string"
+        },
+        "website": {
+          "#docs": 194,
+          "%docs": 19.4,
+          "nestingDepth": 0,
+          "samples": [
+            "http://www.realalebrewing.com/",
+            "http://www.diageo.ie/Company/B...",
+            "http://www.flatbranch.com",
+            "http://www.peteswicked.com/",
+            ""
+          ],
+          "type": "string"
+        },
+        "xattrs": {
+          "#docs": 1000,
+          "%docs": 100,
+          "nestingDepth": 0,
+          "samples": [
+            null,
+            null,
+            null,
+            null,
+            null
+          ],
+          "type": "missing"
         }
       },
       "type": "object"

--- a/modules/n1ql/pages/n1ql-language-reference/infer.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/infer.adoc
@@ -655,8 +655,8 @@ include::ROOT:partial$query-context.adoc[tag=unset]
 [source,sqlpp]
 ----
 INFER `beer-sample`
-WITH {"sample_size": 1500, "num_sample_values": 5, "similarity_metric": 0.0, 
-      "flags": ["include_key", "include_xattrs"]};
+WITH {"sample_size": 1500, "num_sample_values": 10, "similarity_metric": 0.0, 
+      "flags": ["allow_dups", "include_xattrs"]};
 ----
 .Results
 [source,json]
@@ -664,72 +664,39 @@ WITH {"sample_size": 1500, "num_sample_values": 5, "similarity_metric": 0.0,
 [
   [
     {
-      "#docs": 1000,
+      "#docs": 1500,
       "$schema": "http://json-schema.org/draft-06/schema",
-      "Flavor": "",
       "properties": {
         "abv": {
-          "#docs": 806,
-          "%docs": 80.6,
-          "samples": [0, 5.3, ...],
+          "#docs": 1199,
+          "%docs": 79.93,
+          "samples": [0, 3.5, 5, 5.3, 5.5, ...],
           "type": "number"
         },
-        "address": {
-          "#docs": 194,
-          "%docs": 19.4,
-          "samples": [["107 North Lincoln Avenue"], ...],
-          "type": "array"
-        },
         "brewery_id": {
-          "#docs": 806,
-          "%docs": 80.6,
-          "samples": ["anheuser_busch", ...],
+          "#docs": 1199,
+          "%docs": 79.93,
+          "samples": ["anchor_brewing", "brasserie_duyck", ...],
           "type": "string"
-        },
-        "category": {
-          "#docs": 595,
-          "%docs": 59.5,
-          "samples": ["British Ale", ...],
-          "type": "string"
-        },
-        "geo": {
-          "#docs": 180,
-          "%docs": 18,
-          "properties": {
-            "accuracy": {
-              "#docs": 180,
-              "%docs": 100,
-              "samples": ["APPROXIMATE", ...],
-              "type": "string"
-            },
-            "lat": {
-              "#docs": 180,
-              "%docs": 100,
-              "samples": [38.95, ...],
-              "type": "number"
-            },
-            "lon": {
-              "#docs": 180,
-              "%docs": 100,
-              "samples": [-98.3912, ...],
-              "type": "number"
-            }
-          },
-          "type": "object"
         },
         "name": {
-          "#docs": 1000,
+          "#docs": 1500,
           "%docs": 100,
-          "samples": ["Duck-Rabbit Amber Ale", ...],
+          "samples": ["All Saints Belgian Golden Ale", "Cornhusker Lager", ...],
+          "type": "string"
+        },
+        "type": {
+          "#docs": 1500,
+          "%docs": 100,
+          "samples": ["beer", "brewery"],
           "type": "string"
         },
         "xattrs": {
-          "#docs": 1000,
+          "#docs": 1500,
           "%docs": 100,
-          "samples": [null, ...],
+          "samples": [null, null, ...],
           "type": "missing"
-        },
-        ...
+        }
       },
       "type": "object"
     }

--- a/modules/n1ql/pages/n1ql-language-reference/infer.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/infer.adoc
@@ -92,74 +92,21 @@ You can specify a real number between 0 and 1 indicating the percentage match (o
 The default value is 0.6, which means two documents are considered similar if 60% of the top-level attributes are the same.
 
 [[infer-flags]]
-[.var]`flags`:: A set of flags that control the behavior of the INFER statement.
-The following flags are supported: 
+[.var]`flags`:: Flags control the behavior of the INFER statement. 
+It can be a string or an array of strings.
+You can specify one or more of the following flags:
 +
 [cols="1,2", options="header"]
 |===
 | Flag | Description
 
-| `NO_FLAGS`
-| No specific flags are set.
+| `allow_dups`
+| Allows including duplicate documents in the infer analysis.
 
-| `SINGLE_INDEX`
-| Restricts the operation to use only a single index.
+| `include_xattrs`
+| Includes extended attributes (xattrs) in the output.
 
-| `LIMIT_2_INDEXES`
-| Limits the operation to use at most two indexes.
-
-| `LIMIT_5_INDEXES`
-| Limits the operation to use at most five indexes.
-
-| `NO_RANDOM_ENTRY`
-| Disables the use of random entries in the operation.
-
-| `NO_PRIMARY_INDEX`
-| Excludes the primary index from being used.
-
-| `NO_SECONDARY_INDEX`
-| Excludes secondary indexes from being used.
-
-| `NO_RANDOM_INDEX_SAMPLE`
-| Disables random sampling of indexes.
-
-| `ALLOW_DUPLICATED_LEADING_KEY`
-| Allows duplicate leading keys in the operation.
-
-| `ALLOW_ARRAY_INDEXES`
-| Enables the use of array indexes.
-
-| `NO_LIMIT_RANDOM`
-| Removes any limit on random sampling.
-
-| `ALLOW_CONDITIONAL`
-| Enables conditional logic in the operation.
-
-| `ALLOW_SUPERSET_CONDITIONS`
-| Allows superset conditions in the operation.
-
-| `CACHE_KEYS`
-| Enables caching of keys during the operation.
-
-| `RANDOM_ENTRY_LAST`
-| Ensures that random entries are processed last.
-
-| `NO_RANDOM_SCAN`
-| Disables random scanning of documents.
-
-| `SAMPLE_ALL_DOCS`
-| Samples all documents in the dataset.
-
-| `SAMPLE_ALLOW_EXTRA`
-| Allows additional documents to be included in the sample beyond the specified limit.
-
-| `FULL_SCAN`
-| Forces a full scan of the dataset.
-
-| `ALLOW_DUPS`
-| Allows duplicate documents to be included in the operation.
-
-| `INCLUDE_KEY`
+| `include_key`
 | Includes the `~meta` attribute in the output, which contains the `id` property describing document keys.
 |===
 
@@ -220,10 +167,20 @@ Details for Documents and Subdocuments::
 [.out]`$schema`;; Specifies the version of the JSON Schema standard.
 [.out]`Flavor`;; Specifies the flavor of a document or sub-document.
 
-NOTE: From Couchbase Server 8.0 onwards, the `~meta` attribute is included in the output of the INFER statement by default. 
-This attribute contains the `id` property that describes the document keys.
-However, if you use the `flags` option to customize the behavior of the INFER analysis, you must explicitly set the `INCLUDE_KEY` flag to include the `~meta` attribute in the output. 
+Metadata Details:: 
+[.out]`~meta`;; Contains the `id` property that holds the document keys.
++
+By default, the INFER statement includes this attribute in the output. 
+However, you can control this behavior using the `flags` option in the WITH clause.
++
+--
+* If you do not use the `flags` option, INFER automatically includes the `~meta` attribute.
+* If you use the `flags` option, INFER will not return `~meta` unless you specify the `include_key` flag.
+--
++
 For more information about the available flags, see <<infer-flags,flags>>.
++
+NOTE: The `~meta` attribute is only available in Couchbase Server 8.0 and later.
 
 == Examples
 


### PR DESCRIPTION
Doc tickets: DOC-11953, DOC-13497

Added the following new options for INFER:  ~meta, flags, array_sample_size, max_nesting_depth.
Also, updated the examples show the usage of these options. 

Doc previews:

- [Syntax > Options](https://preview.docs-test.couchbase.com/docs-devex-DOC-11953-update-infer-statement/server/current/n1ql/n1ql-language-reference/infer.html#infer-parameters)
- [Schema Output > ~meta](https://preview.docs-test.couchbase.com/docs-devex-DOC-11953-update-infer-statement/server/current/n1ql/n1ql-language-reference/infer.html#schema-output)
- [Examples](https://preview.docs-test.couchbase.com/docs-devex-DOC-11953-update-infer-statement/server/current/n1ql/n1ql-language-reference/infer.html#examples)
