### PR TITLE
DOC-12464 Incorporate Vector Search in the Vector Index section

### DIFF
--- a/modules/vector-index/pages/composite-vector-index.adoc
+++ b/modules/vector-index/pages/composite-vector-index.adoc
@@ -1,4 +1,4 @@
-= Filtered Searches Using Composite Vector Index
+= Create Filtered Searches Using Composite Vector Index
 :page-topic-type: guide
 :page-ui-name: {ui-name}
 :page-product-name: {product-name}

--- a/modules/vector-index/pages/composite-vector-index.adoc
+++ b/modules/vector-index/pages/composite-vector-index.adoc
@@ -1,4 +1,4 @@
-= Create Filtered Searches Using Composite Vector Index
+= Filtered Search Using Composite Vector Indexes
 :page-topic-type: guide
 :page-ui-name: {ui-name}
 :page-product-name: {product-name}

--- a/modules/vector-index/pages/hyperscale-vector-index.adoc
+++ b/modules/vector-index/pages/hyperscale-vector-index.adoc
@@ -1,4 +1,4 @@
-= Vector Searches Using Hyperscale Vector Indexes
+= Create Vector Searches Using Hyperscale Vector Indexes
 :page-topic-type: guide
 :page-ui-name: {ui-name}
 :page-product-name: {product-name}

--- a/modules/vector-index/pages/hyperscale-vector-index.adoc
+++ b/modules/vector-index/pages/hyperscale-vector-index.adoc
@@ -1,4 +1,4 @@
-= Create Vector Searches Using Hyperscale Vector Indexes
+= Vector Search Using Hyperscale Vector Indexes
 :page-topic-type: guide
 :page-ui-name: {ui-name}
 :page-product-name: {product-name}

--- a/modules/vector-index/pages/use-vector-indexes.adoc
+++ b/modules/vector-index/pages/use-vector-indexes.adoc
@@ -1,4 +1,4 @@
-= Use Vector Indexes for AI Applications
+= Choose the Right Vector Index
 :page-topic-type: concept
 :page-ui-name: {ui-name}
 :page-product-name: {product-name}

--- a/modules/vector-index/pages/use-vector-indexes.adoc
+++ b/modules/vector-index/pages/use-vector-indexes.adoc
@@ -142,7 +142,7 @@ When choosing which type of index to use, consider the following:
 
 * In most cases, test using a Hyperscale Vector index.
 If you find that the performance is not what you need, you can try using one of the other index types.
-* If your dataset will not grow beyond 100 million documents and you need to perform hybrid searches that combine vector searches with Full-Text Search or geospatial searches, use an Search Vector Index.
+* If your dataset will not grow beyond 100 million documents and you need to perform hybrid searches that combine vector searches with Full-Text Search or geospatial searches, use a Search Vector Index.
 
 == Applications for Vector Indexes
 
@@ -256,14 +256,14 @@ Users often want to search for hotels using multiple criteria:
 * Semantic searches of descriptions and reviews for searches that do not rely on literal text matches, such as "modern beach resort with chic décor," which requires vector searches.
 
 +
-An Search Vector Index can combine geospatial, keyword, and semantic searches into a single index.
+A Search Vector Index can combine geospatial, keyword, and semantic searches into a single index.
 
 Real estate searches::
 Real estate applications can use Search Vector Indexes to find properties within a search region and have floor plan similar to an uploaded image.
 
 === Search Vector Index Application Workflow
 
-To create and use an Search Vector Index, your application follows the workflow shown in the following diagram:
+To create and use a Search Vector Index, your application follows the workflow shown in the following diagram:
 
 .Application Workflow with Search Vector Indexes
 [plantuml,fts-app-workflow,svg]

--- a/modules/vector-index/pages/use-vector-indexes.adoc
+++ b/modules/vector-index/pages/use-vector-indexes.adoc
@@ -142,7 +142,7 @@ When choosing which type of index to use, consider the following:
 
 * In most cases, test using a Hyperscale Vector index.
 If you find that the performance is not what you need, you can try using one of the other index types.
