### PR TITLE
[DOC-13535/release/8.0]: Update import guide to use updated Java SDK paths

### DIFF
--- a/modules/guides/pages/import.adoc
+++ b/modules/guides/pages/import.adoc
@@ -295,17 +295,17 @@ To parse CSV and TSV data, use the http://opencsv.sourceforge.net/[opencsv^] lib
 
 [source,java]
 ----
-include::java-sdk:devguide:example$/java/Import.java[tags=csv-tsv-import,indent=0]
+include::java-sdk:devguide:example$java/Import.java[tags=csv-tsv-import,indent=0]
 ----
 
 [source,java]
 ----
-include::java-sdk:devguide:example$/java/Import.java[tags=importCSV,indent=0]
+include::java-sdk:devguide:example$java/Import.java[tags=importCSV,indent=0]
 ----
 
 [source,java]
 ----
-include::java-sdk:devguide:example$/java/Import.java[tags=importTSV;!omit,indent=0]
+include::java-sdk:devguide:example$java/Import.java[tags=importTSV;!omit,indent=0]
 ----
 
 If you are using the *Reactor API* then, as OpenCSV doesn't have a built-in converter,
@@ -313,12 +313,12 @@ use the https://projectreactor.io/docs/core/release/api/reactor/core/publisher/F
 
 [source,java]
 ----
-include::java-sdk:devguide:example$/java/Import.java[tags=importCSV_batch;!omit,indent=0]
+include::java-sdk:devguide:example$java/Import.java[tags=importCSV_batch;!omit,indent=0]
 ----
 
 [source,java]
 ----
-include::java-sdk:devguide:example$/java/Import.java[tags=importTSV_batch;!omit,indent=0]
+include::java-sdk:devguide:example$java/Import.java[tags=importTSV_batch;!omit,indent=0]
 ----
 
 {github}
@@ -405,33 +405,33 @@ To parse *JSON* data, read the file as a string, then use the built-in Couchbase
 
 [source,java]
 ----
-include::java-sdk:devguide:example$/java/Import.java[tags=json-jsonl-import,indent=0]
+include::java-sdk:devguide:example$java/Import.java[tags=json-jsonl-import,indent=0]
 ----
 
 [source,java]
 ----
-include::java-sdk:devguide:example$/java/Import.java[tags=importJSON,indent=0]
+include::java-sdk:devguide:example$java/Import.java[tags=importJSON,indent=0]
 ----
 
 If you are using the *Reactor API* then, once you've read the JSON array, use the https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#fromIterable-java.lang.Iterable-[`Flux::fromIterable`] method to convert it into streams:
 
 [source,java]
 ----
-include::java-sdk:devguide:example$/java/Import.java[tags=importJSON_batch;!omit,indent=0]
+include::java-sdk:devguide:example$java/Import.java[tags=importJSON_batch;!omit,indent=0]
 ----
 
 To parse *JSONL* data: do the same, but read the file line-by-line.
 
 [source,java]
 ----
-include::java-sdk:devguide:example$/java/Import.java[tags=importJSONL;!omit,indent=0]
+include::java-sdk:devguide:example$java/Import.java[tags=importJSONL;!omit,indent=0]
 ----
 
 If you are using the *Reactor API* then open the JSONL file as a stream using the https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#using-java.util.concurrent.Callable-java.util.function.Function-java.util.function.Consumer-[`Flux::using`] method.
 
 [source,java]
 ----
-include::java-sdk:devguide:example$/java/Import.java[tags=importJSONL_batch;!omit,indent=0]
+include::java-sdk:devguide:example$java/Import.java[tags=importJSONL_batch;!omit,indent=0]
 ----
 
 {github}
@@ -513,14 +513,14 @@ Java::
 --
 [source,java]
 ----
-include::java-sdk:devguide:example$/java/Import.java[tags=connect,indent=0]
+include::java-sdk:devguide:example$java/Import.java[tags=connect,indent=0]
 ----
 
 If you are using the xref:java-sdk:howtos:concurrent-async-apis.adoc#reactive-programming-with-reactor[Reactive API], then use the reactive collection instead:
 
 [source,java]
 ----
-include::java-sdk:devguide:example$/java/Import.java[tags=reactiveCollection,indent=0]
+include::java-sdk:devguide:example$java/Import.java[tags=reactiveCollection,indent=0]
 ----
 
 {github}
@@ -598,7 +598,7 @@ For the blocking API, use the method below.
 
 [source,java]
 ----
-include::java-sdk:devguide:example$/java/Import.java[tags=upsertDocument,indent=0]
+include::java-sdk:devguide:example$java/Import.java[tags=upsertDocument,indent=0]
 ----
 
 The *Reactive API* examples above already include a call to `ReactiveCollection::upsert`.
@@ -607,12 +607,12 @@ In both cases, you must provide a preprocess routine which returns a key-value t
 
 [source,java]
 ----
-include::java-sdk:devguide:example$/java/Import.java[tags=JsonDocument,indent=0]
+include::java-sdk:devguide:example$java/Import.java[tags=JsonDocument,indent=0]
 ----
 
 [source,java]
 ----
-include::java-sdk:devguide:example$/java/Import.java[tags=preprocess,indent=0]
+include::java-sdk:devguide:example$java/Import.java[tags=preprocess,indent=0]
 ----
 
 {github}

