### PR TITLE
DOC-11697: Add landing page for SQL++ statements

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/index.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/index.adoc
@@ -29,8 +29,12 @@ The {sqlpp} language is composed of <<statements,statements>>, <<N1QL_Expression
 
 {sqlpp} statements are categorized into the following groups:
 
-* *Data Definition Language* (DDL) statements to {createindex}[create indexes], {alterindex}[modify indexes], and {dropindex}[drop indexes].
-* *Data Manipulation Language* (DML) statements to {selectintro}[select], {insert}[insert], {update}[update], {delete}[delete], and {upsert}[upsert] data into JSON documents.
+* *Data Definition Language* (DDL) statements enable you to create and modify database objects, such as users, keyspaces, and indexes.
+* *Data Control Language* (DCL) statements enable you to control which users or groups have access to data, and what they are permitted to do with that data.
+* *Data Manipulation Language* (DML) statements enable you to create, read, update, and delete data.
+Some DML statements may be further subcategorized as data query language, transaction control language, or utility statements.
+
+For more details, see xref:n1ql:n1ql-language-reference/statements.adoc[].
 
 [[N1QL_Expressions]]
 == Expressions

--- a/modules/n1ql/pages/n1ql-language-reference/statements.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/statements.adoc
@@ -92,7 +92,7 @@ xref:n1ql:n1ql-language-reference/set-transaction.adoc[]
 === Utility Statements
 
 Utility statements don't manipulate data directly, but support other operations.
-For example, you can create and execute prepared statements, explain query plans, advise you on query or index creation, and so on.
+For example, you can create and execute prepared statements, see query plans, get advice on query or index creation, and so on.
 
 [%hardbreaks]
 xref:n1ql:n1ql-language-reference/advise.adoc[]