-* If your dataset will not grow beyond 100 million documents and you need to perform hybrid searches that combine vector searches with Full-Text Search or geospatial searches, use a Search Vector Index.
+* If your dataset will not grow beyond 100 million documents and you need to perform hybrid searches that combine vector searches with other Search Service features, such as text or geospatial search, use a Search Vector Index.
 
 == Applications for Vector Indexes
 

--- a/modules/vector-index/pages/vectors-and-indexes-overview.adoc
+++ b/modules/vector-index/pages/vectors-and-indexes-overview.adoc
@@ -1,4 +1,4 @@
-= Vectors and Vector Indexes
+= Use Vector Indexes for AI Applications
 :page-topic-type: concept
 :page-ui-name: {ui-name}
 :stem: latexmath

--- a/modules/vector-index/partials/nav.adoc
+++ b/modules/vector-index/partials/nav.adoc
@@ -1,12 +1,12 @@
-* xref:server:vector-index:vectors-and-indexes-overview.adoc[]
+* xref:vector-index:vectors-and-indexes-overview.adoc[]
 +
 --
-** xref:server:vector-index:use-vector-indexes.adoc[] 
-** xref:server:vector-index:hyperscale-vector-index.adoc[]
-*** xref:server:vector-index:hyperscale-filter.adoc[]
-*** xref:server:vector-index:hyperscale-reranking.adoc[]
-** xref:server:vector-index:composite-vector-index.adoc[]
-** xref:server:vector-index:vector-index-best-practices.adoc[]
+** xref:vector-index:use-vector-indexes.adoc[] 
+** xref:vector-index:hyperscale-vector-index.adoc[]
+*** xref:vector-index:hyperscale-filter.adoc[]
+*** xref:vector-index:hyperscale-reranking.adoc[]
+** xref:vector-index:composite-vector-index.adoc[]
+** xref:vector-index:vector-index-best-practices.adoc[]
 --
 +
 --

--- a/modules/vector-search/pages/create-vector-search-index-rest-api.adoc
+++ b/modules/vector-search/pages/create-vector-search-index-rest-api.adoc
@@ -1,8 +1,8 @@
-= Create an Search Vector Index with the REST API and curl/HTTP
+= Create a Search Vector Index with the REST API and curl/HTTP
 :page-topic-type: guide
 :page-ui-name: {ui-name}
 :page-product-name: {product-name}
-:description: You can create an Search Vector Index with the Search Service API. 
+:description: You can create a Search Vector Index with the Search Service API. 
 
 [abstract]
 {description}
@@ -53,7 +53,7 @@ include::example$create-vector-search-index-header.sh[]
 Do not include the xref:search:search-index-params.adoc#uuid[uuid] or xref:search:search-index-params.adoc#sourceuuid[sourceUUID] parameters. 
 +
 TIP: If you remove the xref:search:search-index-params.adoc#uuid[uuid] and xref:search:search-index-params.adoc#sourceuuid[sourceUUID] parameters, you can copy the Search index definition JSON payload from the Couchbase {page-ui-name} to use in a REST API call.