--- a/modules/guides/pages/import.adoc
+++ b/modules/guides/pages/import.adoc
@@ -295,17 +295,17 @@ To parse CSV and TSV data, use the http://opencsv.sourceforge.net/[opencsv^] lib
 
 [source,java]
 ----
-include::java-sdk:howtos:example$Import.java[tags=csv-tsv-import,indent=0]
+include::java-sdk:devguide:example$/java/Import.java[tags=csv-tsv-import,indent=0]
 ----
 
 [source,java]
 ----
-include::java-sdk:howtos:example$Import.java[tags=importCSV,indent=0]
+include::java-sdk:devguide:example$/java/Import.java[tags=importCSV,indent=0]
 ----
 
 [source,java]
 ----
-include::java-sdk:howtos:example$Import.java[tags=importTSV;!omit,indent=0]
+include::java-sdk:devguide:example$/java/Import.java[tags=importTSV;!omit,indent=0]
 ----
 
 If you are using the *Reactor API* then, as OpenCSV doesn't have a built-in converter,
@@ -313,12 +313,12 @@ use the https://projectreactor.io/docs/core/release/api/reactor/core/publisher/F
 
 [source,java]
 ----
-include::java-sdk:howtos:example$Import.java[tags=importCSV_batch;!omit,indent=0]
+include::java-sdk:devguide:example$/java/Import.java[tags=importCSV_batch;!omit,indent=0]
 ----
 
 [source,java]
 ----
-include::java-sdk:howtos:example$Import.java[tags=importTSV_batch;!omit,indent=0]
+include::java-sdk:devguide:example$/java/Import.java[tags=importTSV_batch;!omit,indent=0]
 ----
 
 {github}
@@ -405,33 +405,33 @@ To parse *JSON* data, read the file as a string, then use the built-in Couchbase
 
 [source,java]
 ----
-include::java-sdk:howtos:example$Import.java[tags=json-jsonl-import,indent=0]
+include::java-sdk:devguide:example$/java/Import.java[tags=json-jsonl-import,indent=0]
 ----
 
 [source,java]
 ----
-include::java-sdk:howtos:example$Import.java[tags=importJSON,indent=0]
+include::java-sdk:devguide:example$/java/Import.java[tags=importJSON,indent=0]
 ----
 
 If you are using the *Reactor API* then, once you've read the JSON array, use the https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#fromIterable-java.lang.Iterable-[`Flux::fromIterable`] method to convert it into streams:
 
 [source,java]
 ----
-include::java-sdk:howtos:example$Import.java[tags=importJSON_batch;!omit,indent=0]
+include::java-sdk:devguide:example$/java/Import.java[tags=importJSON_batch;!omit,indent=0]
 ----
 
 To parse *JSONL* data: do the same, but read the file line-by-line.
 
 [source,java]
 ----
-include::java-sdk:howtos:example$Import.java[tags=importJSONL;!omit,indent=0]
+include::java-sdk:devguide:example$/java/Import.java[tags=importJSONL;!omit,indent=0]
 ----
 
 If you are using the *Reactor API* then open the JSONL file as a stream using the https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#using-java.util.concurrent.Callable-java.util.function.Function-java.util.function.Consumer-[`Flux::using`] method.
 
 [source,java]
 ----
-include::java-sdk:howtos:example$Import.java[tags=importJSONL_batch;!omit,indent=0]
+include::java-sdk:devguide:example$/java/Import.java[tags=importJSONL_batch;!omit,indent=0]
 ----
 
 {github}
@@ -513,14 +513,14 @@ Java::
 --
 [source,java]
 ----
-include::java-sdk:howtos:example$Import.java[tags=connect,indent=0]
+include::java-sdk:devguide:example$/java/Import.java[tags=connect,indent=0]
 ----
 
 If you are using the xref:java-sdk:howtos:concurrent-async-apis.adoc#reactive-programming-with-reactor[Reactive API], then use the reactive collection instead:
 
 [source,java]
 ----
-include::java-sdk:howtos:example$Import.java[tags=reactiveCollection,indent=0]
+include::java-sdk:devguide:example$/java/Import.java[tags=reactiveCollection,indent=0]
 ----
 
 {github}
@@ -598,7 +598,7 @@ For the blocking API, use the method below.
 
 [source,java]
 ----
-include::java-sdk:howtos:example$Import.java[tags=upsertDocument,indent=0]
+include::java-sdk:devguide:example$/java/Import.java[tags=upsertDocument,indent=0]
 ----
 
 The *Reactive API* examples above already include a call to `ReactiveCollection::upsert`.
@@ -607,12 +607,12 @@ In both cases, you must provide a preprocess routine which returns a key-value t
 
 [source,java]
 ----
-include::java-sdk:howtos:example$Import.java[tags=JsonDocument,indent=0]
+include::java-sdk:devguide:example$/java/Import.java[tags=JsonDocument,indent=0]
 ----
 
 [source,java]
 ----
-include::java-sdk:howtos:example$Import.java[tags=preprocess,indent=0]
+include::java-sdk:devguide:example$/java/Import.java[tags=preprocess,indent=0]
 ----
 
 {github}


### PR DESCRIPTION
Updated the documentation to reflect changes in Java SDK paths for version 8.0. This ensures that users follow the correct import paths when utilizing the guide.

This is for release/8.0