### PR TITLE
[DOC-13546] Update reserved keywords list

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/reservedwords.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/reservedwords.adoc
@@ -50,7 +50,7 @@ The following keywords are reserved and cannot be used as unescaped identifiers:
 | AT
 
 | BEGIN
-| BETWEEN
+| xref:n1ql-language-reference/comparisonops.adoc#between[BETWEEN]
 | xref:n1ql-language-reference/datatypes.adoc#datatype-binary[BINARY]
 | xref:n1ql-language-reference/datatypes.adoc#datatype-boolean[BOOLEAN]
 | BREAK
@@ -60,7 +60,7 @@ The following keywords are reserved and cannot be used as unescaped identifiers:
 | BY
 | CACHE
 | CALL
-| CASE
+| xref:n1ql-language-reference/conditionalops.adoc[CASE]
 | CAST
 
 | CLUSTER
@@ -100,15 +100,15 @@ The following keywords are reserved and cannot be used as unescaped identifiers:
 
 | xref:n1ql-language-reference/collectionops.adoc#collection-op-every[EVERY]
 | xref:n1ql-language-reference/union.adoc[EXCEPT]
-| EXCLUDE
-| EXECUTE
+| xref:n1ql-language-reference/selectclause.adoc#sec_ExcludeClause[EXCLUDE]
+| xref:n1ql-language-reference/execute.adoc[EXECUTE]
 | xref:n1ql-language-reference/collectionops.adoc#exists[EXISTS]
 | xref:n1ql-language-reference/explain.adoc[EXPLAIN]
 
 | FALSE
 | FETCH
 | FILTER
-| FIRST
+| xref:n1ql-language-reference/collectionops.adoc#first[FIRST]
 | FLATTEN
 | FLATTEN_KEYS
 
@@ -121,7 +121,7 @@ The following keywords are reserved and cannot be used as unescaped identifiers:
 
 | xref:n1ql-language-reference/createfunction.adoc[FUNCTION]
 | GOLANG
-| GRANT
+| xref:n1ql-language-reference/grant.adoc[GRANT]
 | xref:n1ql-language-reference/groupby.adoc[GROUP]
 | xref:n1ql-language-reference/window.adoc#window-frame-clause[GROUPS]
 | xref:n1ql-language-reference/hints.adoc#index-type[GSI]
@@ -136,14 +136,14 @@ The following keywords are reserved and cannot be used as unescaped identifiers:
 | INCLUDE
 | INCREMENT
 | INDEX
-| INFER
+| xref:n1ql-language-reference/infer.adoc[INFER]
 | INLINE
 | INNER
 
 | xref:n1ql-language-reference/insert.adoc[INSERT]
 | xref:n1ql-language-reference/union.adoc[INTERSECT]
 | INTO
-| IS
+| xref:n1ql-language-reference/comparisonops.adoc#is[IS]
 | xref:n1ql:n1ql-language-reference/set-transaction.adoc[ISOLATION]
 | xref:n1ql-language-reference/createfunction.adoc[JAVASCRIPT]
 
@@ -161,7 +161,7 @@ The following keywords are reserved and cannot be used as unescaped identifiers:
 | LETTING
 | xref:n1ql:n1ql-language-reference/set-transaction.adoc[LEVEL]
 
-| LIKE
+| xref:n1ql-language-reference/comparisonops.adoc#like[LIKE]
 | xref:n1ql-language-reference/limit.adoc[LIMIT]
 | LSM
 | MAP
@@ -208,7 +208,7 @@ The following keywords are reserved and cannot be used as unescaped identifiers:
 | PATH
 | POOL
 | xref:n1ql-language-reference/window.adoc#window-frame-extent[PRECEDING]
-| PREPARE
+| xref:n1ql-language-reference/prepare.adoc[PREPARE]
 
 | PREV
 | PREVIOUS
@@ -235,7 +235,7 @@ The following keywords are reserved and cannot be used as unescaped identifiers:
 | RESTRICT
 | RETURN
 | RETURNING