--- a/modules/n1ql/pages/n1ql-language-reference/statements.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/statements.adoc
@@ -16,7 +16,7 @@ include::ROOT:partial$component-signpost.adoc[]
 [#ddl]
 == Data Definition Language
 
-Data definition language (DDL) statements enable you to create and modify database objects, such as users, keyspaces, and indexes.
+Data definition language (DDL) statements enable you to create and modify database objects, such as users, buckets, and indexes.
 
 [%hardbreaks.two-columns]
 xref:n1ql:n1ql-language-reference/alterbucket.adoc[]
@@ -50,7 +50,7 @@ xref:n1ql:n1ql-language-reference/dropvectorindex.adoc[]
 [#dcl]
 == Data Control Language
 
-Data control language (DCL) statements enable you to control which users or groups have access to data, and what they are permitted to do with that data.
+Data control language (DCL) statements enable you to control which users or groups have access to data, and what they're permitted to do with that data.
 
 [%hardbreaks]
 xref:n1ql:n1ql-language-reference/grant.adoc[]
@@ -60,7 +60,7 @@ xref:n1ql:n1ql-language-reference/revoke.adoc[]
 == Data Manipulation Language
 
 Data manipulation language (DML) statements enable you to create, read, update, and delete data.
-Some DML statements may be further subcategorized as data query language, transaction control language, or utility statements.
+Some DML statements may be further categorized as data query language, transaction control language, or utility statements.
 
 [%hardbreaks]
 xref:n1ql:n1ql-language-reference/delete.adoc[]
@@ -72,7 +72,7 @@ xref:n1ql:n1ql-language-reference/upsert.adoc[]
 [#dql]
 === Data Query Language
 
-Data query language (DQL) statements enable you to read and filter data and transform the results.
+Data query language (DQL) statements enable you to read and filter data and manipulate the results.
 
 xref:n1ql:n1ql-language-reference/selectintro.adoc[SELECT]
 
@@ -91,7 +91,7 @@ xref:n1ql:n1ql-language-reference/set-transaction.adoc[]
 [#utility]
 === Utility Statements
 
-Utility statements don't manipulate data directly, but support other operations.
+Utility statements do not manipulate data directly, but support other operations.
 For example, you can create and execute prepared statements, see query plans, get advice on query or index creation, and so on.
 
 [%hardbreaks]

--- a/modules/n1ql/pages/n1ql-language-reference/statements.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/statements.adoc
@@ -1,0 +1,100 @@
+= Statements
+:page-topic-type: reference
+:page-toclevels: 2
+:keywords: DDL, data definition language, DCL, data control language, DML, data manipulation language, TCL, transaction control language
+:description: Statements are the commands that make up a {sqlpp} query. \
+They can be categorized into three main groups: data definition language, data control language, and data manipulation language.
+
+// TEMP
+include::partial$n1ql-language-reference/column-style.adoc[]
+
+[abstract]
+{description}
+
+include::ROOT:partial$component-signpost.adoc[]
+
+== Data Definition Language
+
+Data definition language (DDL) statements enable you to create and modify database objects, such as users, keyspaces, and indexes.
+
+[%hardbreaks.two-columns]
+xref:n1ql:n1ql-language-reference/alterbucket.adoc[]
+xref:n1ql:n1ql-language-reference/altergroup.adoc[]
+xref:n1ql:n1ql-language-reference/alterindex.adoc[]
+xref:n1ql:n1ql-language-reference/altersequence.adoc[]
+xref:n1ql:n1ql-language-reference/alteruser.adoc[]
+xref:n1ql:n1ql-language-reference/altervectorindex.adoc[]
+xref:n1ql:n1ql-language-reference/build-index.adoc[]
+xref:n1ql:n1ql-language-reference/createbucket.adoc[]
+xref:n1ql:n1ql-language-reference/createcollection.adoc[]
+xref:n1ql:n1ql-language-reference/createfunction.adoc[]
+xref:n1ql:n1ql-language-reference/creategroup.adoc[]
+xref:n1ql:n1ql-language-reference/createindex.adoc[]
+xref:n1ql:n1ql-language-reference/createprimaryindex.adoc[]
+xref:n1ql:n1ql-language-reference/createsequence.adoc[]
+xref:n1ql:n1ql-language-reference/createscope.adoc[]
+xref:n1ql:n1ql-language-reference/createuser.adoc[]
+xref:n1ql:n1ql-language-reference/createvectorindex.adoc[]
+xref:n1ql:n1ql-language-reference/dropbucket.adoc[]
+xref:n1ql:n1ql-language-reference/dropcollection.adoc[]
+xref:n1ql:n1ql-language-reference/dropfunction.adoc[]
+xref:n1ql:n1ql-language-reference/dropgroup.adoc[]
+xref:n1ql:n1ql-language-reference/dropindex.adoc[]
+xref:n1ql:n1ql-language-reference/dropprimaryindex.adoc[]
+xref:n1ql:n1ql-language-reference/dropsequence.adoc[]
+xref:n1ql:n1ql-language-reference/dropscope.adoc[]
+xref:n1ql:n1ql-language-reference/dropuser.adoc[]
+xref:n1ql:n1ql-language-reference/dropvectorindex.adoc[]
+
+== Data Control Language
+
+Data control language (DCL) statements enable you to control which users or groups have access to data, and what they are permitted to do with that data.
+
+[%hardbreaks]
+xref:n1ql:n1ql-language-reference/grant.adoc[]
+xref:n1ql:n1ql-language-reference/revoke.adoc[]
+
+== Data Manipulation Language
+
+Data manipulation language (DML) statements enable you to create, read, update, and delete data.
+Some DML statements may be further subcategorized as data query language, transaction control language, or utility statements.
+
+[%hardbreaks]
+xref:n1ql:n1ql-language-reference/delete.adoc[]
+xref:n1ql:n1ql-language-reference/insert.adoc[]
+xref:n1ql:n1ql-language-reference/merge.adoc[]
+xref:n1ql:n1ql-language-reference/update.adoc[]
+xref:n1ql:n1ql-language-reference/upsert.adoc[]
+
+=== Data Query Language
+
+Data query language (DQL) statements enable you to read and filter data and transform the results.
+
+xref:n1ql:n1ql-language-reference/selectintro.adoc[SELECT]
+
+=== Transaction Control Language
+
+Transaction control language (TCL) statements enable you to work with Couchbase transactions.
+
+[%hardbreaks]
+xref:n1ql:n1ql-language-reference/begin-transaction.adoc[]
+xref:n1ql:n1ql-language-reference/commit-transaction.adoc[]
+xref:n1ql:n1ql-language-reference/rollback-transaction.adoc[]
+xref:n1ql:n1ql-language-reference/savepoint.adoc[]
+xref:n1ql:n1ql-language-reference/set-transaction.adoc[]
+
+=== Utility Statements
+
+Utility statements don't manipulate data directly, but support other operations.
+For example, you can create and execute prepared statements, explain query plans, advise you on query or index creation, and so on.
+
+[%hardbreaks]
+xref:n1ql:n1ql-language-reference/advise.adoc[]
+xref:n1ql:n1ql-language-reference/execute.adoc[]
+xref:n1ql:n1ql-language-reference/execfunction.adoc[]
+xref:n1ql:n1ql-language-reference/explain.adoc[]
+xref:n1ql:n1ql-language-reference/explainfunction.adoc[]
+xref:n1ql:n1ql-language-reference/infer.adoc[]
+xref:n1ql:n1ql-language-reference/prepare.adoc[]
+xref:n1ql:n1ql-language-reference/updatestatistics.adoc[]
+xref:n1ql:n1ql-language-reference/using-ai.adoc[]

--- a/modules/n1ql/pages/n1ql-language-reference/statements.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/statements.adoc
@@ -1,7 +1,7 @@
 = Statements
 :page-topic-type: reference
 :page-toclevels: 2
-:keywords: DDL, data definition language, DCL, data control language, DML, data manipulation language, TCL, transaction control language
+:keywords: DDL, data definition language, DCL, data control language, DML, data manipulation language, TCL, transaction control language, DQL, data query language
 :description: Statements are the commands that make up a {sqlpp} query. \
 They can be categorized into three main groups: data definition language, data control language, and data manipulation language.
 
@@ -13,6 +13,7 @@ include::partial$n1ql-language-reference/column-style.adoc[]
 
 include::ROOT:partial$component-signpost.adoc[]
 
+[#ddl]
 == Data Definition Language
 
 Data definition language (DDL) statements enable you to create and modify database objects, such as users, keyspaces, and indexes.
@@ -46,6 +47,7 @@ xref:n1ql:n1ql-language-reference/dropscope.adoc[]
 xref:n1ql:n1ql-language-reference/dropuser.adoc[]
 xref:n1ql:n1ql-language-reference/dropvectorindex.adoc[]
 
+[#dcl]
 == Data Control Language
 
 Data control language (DCL) statements enable you to control which users or groups have access to data, and what they are permitted to do with that data.
@@ -54,6 +56,7 @@ Data control language (DCL) statements enable you to control which users or grou
 xref:n1ql:n1ql-language-reference/grant.adoc[]
 xref:n1ql:n1ql-language-reference/revoke.adoc[]
 
+[#dml]
 == Data Manipulation Language
 
 Data manipulation language (DML) statements enable you to create, read, update, and delete data.
@@ -66,12 +69,14 @@ xref:n1ql:n1ql-language-reference/merge.adoc[]
 xref:n1ql:n1ql-language-reference/update.adoc[]
 xref:n1ql:n1ql-language-reference/upsert.adoc[]
 
+[#dql]
 === Data Query Language
 
 Data query language (DQL) statements enable you to read and filter data and transform the results.
 
 xref:n1ql:n1ql-language-reference/selectintro.adoc[SELECT]
 
+[#tcl]
 === Transaction Control Language
 
 Transaction control language (TCL) statements enable you to work with Couchbase transactions.
@@ -83,6 +88,7 @@ xref:n1ql:n1ql-language-reference/rollback-transaction.adoc[]
 xref:n1ql:n1ql-language-reference/savepoint.adoc[]
 xref:n1ql:n1ql-language-reference/set-transaction.adoc[]
 
+[#utility]
 === Utility Statements
 
 Utility statements don't manipulate data directly, but support other operations.

--- a/modules/n1ql/partials/nav.adoc
+++ b/modules/n1ql/partials/nav.adoc
@@ -87,7 +87,7 @@
       **** xref:n1ql:n1ql-language-reference/keyspace-hints.adoc[]
       **** xref:n1ql:n1ql-language-reference/negative-keyspace-hints.adoc[]
     *** xref:n1ql:n1ql-language-reference/booleanlogic.adoc[]
-    *** Statements
+    *** xref:n1ql:n1ql-language-reference/statements.adoc[]
       **** xref:n1ql:n1ql-language-reference/advise.adoc[]
       **** xref:n1ql:n1ql-language-reference/alterbucket.adoc[]
       **** xref:n1ql:n1ql-language-reference/altergroup.adoc[]


### PR DESCRIPTION
Docs issue: DOC-11697

This has been on the backlog for a while, but seems really necessary now, with the proliferation of new statements in Couchbase Server 8.0.

Docs preview: [Statements](https://preview.docs-test.couchbase.com/docs-devex-DOC-11697-sqplpp-statements/server/current/n1ql/n1ql-language-reference/statements.html)
Credentials: [Preview docs for internal review](https://couchbasecloud.atlassian.net/wiki/x/dYF_dQ#Preview-docs-for-internal-Couchbase-reviews)

> [!NOTE]
> The links to ALTER VECTOR INDEX, CREATE VECTOR INDEX, and DROP VECTOR INDEX won't work until the following PR is merged:
>
> - #420 