### PR TITLE
[DOC-9905] Additional date string formats

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/datefun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/datefun.adoc
@@ -582,6 +582,30 @@ For example, `%Y %m %d` parses `2021-06-28`, `2021/06/28`, `2021.06.28`, and so 
 --
 ====
 
+In addition to the date formats listed above, {sqlpp} also accepts the following formats that's common to all styles: 
+
+
+
+MONTH/Month/month - English month name in upper/mixed/lower case.
+
+MON/Mon/mon - Abbreviated English month name
+
+DAY/Day/day - English day name
+
+DY/Dy/dy - Abbreviated English day name
+
+AM/PM - synonyms for PP
+
+am/pm - synonyms for pp
+
+HH12 - synonym for HH
+
+HH24 - synonym for hh
+
+SS - synonym for ss
+
+MI - synonym for mm
+
 [NOTE#default-values]
 .Default Values
 ====

--- a/modules/n1ql/pages/n1ql-language-reference/datefun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/datefun.adoc
@@ -582,29 +582,54 @@ For example, `%Y %m %d` parses `2021-06-28`, `2021/06/28`, `2021.06.28`, and so 
 --
 ====
 
-In addition to the date formats listed above, {sqlpp} also accepts the following formats that's common to all styles: 
+==== Common Date Formats
 
+The following table lists common date formats used across all conventions:
 
+[cols="1,2,2"]
+|====
+| Format | Description | Example
 
-MONTH/Month/month - English month name in upper/mixed/lower case.
+| `MONTH` / `Month` / `month`
+| Full English month name in uppercase, mixed case, or lowercase.
+| `JANUARY` / `January` / `january`
 
-MON/Mon/mon - Abbreviated English month name
+| `MON` / `Mon` / `mon`
+| Abbreviated English month name in uppercase, mixed case, or lowercase.
+| `JAN` / `Jan` / `jan`
 
-DAY/Day/day - English day name
+| `DAY` / `Day` / `day`
+| Full English day name in uppercase, mixed case, or lowercase.
+| `MONDAY` / `Monday` / `monday`
 
-DY/Dy/dy - Abbreviated English day name
+| `DY` / `Dy` / `dy`
+| Abbreviated English day name in uppercase, mixed case, or lowercase.
+| `MON` / `Mon` / `mon`
 
-AM/PM - synonyms for PP
+| `AM` / `PM`
+| Synonyms for `PP` (uppercase).
+| `AM` / `PM`
 
-am/pm - synonyms for pp
+| `am` / `pm`
+| Synonyms for `pp` (lowercase).
+| `am` / `pm`
 
-HH12 - synonym for HH
+| `HH12`
+| Synonym for `HH` (12-hour clock).
+| `01` (1 AM) to `12` (12 PM)
 
-HH24 - synonym for hh
+| `HH24`
+| Synonym for `hh` (24-hour clock).
+| `00` (midnight) to `23` (11 PM)
 
-SS - synonym for ss
+| `SS`
+| Synonym for `ss` (seconds).
+| `00` to `59`
 
-MI - synonym for mm
+| `MI`
+| Synonym for `mm` (minutes).
+| `00` to `59`
+|====
 
 [NOTE#default-values]
 .Default Values

--- a/modules/n1ql/pages/n1ql-language-reference/datefun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/datefun.adoc
@@ -261,10 +261,10 @@ The date string codes are given below.
 | `s`
 | Fraction of a second (down to millisecond) -- output only
 
-| `AM` / `PM`
+| `AM` / `PM` / `PP`
 | AM or PM (uppercase)
 
-| `am` / `pm`
+| `am` / `pm` / `pp`
 | am or pm (lowercase)
 
 | `TZD`

--- a/modules/n1ql/pages/n1ql-language-reference/datefun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/datefun.adoc
@@ -225,8 +225,20 @@ The date string codes are given below.
 | `MM`
 | 2-digit month
 
+| `MONTH` / `Month` / `month`
+| Full English month name in uppercase, mixed case, or lowercase
+
+| `MON` / `Mon` / `mon`
+| Abbreviated English month name in uppercase, mixed case, or lowercase
+
 | `DD`
 | 2-digit day
+
+| `DAY` / `Day` / `day`
+| Full English day name in uppercase, mixed case, or lowercase
+
+| `DY` / `Dy` / `dy`
+| Abbreviated English day name in upper case, mixed case, or lower case
 
 | `hh`
 | 2-digit hour, 00-23
@@ -234,14 +246,26 @@ The date string codes are given below.
 | `HH`
 | 2-digit hour, 00-23
 
-| `mm`
+| `HH12`
+| 2-digit hour, 01-12
+
+| `HH24`
+| 2-digit hour, 00-23
+
+| `mm` / `MI`
 | 2-digit minute, 00-59
 
-| `ss`
+| `ss` / `SS`
 | 2-digit second, 00-59
 
 | `s`
 | Fraction of a second (down to millisecond) -- output only
+
+| `AM` / `PM`
+| AM or PM (upper case)
+
+| `am` / `pm`
+| am or pm (lower case)
 
 | `TZD`
 | Time Zone (as UTC offset)
@@ -581,55 +605,6 @@ If you need to include a literal percent symbol in the date format, use the spec
 For example, `%Y %m %d` parses `2021-06-28`, `2021/06/28`, `2021.06.28`, and so on.
 --
 ====
-
-==== Common Date Formats
-
-The following table lists common date formats used across all conventions:
-
-[cols="1,2,2"]
-|====
-| Format | Description | Example
-
-| `MONTH` / `Month` / `month`
-| Full English month name in uppercase, mixed case, or lowercase.
-| `JANUARY` / `January` / `january`
-
-| `MON` / `Mon` / `mon`
-| Abbreviated English month name in uppercase, mixed case, or lowercase.
-| `JAN` / `Jan` / `jan`
-
-| `DAY` / `Day` / `day`
-| Full English day name in uppercase, mixed case, or lowercase.
-| `MONDAY` / `Monday` / `monday`
-
-| `DY` / `Dy` / `dy`
-| Abbreviated English day name in uppercase, mixed case, or lowercase.
-| `MON` / `Mon` / `mon`
-
-| `AM` / `PM`
-| Synonyms for `PP` (uppercase).
-| `AM` / `PM`
-
-| `am` / `pm`
-| Synonyms for `pp` (lowercase).
-| `am` / `pm`
-
-| `HH12`
-| Synonym for `HH` (12-hour clock).
-| `01` (1 AM) to `12` (12 PM)
-
-| `HH24`
-| Synonym for `hh` (24-hour clock).
-| `00` (midnight) to `23` (11 PM)
-
-| `SS`
-| Synonym for `ss` (seconds).
-| `00` to `59`
-
-| `MI`
-| Synonym for `mm` (minutes).
-| `00` to `59`
-|====
 
 [NOTE#default-values]
 .Default Values

--- a/modules/n1ql/pages/n1ql-language-reference/datefun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/datefun.adoc
@@ -262,10 +262,10 @@ The date string codes are given below.
 | Fraction of a second (down to millisecond) -- output only
 
 | `AM` / `PM`
-| AM or PM (upper case)
+| AM or PM (uppercase)
 
 | `am` / `pm`
-| am or pm (lower case)
+| am or pm (lowercase)
 
 | `TZD`
 | Time Zone (as UTC offset)

--- a/modules/n1ql/pages/n1ql-language-reference/datefun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/datefun.adoc
@@ -238,7 +238,7 @@ The date string codes are given below.
 | Full English day name in uppercase, mixed case, or lowercase
 
 | `DY` / `Dy` / `dy`
-| Abbreviated English day name in upper case, mixed case, or lower case
+| Abbreviated English day name in uppercase, mixed case, or lowercase
 
 | `hh`
 | 2-digit hour, 00-23


### PR DESCRIPTION
Jira: DOC-9905

Updated the Date String Codes table to add more formats. 

- [Docs preview](https://preview.docs-test.couchbase.com/docs-devex-DOC-9905-date-formats/server/current/n1ql/n1ql-language-reference/datefun.html#date-formats)
- [Preview credentials](https://couchbasecloud.atlassian.net/wiki/x/dYF_dQ#Preview-docs-for-internal-review)