-| REVOKE
+| xref:n1ql-language-reference/revoke.adoc[REVOKE]
 | RIGHT
 
 | ROLE
@@ -277,7 +277,7 @@ The following keywords are reserved and cannot be used as unescaped identifiers:
 | UNIQUE
 | UNKNOWN
 | xref:n1ql-language-reference/unnest.adoc[UNNEST]
-| UNSET
+| xref:n1ql-language-reference/update.adoc#unset-clause[UNSET]
 | xref:n1ql-language-reference/update.adoc[UPDATE]
 
 | xref:n1ql-language-reference/upsert.adoc[UPSERT]
@@ -297,8 +297,8 @@ The following keywords are reserved and cannot be used as unescaped identifiers:
 | WHEN
 | xref:n1ql-language-reference/where.adoc[WHERE]
 | WHILE
-| WINDOW
-| WITH
+| xref:n1ql-language-reference/window.adoc[WINDOW]
+| xref:n1ql-language-reference/with.adoc[WITH]
 | xref:n1ql-language-reference/collectionops.adoc#collection-op-within[WITHIN]
 
 | xref:n1ql:n1ql-language-reference/begin-transaction.adoc[WORK]

--- a/modules/n1ql/pages/n1ql-language-reference/reservedwords.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/reservedwords.adoc
@@ -309,3 +309,7 @@ The following keywords are reserved and cannot be used as unescaped identifiers:
 |
 
 |===
+
+TIP: You can combine `USING` with the keyword `AI` to form the statement `USING AI`.
+This statement uses AI capabilities to convert natural language prompts into {sqlpp} queries.
+For more information, see xref:n1ql-language-reference/using-ai.adoc[].

--- a/modules/n1ql/pages/n1ql-language-reference/reservedwords.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/reservedwords.adoc
@@ -310,6 +310,5 @@ The following keywords are reserved and cannot be used as unescaped identifiers:
 
 |===
 
-TIP: You can combine `USING` with the keyword `AI` to form the statement `USING AI`.
-This statement uses AI capabilities to convert natural language prompts into {sqlpp} queries.
-For more information, see xref:n1ql-language-reference/using-ai.adoc[].
+NOTE: The word `AI` is not a reserved word, even though you can use it in combination with the `USING` keyword as part of the xref:n1ql-language-reference/using-ai.adoc[USING AI] statement.
+You do not have to escape the word `AI` inside backticks when using it by itself as an identifier.

--- a/modules/n1ql/pages/n1ql-language-reference/reservedwords.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/reservedwords.adoc
@@ -171,133 +171,141 @@ The following keywords are reserved and cannot be used as unescaped identifiers:
 | MATERIALIZED
 | MAXVALUE
 | xref:n1ql-language-reference/merge.adoc[MERGE]
+| MINUS
 | MINVALUE
 | xref:n1ql-language-reference/comparisonops.adoc#null-and-missing[MISSING]
-| NAMESPACE
 
+| NAMESPACE
+| NAMESPACE_ID
 | xref:n1ql-language-reference/nest.adoc[NEST]
 | NEXT
 | NEXTVAL
 | xref:n1ql-language-reference/join.adoc#use-nl-hint[NL]
+
 | xref:n1ql-language-reference/window.adoc#window-frame-exclusion[NO]
 | xref:n1ql-language-reference/logicalops.adoc#logical-op-not[NOT]
-
+| NOT_A_TOKEN
 | xref:n1ql-language-reference/windowfun.adoc#fn-window-nth-value[NTH_VALUE]
 | xref:n1ql-language-reference/comparisonops.adoc#null-and-missing[NULL]
 | xref:n1ql-language-reference/window.adoc#nulls-treatment[NULLS]
+
 | NUMBER
 | OBJECT
 | xref:n1ql-language-reference/offset.adoc[OFFSET]
-
 | ON
 | OPTION
 | xref:n1ql-language-reference/insert.adoc#insert-values[OPTIONS]