-For more information about how to create an Search Vector Index with the UI, see xref:create-vector-search-index-ui.adoc[]. 
+For more information about how to create a Search Vector Index with the UI, see xref:create-vector-search-index-ui.adoc[]. 
 
 [#example]
 === Example

--- a/modules/vector-search/pages/create-vector-search-index-ui.adoc
+++ b/modules/vector-search/pages/create-vector-search-index-ui.adoc
@@ -1,14 +1,14 @@
-= Create an Search Vector Index with the {page-ui-name}
+= Create a Search Vector Index with the {page-ui-name}
 :page-topic-type: guide
 :page-ui-name: {ui-name}
 :page-product-name: {product-name}
 :page-toclevels: 2
-:description: You can create an Search Vector Index with the Couchbase {page-ui-name}. 
+:description: You can create a Search Vector Index with the Couchbase {page-ui-name}. 
 
 [abstract]
 {description}
 
-You must create an Search Vector Index before you can xref:run-vector-search-ui.adoc[run a search] that supports vector comparisons.
+You must create a Search Vector Index before you can xref:run-vector-search-ui.adoc[run a search] that supports vector comparisons.
 
 TIP: Search Vector Indexes can include all the same features and settings as a Search index. 
 For more information about Search indexes, see the xref:search:search.adoc[Search documentation].
@@ -37,7 +37,7 @@ include::partial$download-sample-partial.adoc[]
 
 == Procedure 
 
-To create an Search Vector Index with the Couchbase {page-ui-name}: 
+To create a Search Vector Index with the Couchbase {page-ui-name}: 
 
 . Go to *Search*.
 . Click btn:[Add Index].
@@ -90,7 +90,7 @@ For more information about how to create child fields, see xref:search:create-ch
 . Click btn:[Create Index].
 
 [#example]
-=== Example: Creating an Search Vector Index for Vector Search Query Examples 
+=== Example: Creating a Search Vector Index for Vector Search Query Examples 
 
 If you want to use the sample dataset for the examples in xref:run-vector-search-ui.adoc[] and xref:run-vector-search-sdk.adoc[], then you can xref:search:import-search-index.adoc[import] the following Search index definition into {page-ui-name}:
 
@@ -121,4 +121,4 @@ For more information about how to add additional child fields to your index, see
 You can customize your Search Vector Index like any other Search index to add additional data and improve search results. 
 For more information about how to customize an index, see xref:search:customize-index.adoc[].
 
-For more information about how to run a search against an Search Vector Index, see xref:run-vector-search-ui.adoc[] or xref:run-vector-search-rest-api.adoc[].
+For more information about how to run a search against a Search Vector Index, see xref:run-vector-search-ui.adoc[] or xref:run-vector-search-rest-api.adoc[].

--- a/modules/vector-search/pages/fine-tune-vector-search.adoc
+++ b/modules/vector-search/pages/fine-tune-vector-search.adoc
@@ -74,7 +74,7 @@ For more information on the `vector_index_optimized_for` setting, see  xref:sear
 
 |===
 
-==  Default `nlist` and `nprobe` calculations on an Search Vector Index
+==  Default `nlist` and `nprobe` calculations on a Search Vector Index
 
 
 The cluster maintains two dynamically adjusted parameters that will affect the speed, accuracy, and resources used during a search: 
@@ -90,7 +90,7 @@ Reducing the value reduces the number of centroids visited, which will decrease 
 
 .Default calculation
 ====
-If you have an Search Vector Index with `vector_index_optimized_for` set to `"recall"` and `indexPartitions` set to `5`, then the `centroid count` (`nlist`) and `nprobe` are determined based on the current vector count in a given partition.
+If you have a Search Vector Index with `vector_index_optimized_for` set to `"recall"` and `indexPartitions` set to `5`, then the `centroid count` (`nlist`) and `nprobe` are determined based on the current vector count in a given partition.
 [options="noheader", frame="none", grid="none" cols="1,1"]
 
 |===

--- a/modules/vector-search/pages/pre-filtering-vector-search.adoc
+++ b/modules/vector-search/pages/pre-filtering-vector-search.adoc
@@ -29,15 +29,15 @@ For more information about how to create a bucket, see xref:server:manage:manage
 * You have the hostname or IP address for the node in your cluster where you're running the Search Service.
 For more information about where to find the IP address for your node, see xref:server:manage:manage-nodes/list-cluster-nodes.adoc[].
 
-* You have created an Search Vector Index.
+* You have created a Search Vector Index.
 +
-For more information about how to create an Search Vector Index, see xref:create-vector-search-index-ui.adoc[] or xref:create-vector-search-index-rest-api.adoc[].
+For more information about how to create a Search Vector Index, see xref:create-vector-search-index-ui.adoc[] or xref:create-vector-search-index-rest-api.adoc[].
 +
 [TIP]
 --
 include::partial$download-sample-partial.adoc[]
 
-For the best results, consider using the sample Search Vector Index from xref:create-vector-search-index-ui.adoc#example[Create an Search Vector Index with the {page-ui-name}] or xref:create-vector-search-index-rest-api.adoc#example[Create an Search Vector Index with the REST API and curl/HTTP].
+For the best results, consider using the sample Search Vector Index from xref:create-vector-search-index-ui.adoc#example[Create a Search Vector Index with the {page-ui-name}] or xref:create-vector-search-index-rest-api.adoc#example[Create a Search Vector Index with the REST API and curl/HTTP].
 --
 
 == Procedure

--- a/modules/vector-search/pages/run-vector-search-rest-api.adoc
+++ b/modules/vector-search/pages/run-vector-search-rest-api.adoc
@@ -2,7 +2,7 @@
 :page-topic-type: guide 
 :page-ui-name: {ui-name}
 :page-product-name: {product-name}
-:description: You can use the REST API and a curl command to run a search against an Search Vector Index and return similar vectors.
+:description: You can use the REST API and a curl command to run a search against a Search Vector Index and return similar vectors.
 :page-toclevels: 3
 
 [abstract]
@@ -27,15 +27,15 @@ For more information about how to create a bucket, see xref:server:manage:manage
 * You have the hostname or IP address for the node in your cluster where you're running the Search Service.
 For more information about where to find the IP address for your node, see xref:server:manage:manage-nodes/list-cluster-nodes.adoc[].
 
-* You have created an Search Vector Index. 
+* You have created a Search Vector Index. 
 +
-For more information about how to create an Search Vector Index, see xref:create-vector-search-index-ui.adoc[] or xref:create-vector-search-index-rest-api.adoc[].
+For more information about how to create a Search Vector Index, see xref:create-vector-search-index-ui.adoc[] or xref:create-vector-search-index-rest-api.adoc[].
 +
 [TIP]
 --
 include::partial$download-sample-partial.adoc[]
 
-For the best results, consider using the sample Search Vector Index from xref:create-vector-search-index-ui.adoc#example[Create an Search Vector Index with the {page-ui-name}] or xref:create-vector-search-index-rest-api.adoc#example[Create an Search Vector Index with the REST API and curl/HTTP]. 
+For the best results, consider using the sample Search Vector Index from xref:create-vector-search-index-ui.adoc#example[Create a Search Vector Index with the {page-ui-name}] or xref:create-vector-search-index-rest-api.adoc#example[Create a Search Vector Index with the REST API and curl/HTTP]. 
 --
 
 == Procedure 

--- a/modules/vector-search/pages/run-vector-search-sdk.adoc
+++ b/modules/vector-search/pages/run-vector-search-sdk.adoc
@@ -2,7 +2,7 @@
 :page-topic-type: guide
 :page-ui-name: {ui-name}
 :page-product-name: {product-name}
-:description: Using a Couchbase SDK, you can run a simple or more complex vector search against an Search Vector Index.
+:description: Using a Couchbase SDK, you can run a simple or more complex vector search against a Search Vector Index.
 :tabs:
 :tabs-sync-option:
 
@@ -36,15 +36,15 @@ For more information about how to deploy a new node and Services on your cluster
 * You have the hostname or IP address for the node in your cluster where you're running the Search Service.
 For more information about where to find the IP address for your node, see xref:server:manage:manage-nodes/list-cluster-nodes.adoc[].
 
-* You have created an Search Vector Index. 
+* You have created a Search Vector Index. 
 +
-For more information about how to create an Search Vector Index, see xref:create-vector-search-index-ui.adoc[] or xref:create-vector-search-index-rest-api.adoc[].
+For more information about how to create a Search Vector Index, see xref:create-vector-search-index-ui.adoc[] or xref:create-vector-search-index-rest-api.adoc[].
 +
 [TIP]
 --
 include::partial$download-sample-partial.adoc[]
 
-For the best results, consider using the sample Search Vector Index from xref:create-vector-search-index-ui.adoc#example[Create an Search Vector Index with the {page-ui-name}] or xref:create-vector-search-index-rest-api.adoc#example[Create an Search Vector Index with the REST API and curl/HTTP]. 
+For the best results, consider using the sample Search Vector Index from xref:create-vector-search-index-ui.adoc#example[Create a Search Vector Index with the {page-ui-name}] or xref:create-vector-search-index-rest-api.adoc#example[Create a Search Vector Index with the REST API and curl/HTTP]. 
 --
 
 * You have installed the Couchbase Go SDK. 
@@ -59,15 +59,15 @@ For more information about how to deploy a new node and Services on your cluster
 * You have the hostname or IP address for the node in your cluster where you're running the Search Service.
 For more information about where to find the IP address for your node, see xref:server:manage:manage-nodes/list-cluster-nodes.adoc[].
 
-* You have created an Search Vector Index. 
+* You have created a Search Vector Index. 
 +
-For more information about how to create an Search Vector Index, see xref:create-vector-search-index-ui.adoc[] or xref:create-vector-search-index-rest-api.adoc[].
+For more information about how to create a Search Vector Index, see xref:create-vector-search-index-ui.adoc[] or xref:create-vector-search-index-rest-api.adoc[].
 +
 [TIP]
 --
 include::partial$download-sample-partial.adoc[]
 
-For the best results, consider using the sample Search Vector Index from xref:create-vector-search-index-ui.adoc#example[Create an Search Vector Index with the {page-ui-name}] or xref:create-vector-search-index-rest-api.adoc#example[Create an Search Vector Index with the REST API and curl/HTTP]. 
+For the best results, consider using the sample Search Vector Index from xref:create-vector-search-index-ui.adoc#example[Create a Search Vector Index with the {page-ui-name}] or xref:create-vector-search-index-rest-api.adoc#example[Create a Search Vector Index with the REST API and curl/HTTP]. 
 --
 
 * You have installed the Couchbase Java SDK. 
@@ -82,15 +82,15 @@ For more information about how to deploy a new node and Services on your cluster
 * You have the hostname or IP address for the node in your cluster where you're running the Search Service.
 For more information about where to find the IP address for your node, see xref:server:manage:manage-nodes/list-cluster-nodes.adoc[].
 
-* You have created an Search Vector Index. 
+* You have created a Search Vector Index. 
 +
-For more information about how to create an Search Vector Index, see xref:create-vector-search-index-ui.adoc[] or xref:create-vector-search-index-rest-api.adoc[].
+For more information about how to create a Search Vector Index, see xref:create-vector-search-index-ui.adoc[] or xref:create-vector-search-index-rest-api.adoc[].
 +
 [TIP]
 --
 include::partial$download-sample-partial.adoc[]
 
-For the best results, consider using the sample Search Vector Index from xref:create-vector-search-index-ui.adoc#example[Create an Search Vector Index with the {page-ui-name}] or xref:create-vector-search-index-rest-api.adoc#example[Create an Search Vector Index with the REST API and curl/HTTP].  
+For the best results, consider using the sample Search Vector Index from xref:create-vector-search-index-ui.adoc#example[Create a Search Vector Index with the {page-ui-name}] or xref:create-vector-search-index-rest-api.adoc#example[Create a Search Vector Index with the REST API and curl/HTTP].  
 --
 
 * You have installed the Couchbase Python SDK.

--- a/modules/vector-search/pages/run-vector-search-ui.adoc
+++ b/modules/vector-search/pages/run-vector-search-ui.adoc
@@ -2,7 +2,7 @@
 :page-topic-type: guide
 :page-ui-name: {ui-name}
 :page-product-name: {product-name}
-:description: Run a Vector Search query from the Couchbase {page-ui-name} to preview and test the search results from an Search Vector Index.
+:description: Run a Vector Search query from the Couchbase {page-ui-name} to preview and test the search results from a Search Vector Index.
 
 [abstract]
 {description}
@@ -21,15 +21,15 @@ For more information about how to create a bucket, see xref:server:manage:manage
 
 * Your user account has the *Search Admin* or *Search Reader* role. 
 
-* You have created an Search Vector Index. 
+* You have created a Search Vector Index. 
 +
-For more information about how to create an Search Vector Index, see xref:create-vector-search-index-ui.adoc[].
+For more information about how to create a Search Vector Index, see xref:create-vector-search-index-ui.adoc[].
 +
 [TIP]
 --
 include::partial$download-sample-partial.adoc[]
 
-For the best results, consider using the sample Search Vector Index from xref:create-vector-search-index-ui.adoc#example[Create an Search Vector Index with the {page-ui-name}] or xref:create-vector-search-index-rest-api.adoc#example[Create an Search Vector Index with the REST API and curl/HTTP]. 
+For the best results, consider using the sample Search Vector Index from xref:create-vector-search-index-ui.adoc#example[Create a Search Vector Index with the {page-ui-name}] or xref:create-vector-search-index-rest-api.adoc#example[Create a Search Vector Index with the REST API and curl/HTTP]. 
 --
 
 * You have logged in to the Couchbase {page-ui-name}. 

--- a/modules/vector-search/pages/vector-search-index-architecture.adoc
+++ b/modules/vector-search/pages/vector-search-index-architecture.adoc
@@ -8,7 +8,7 @@
 
 include::partial$vector-search-no-windows.adoc[]
 
-An Search Vector Index still relies on <<sync,>> and uses <<segments,>> to manage merging and persisting data to disk in your cluster.
+A Search Vector Index still relies on <<sync,>> and uses <<segments,>> to manage merging and persisting data to disk in your cluster.
 All changes from Database Change Protocol (DCP) and the Data Service are introduced to a Search index in batches, which are further managed by segments. 
 
 [#sync]
@@ -46,7 +46,7 @@ Segments are marked as stale when they're replaced by a new merged segment creat
 Stale segments are deleted when they're no longer used by any new queries. 
 
 As smaller segments are merged together through the merger routine, the Search Service automatically runs any needed retraining for Search Vector Indexes.
-The segments for an Search Vector Index can contain different index types and use a separate indexing pipeline, choosing the appropriate indexing algorithm based on the size of your available documents.
+The segments for a Search Vector Index can contain different index types and use a separate indexing pipeline, choosing the appropriate indexing algorithm based on the size of your available documents.
 
 == Vector Search and FAISS
 
@@ -97,7 +97,7 @@ Flat indexes are a list of vectors.
 Searches run on a nearest neighbor process, based on examining the query vector against each vector in the index and calculating the distance.
 Results for flat indexes are very accurate, but performance does not scale well as a dataset grows.
 
-If an Search Vector Index uses only flat indexes, no training is required - IDs are mapped directly to vectors with exact vector comparisons, with no need for preprocessing or learning on the data.
+If a Search Vector Index uses only flat indexes, no training is required - IDs are mapped directly to vectors with exact vector comparisons, with no need for preprocessing or learning on the data.
 
 [#ivf]
 === Inverted File Index (IVF)

--- a/modules/vector-search/pages/vector-search.adoc
+++ b/modules/vector-search/pages/vector-search.adoc
@@ -1,4 +1,4 @@
-= Use Vector Search for AI Applications
+= Create Vector Searches Using Search Vector Indexes
 :page-topic-type: concept
 :page-ui-name: {ui-name}
 :page-product-name: {product-name}

--- a/modules/vector-search/pages/vector-search.adoc
+++ b/modules/vector-search/pages/vector-search.adoc
@@ -36,17 +36,17 @@ To get started using Vector Search in {page-product-name}:
 . *Store data*: Store the data you want to use for your search or AI project in a {page-product-name} cluster. 
 . *Generate embeddings*: Generate vector embeddings from your data with your preferred embedding model.
 . *Store your embeddings*: Store your vector embeddings in an array inside the documents in your {page-product-name} cluster. 
-. *Create an Search Vector Index*: Create an index to use your embeddings and identify similar documents with vector similarity. 
+. *Create a Search Vector Index*: Create an index to use your embeddings and identify similar documents with vector similarity. 
 
 In addition to supporting integrations with frameworks like LangChain and LlamaIndex, you can also use the API for an existing LLM and one of their embedding models to generate vector embeddings for your data.
 For example, the OpenAI `embeddings` endpoint can generate embeddings for a text string using a specified embedding model. 
 You can then store that embedding as a new field in your documents. 
 For more information about how to generate and obtain embeddings for text strings using the OpenAI API, see the https://platform.openai.com/docs/guides/embeddings/what-are-embeddings[Embeddings documentation].
 
-NOTE: When you create an Search Vector Index, the xref:search:child-field-options-reference.adoc#dimension[dimension] of your data vector embeddings must match the dimension for any search query vectors.
+NOTE: When you create a Search Vector Index, the xref:search:child-field-options-reference.adoc#dimension[dimension] of your data vector embeddings must match the dimension for any search query vectors.
 Otherwise, a Vector Search query fails to return any results.
 
-For more information about how to create an Search Vector Index, see xref:create-vector-search-index-ui.adoc[] or xref:create-vector-search-index-rest-api.adoc[].
+For more information about how to create a Search Vector Index, see xref:create-vector-search-index-ui.adoc[] or xref:create-vector-search-index-rest-api.adoc[].
 
 For information about how to run a Vector Search query, see xref:run-vector-search-ui.adoc[] or xref:run-vector-search-rest-api.adoc[].
 

--- a/modules/vector-search/pages/vector-search.adoc
+++ b/modules/vector-search/pages/vector-search.adoc
@@ -1,4 +1,4 @@
-= Create Vector Searches Using Search Vector Indexes
+= Vector Search Using Search Vector Indexes
 :page-topic-type: concept
 :page-ui-name: {ui-name}
 :page-product-name: {product-name}

--- a/preview/DOC-12464-inc-vector-search.yml
+++ b/preview/DOC-12464-inc-vector-search.yml
@@ -1,5 +1,0 @@
-sources:
-  docs-server:
-    branches: [DOC-12565_vector_search_concepts]
-override:
-  startPage: server:introduction:intro.adoc

--- a/preview/DOC-12464-inc-vector-search.yml
+++ b/preview/DOC-12464-inc-vector-search.yml
@@ -1,0 +1,5 @@
+sources:
+  docs-server:
+    branches: [DOC-12565_vector_search_concepts]
+override:
+  startPage: server:introduction:intro.adoc


### PR DESCRIPTION
Docs ticket: DOC-12464

* Retitles the new Vector Indexes section as **Use Vector Indexes for AI Applications**
* Following stakeholder feedback, retitles `use-vector-indexes.adoc` as **Choose the Right Vector Index**
* Retitles `vector-search.adoc` to fit in its new location in the overall Vector Indexes section, alongside the other Vector Search topics 
* Retitles `hyperscale-vector-index.adoc` and `composite-vector-index.adoc` to be action-first
* Fixes "an Search Index" → "a Search Index" throughout 

Docs preview: [Use Vector Indexes for AI Applications](https://preview.docs-test.couchbase.com/docs-devex-DOC-12464-inc-vector-search/server/current/vector-index/vectors-and-indexes-overview.html)
Credentials: [Preview docs for internal review](https://couchbasecloud.atlassian.net/wiki/x/dYF_dQ#Preview-docs-for-internal-Couchbase-reviews)