+
 | xref:n1ql-language-reference/logicalops.adoc#or-operator[OR]
 | xref:n1ql-language-reference/orderby.adoc[ORDER]
 | xref:n1ql-language-reference/window.adoc#window-frame-exclusion[OTHERS]
-
 | OUTER
 | xref:n1ql-language-reference/window.adoc[OVER]
 | PARSE
+
 | PARTITION
 | PASSWORD
 | PATH
-
 | POOL
 | xref:n1ql-language-reference/window.adoc#window-frame-extent[PRECEDING]
 | PREPARE
+
 | PREV
 | PREVIOUS
 | PREVVAL
-
 | PRIMARY
 | PRIVATE
 | PRIVILEGE
+
 | xref:n1ql-language-reference/join.adoc#use-hash-hint[PROBE]
 | PROCEDURE
 | PUBLIC
-
 | xref:n1ql-language-reference/window.adoc#window-frame-clause[RANGE]
 | RAW
 | READ
+
 | REALM
 | RECURSIVE
 | REDUCE
-
 | RENAME
 | REPLACE
 | xref:n1ql-language-reference/window.adoc#nulls-treatment[RESPECT]
+
 | RESTART
 | RESTRICT
 | RETURN
-
 | RETURNING
 | REVOKE
 | RIGHT
+
 | ROLE
+| ROLES
 | xref:n1ql:n1ql-language-reference/rollback-transaction.adoc[ROLLBACK]
 | xref:n1ql-language-reference/window.adoc#window-frame-extent[ROW]
-
 | xref:n1ql-language-reference/window.adoc#window-frame-clause[ROWS]
 | SATISFIES
+
 | xref:n1ql:n1ql-language-reference/savepoint.adoc[SAVEPOINT]
 | SCHEMA
 | SCOPE
 | xref:n1ql-language-reference/selectclause.adoc[SELECT]
-
 | SELF
 | SEQUENCE
+
+| SEMI
 | SET
 | SHOW
 | SOME
 | START
-
 | STATISTICS
+
 | STRING
 | SYSTEM
 | THEN
 | xref:n1ql-language-reference/window.adoc#window-frame-exclusion[TIES]
 | TO
-
 | xref:n1ql:n1ql-language-reference/begin-transaction.adoc[TRAN]
+
 | xref:n1ql:n1ql-language-reference/begin-transaction.adoc[TRANSACTION]
 | TRIGGER
 | TRUE
 | TRUNCATE
 | xref:n1ql-language-reference/window.adoc#window-frame-extent[UNBOUNDED]
-
 | UNDER
+
 | xref:n1ql-language-reference/union.adoc[UNION]
 | UNIQUE
 | UNKNOWN
 | xref:n1ql-language-reference/unnest.adoc[UNNEST]
 | UNSET
-
 | xref:n1ql-language-reference/update.adoc[UPDATE]
+
 | xref:n1ql-language-reference/upsert.adoc[UPSERT]
 | xref:n1ql-language-reference/hints.adoc[USE]
 | USER
 | USERS
 | USING
-
 | VALIDATE
+
 | VALUE
 | VALUED
 | VALUES
 | VECTOR
 | VIA
-
 | VIEW
+
 | WHEN
 | xref:n1ql-language-reference/where.adoc[WHERE]
 | WHILE
 | WINDOW
 | WITH
-
 | xref:n1ql-language-reference/collectionops.adoc#collection-op-within[WITHIN]
+
 | xref:n1ql:n1ql-language-reference/begin-transaction.adoc[WORK]
 | XOR
 |
 |
 |
+|
+
 |===


### PR DESCRIPTION
Jira: DOC-13546

This PR adds the following keywords to the reserved words list: MINUS, NAMESPACE_ID, NOT_A_TOKEN, ROLES, and SEMI.
Also includes new xrefs for several existing keywords . 

Preview: [Reserved Words](https://preview.docs-test.couchbase.com/docs-devex-DOC-13546-reserved-keywords/server/current/n1ql/n1ql-language-reference/reservedwords.html)
