### PR TITLE
DOC-13644: [Capella] Vector-index sample bucket

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/altervectorindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/altervectorindex.adoc
@@ -58,9 +58,9 @@ To try the examples in this section, you must do the following:
 The examples in this section assume that the 3 nodes have the names `svc-dqi-node-001`, `svc-dqi-node-002`, and `svc-dqi-node-003`.
 The nodes in your cluster may have different names or IP addresses.
 
-. Install the vector sample data as described in {prerequisites}[Prerequisites].
+. Install the `color-vector-sample` data as described in {prerequisites}[Prerequisites].
 
-. Set the query context to the `color` scope in the vector sample dataset.
+. Set the query context to the `color` scope in the `color-vector-sample` dataset.
 For more information, see xref:n1ql:n1ql-intro/queriesandresults.adoc#query-context[Query Context].
 
 .Create and move an index from one node to another

--- a/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
@@ -722,7 +722,7 @@ For more examples of indexes where the leading key may be missing, see xref:n1ql
 [[ex-create-rgb-idx]]
 .Create a Composite Vector index
 ====
-For this example, you must install the vector sample data as described in {prerequisites}[Prerequisites].
+For this example, you must install the `color-vector-sample` data as described in {prerequisites}[Prerequisites].
 The path to the required keyspace is specified by the query, so you do not need to set the query context.
 
 Create a Composite Vector index that indexes the vector field named `colorvect_l2`, as well as the scalar `color` and `brightness` fields.
@@ -736,7 +736,7 @@ include::vector-index:example$gsi-vector-idx-examples.sqlpp[tag=create-rgb-idx]
 [[ex-create-vectors-idx]]
 .Create a Composite Vector index using embedded vectors
 ====
-For this example, you must install the vector sample data as described in {prerequisites}[Prerequisites].
+For this example, you must install the `color-vector-sample` data as described in {prerequisites}[Prerequisites].
 The path to the required keyspace is specified by the query, so you do not need to set the query context.
 
 Create a Composite Vector index that indexes the vector field named `embedding-vector-dot`, as well as the scalar `color` and `brightness` fields.
@@ -750,7 +750,7 @@ include::vector-index:example$gsi-vector-idx-examples.sqlpp[tag=create-vectors-i
 [[ex-create-colors-idx]]
 .Create a Composite Vector index with a scalar leading key
 ====
-For this example, you must install the vector sample data as described in {prerequisites}[Prerequisites].
+For this example, you must install the `color-vector-sample` data as described in {prerequisites}[Prerequisites].
 The path to the required keyspace is specified by the query, so you do not need to set the query context.
 
 Create a Composite Vector index that indexes the scalar `color` and `brightness` fields, as well as the vector field named `embedding-vector-dot`.

--- a/modules/n1ql/pages/n1ql-language-reference/createvectorindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createvectorindex.adoc
@@ -175,7 +175,7 @@ include::createindex.adoc[tags=defer-index-builds-by-default]
 
 == Examples
 
-To try the examples in this section, you must install the vector sample data as described in {prerequisites}[Prerequisites].
+To try the examples in this section, you must install the `color-vector-sample` data as described in {prerequisites}[Prerequisites].
 
 [[ex-create-rgb-idx]]
 .Create a Hyperscale Vector index

--- a/modules/n1ql/pages/n1ql-language-reference/dropvectorindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropvectorindex.adoc
@@ -49,7 +49,7 @@ include::dropindex.adoc[tags=usage]
 
 == Examples
 
-To try the examples in this section, you must install the vector sample data as described in {prerequisites}[Prerequisites].
+To try the examples in this section, you must install the `color-vector-sample` data as described in {prerequisites}[Prerequisites].
 
 [[ex-1]]
 .Drop a Hyperscale Vector index
@@ -62,7 +62,7 @@ Drop the Hyperscale Vector index called `color_desc_hyperscale`, if it exists.
 ----
 DROP VECTOR INDEX `color_desc_hyperscale`
      IF EXISTS
-     ON `vector-sample`.color.rgb
+     ON `color-vector-sample`.color.rgb
 ----
 
 The following command would drop the index in exactly the same way, but uses alternative syntax.
@@ -70,7 +70,7 @@ The following command would drop the index in exactly the same way, but uses alt
 [source,sqlpp]
 ----
 DROP VECTOR INDEX IF EXISTS
-     default:`vector-sample`.color.rgb.`color_desc_hyperscale`
+     default:`color-vector-sample`.color.rgb.`color_desc_hyperscale`
 ----
 ====
 

--- a/modules/n1ql/pages/n1ql-language-reference/vectorfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/vectorfun.adoc
@@ -457,7 +457,7 @@ Check whether the specified fields in the `rgb` collection contain vector values
 SELECT ISVECTOR(description, 1, "float32") AS description,
        ISVECTOR(colorvect_l2, 3, "float32") AS colorvect_l2,
        ISVECTOR(embedding_vector_dot, 1536, "float32") AS embedding_vector_dot
-FROM `vector-sample`.color.rgb LIMIT 1;
+FROM `color-vector-sample`.color.rgb LIMIT 1;
 ----
 
 .Results

--- a/modules/vector-index/examples/find-reranking-cases.py
+++ b/modules/vector-index/examples/find-reranking-cases.py
@@ -12,14 +12,14 @@ from datetime import timedelta
 COUCHBASE_URL = "couchbase://localhost"
 USERNAME = "Administrator"
 PASSWORD = "password"
-BUCKET_NAME = "vector-sample"
+BUCKET_NAME = "color-vector-sample"
 
 # --- Connect to Cluster ---
 cluster = Cluster(COUCHBASE_URL, ClusterOptions(PasswordAuthenticator(USERNAME, PASSWORD)))
 cluster.wait_until_ready(timedelta(seconds=10))
 
 # --- Get all search-color IDs ---
-get_ids_query = "SELECT META().id AS id FROM `vector-sample`.`color`.`rgb`"
+get_ids_query = "SELECT META().id AS id FROM `color-vector-sample`.`color`.`rgb`"
 search_colors = cluster.query(get_ids_query)
 search_color_ids = [row["id"] for row in search_colors]
 
@@ -29,10 +29,10 @@ def run_vector_query(search_color_id, use_rerank=False, limit=10):
     query = f"""
     WITH question_vec AS (
         SELECT RAW couchbase_search_query.knn[0].vector  
-        FROM `vector-sample`.`color`.`rgb-questions` 
+        FROM `color-vector-sample`.`color`.`rgb-questions` 
         WHERE meta().id = "{search_color_id}")
     SELECT b.color, b.description, b.id
-    FROM `vector-sample`.`color`.`rgb` AS b
+    FROM `color-vector-sample`.`color`.`rgb` AS b
     ORDER BY APPROX_VECTOR_DISTANCE(b.embedding_vector_dot, question_vec[0], "l2", 4, {rerank_str})
     LIMIT {limit};
     """

--- a/modules/vector-index/examples/gsi-vector-idx-examples.sqlpp
+++ b/modules/vector-index/examples/gsi-vector-idx-examples.sqlpp
@@ -2,7 +2,7 @@
 SELECT RAW OBJECT_PUT(d, "embedding_vector_dot",
   ARRAY_CONCAT(d.embedding_vector_dot[0:4], ["..."])
 )
-FROM `vector-sample`.`color`.`rgb` AS d
+FROM `color-vector-sample`.`color`.`rgb` AS d
 USE KEYS ["#FFEFD5"];
 /* end::get-sample-doc[] */
 
@@ -15,25 +15,25 @@ SELECT RAW OBJECT_PUT(d, "couchbase_search_query",
     FOR k IN d.couchbase_search_query.knn END
   )
 )
-FROM `vector-sample`.`color`.`rgb-questions` AS d
+FROM `color-vector-sample`.`color`.`rgb-questions` AS d
 USE KEYS ["#FFEFD5"];
 /* end::get-sample-doc-question[] */
 
 
 /* tag::create-rgb-idx[] */
-CREATE INDEX `color_vectors_idx` ON `vector-sample`.`color`.`rgb`
+CREATE INDEX `color_vectors_idx` ON `color-vector-sample`.`color`.`rgb`
        (`colorvect_l2` VECTOR, color, brightness)
        WITH {  "dimension":3 , "similarity":"L2", "description":"IVF,SQ8"};
 /* end::create-rgb-idx[] */
 
 /* tag::create-vectors-idx[] */
-CREATE INDEX `color_desc_idx` ON `vector-sample`.`color`.`rgb` 
+CREATE INDEX `color_desc_idx` ON `color-vector-sample`.`color`.`rgb` 
      (`embedding_vector_dot` VECTOR, color, brightness) 
      WITH { "dimension":1536, "similarity":"DOT", "description":" IVF,SQ8" }
 /* end::create-vectors-idx[] */
 
 /* tag::create-colors-idx[] */
-CREATE INDEX `color_name_idx` ON `vector-sample`.`color`.`rgb`
+CREATE INDEX `color_name_idx` ON `color-vector-sample`.`color`.`rgb`
      (color, brightness, `embedding_vector_dot` VECTOR)
      WITH { "dimension":1536, "similarity":"DOT", "description":" IVF,SQ8" }
 /* end::create-colors-idx[] */
@@ -54,7 +54,7 @@ LIMIT 5;
 /* tag::query-vectors-idx-subquery[] */
 WITH question_vec AS (
         SELECT RAW couchbase_search_query.knn[0].vector  
-        from `vector-sample`.`color`.`rgb-questions` 
+        from `color-vector-sample`.`color`.`rgb-questions` 
         WHERE meta().id = "#FFEFD5")
 SELECT b.color, b.description from `rgb` AS b 
 order by APPROX_VECTOR_DISTANCE(b.embedding_vector_dot, 
@@ -64,7 +64,7 @@ question_vec[0], "DOT")  LIMIT 3;
 /* tag::query-vectors-idx-subquery-filtered[] */
 WITH question_vec AS (
         SELECT RAW couchbase_search_query.knn[0].vector  
-        from `vector-sample`.`color`.`rgb-questions` 
+        from `color-vector-sample`.`color`.`rgb-questions` 
         WHERE meta().id = "#FFEFD5")
 SELECT b.color, b.description, b.brightness from `rgb` AS b 
 WHERE b.brightness > 190.0

--- a/modules/vector-index/examples/gsi-vector-idx-examples.sqlpp
+++ b/modules/vector-index/examples/gsi-vector-idx-examples.sqlpp
@@ -3,7 +3,7 @@ SELECT RAW OBJECT_PUT(d, "embedding_vector_dot",
   ARRAY_CONCAT(d.embedding_vector_dot[0:4], ["..."])
 )
 FROM `color-vector-sample`.`color`.`rgb` AS d
-USE KEYS ["#FFEFD5"];
+USE KEYS ["FFEFD5"];
 /* end::get-sample-doc[] */
 
 /* tag::get-sample-doc-question[] */
@@ -55,7 +55,7 @@ LIMIT 5;
 WITH question_vec AS (
         SELECT RAW couchbase_search_query.knn[0].vector  
         from `color-vector-sample`.`color`.`rgb-questions` 
-        WHERE meta().id = "#FFEFD5")
+        USE KEYS "#FFEFD5")
 SELECT b.color, b.description from `rgb` AS b 
 order by APPROX_VECTOR_DISTANCE(b.embedding_vector_dot, 
 question_vec[0], "DOT")  LIMIT 3;
@@ -65,7 +65,7 @@ question_vec[0], "DOT")  LIMIT 3;
 WITH question_vec AS (
         SELECT RAW couchbase_search_query.knn[0].vector  
         from `color-vector-sample`.`color`.`rgb-questions` 
-        WHERE meta().id = "#FFEFD5")
+        USE KEYS "#FFEFD5")
 SELECT b.color, b.description, b.brightness from `rgb` AS b 
 WHERE b.brightness > 190.0
 order by APPROX_VECTOR_DISTANCE(b.embedding_vector_dot, 

--- a/modules/vector-index/examples/hyperscale-idx-examples.sqlpp
+++ b/modules/vector-index/examples/hyperscale-idx-examples.sqlpp
@@ -15,7 +15,7 @@ SELECT
     ["..."]
   ) AS embedding_vector_dot
 FROM `color-vector-sample`.`color`.`rgb` AS d
-WHERE d.id = "#87CEEB";
+USE KEYS "87CEEB";
 /* end::rgb-entry[] */
 
 
@@ -29,18 +29,18 @@ SELECT
     ["..."]
   ) AS vector
 FROM `color-vector-sample`.`color`.`rgb-questions` AS d
-WHERE d.id = "#87CEEB";
+USE KEYS "#87CEEB";
 /* end::query-rgb-questions[] */
 
 /* tag::query-rgb-with-subquery[] */
 WITH question_vec AS (
         SELECT RAW couchbase_search_query.knn[0].vector  
         FROM `color-vector-sample`.`color`.`rgb-questions` 
-        WHERE meta().id = "#87CEEB"),
+        USE KEYS "#87CEEB"),
     question_answer AS (
         SELECT wanted_similar_color_from_search
         FROM `color-vector-sample`.`color`.`rgb-questions` 
-        WHERE meta().id = "#87CEEB")
+        USE KEYS "#87CEEB")
 SELECT b.color, b.description, q.wanted_similar_color_from_search  
        FROM `color-vector-sample`.`color`.`rgb` AS b, question_answer as q
        ORDER BY APPROX_VECTOR_DISTANCE(b.embedding_vector_dot, 
@@ -58,7 +58,7 @@ CREATE VECTOR INDEX `color_desc_hyperscale_brightness`
 WITH question_vec AS (
         SELECT RAW couchbase_search_query.knn[0].vector  
         FROM `color-vector-sample`.`color`.`rgb-questions` 
-        WHERE meta().id = "#87CEEB")
+        USE KEYS "#87CEEB")
 SELECT b.color, b.description, b.brightness
        FROM `color-vector-sample`.`color`.`rgb` AS b
        WHERE b.brightness > 170.0
@@ -77,7 +77,7 @@ CREATE VECTOR INDEX `color_desc_hyperscale_no_persist`
 WITH question_vec AS (
         SELECT RAW couchbase_search_query.knn[0].vector  
         FROM `color-vector-sample`.`color`.`rgb-questions` 
-        WHERE meta().id = "#FFFFE0")
+        USE KEYS "#FFFFE0")
     SELECT b.color, b.description, b.id
     FROM `color-vector-sample`.`color`.`rgb` AS b
     ORDER BY APPROX_VECTOR_DISTANCE(b.embedding_vector_dot, question_vec[0], "l2", 4)
@@ -88,7 +88,7 @@ WITH question_vec AS (
 WITH question_vec AS (
         SELECT RAW couchbase_search_query.knn[0].vector  
         FROM `color-vector-sample`.`color`.`rgb-questions` 
-        WHERE meta().id = "#FFFFE0")
+        USE KEYS "#FFFFE0")
     SELECT b.color, b.description, b.id
     FROM `color-vector-sample`.`color`.`rgb` AS b
     ORDER BY APPROX_VECTOR_DISTANCE(b.embedding_vector_dot, question_vec[0], "l2", 4, TRUE)
@@ -100,15 +100,14 @@ WITH question_vec AS (
 WITH question_vec AS (
         SELECT RAW couchbase_search_query.knn[0].vector  
         FROM `color-vector-sample`.`color`.`rgb-questions` 
-        WHERE meta().id = "#87CEEB"),
+        USE KEYS "#87CEEB"),
     question_answer AS (
         SELECT wanted_similar_color_from_search
         FROM `color-vector-sample`.`color`.`rgb-questions` 
-        WHERE meta().id = "#87CEEB")
+        USE KEYS "#87CEEB")
 SELECT b.color, b.description, q.wanted_similar_color_from_search, approx_distance  
-       FROM `color-vector-sample`.`color`.`rgb` AS b, question_answer as q, 
-       APPROX_VECTOR_DISTANCE(b.embedding_vector_dot, question_vec[0], "l2", 4) 
-       as approx_distance
+       FROM `color-vector-sample`.`color`.`rgb` AS b, question_answer as q 
+       LET approx_distance = APPROX_VECTOR_DISTANCE(b.embedding_vector_dot, question_vec[0], "l2", 4) 
        ORDER BY approx_distance  LIMIT 3;
 /* end::query-rgb-with-distance[] */
 
@@ -116,7 +115,7 @@ SELECT b.color, b.description, q.wanted_similar_color_from_search, approx_distan
 WITH question_vec AS (
         SELECT RAW couchbase_search_query.knn[0].vector 
         FROM `color-vector-sample`.`color`.`rgb-questions` 
-        WHERE meta().id = "#87CEEB"
+        USE KEYS "#87CEEB"
     ), 
 colors AS (
     SELECT b.color
@@ -131,7 +130,7 @@ SELECT RAW colors;
 WITH question_vec AS (
         SELECT RAW couchbase_search_query.knn[0].vector 
         FROM `color-vector-sample`.`color`.`rgb-questions` 
-        WHERE meta().id = "#87CEEB"
+        USE KEYS "#87CEEB"
     ), 
 colors AS (
     SELECT b.color
@@ -146,7 +145,7 @@ SELECT RAW colors;
 WITH question_vec AS (
     SELECT RAW couchbase_search_query.knn[0].vector
     FROM `color-vector-sample`.`color`.`rgb-questions`
-    WHERE meta().id = "#87CEEB"
+    USE KEYS "#87CEEB"
 ),
 -- Exact Search results
 GroundTruthResults AS (
@@ -183,7 +182,7 @@ LEFT JOIN
 WITH question_vec AS (
     SELECT RAW couchbase_search_query.knn[0].vector
     FROM `color-vector-sample`.`color`.`rgb-questions`
-    WHERE meta().id = "#87CEEB"
+    USE KEYS "#87CEEB"
 ),
 -- Exact Search results
 GroundTruthResults AS (
@@ -220,7 +219,7 @@ LEFT JOIN
 WITH question_vec AS (
         SELECT RAW couchbase_search_query.knn[0].vector 
         FROM `color-vector-sample`.`color`.`rgb-questions` 
-        WHERE meta().id = "#87CEEB"
+        USE KEYS "#87CEEB"
     ), 
 colors AS (
     SELECT b.color

--- a/modules/vector-index/examples/hyperscale-idx-examples.sqlpp
+++ b/modules/vector-index/examples/hyperscale-idx-examples.sqlpp
@@ -1,6 +1,6 @@
 /* tag::create-rgb-idx[] */
 CREATE VECTOR INDEX `color_desc_hyperscale` 
-       ON `vector-sample`.`color`.`rgb`(`embedding_vector_dot` VECTOR)
+       ON `color-vector-sample`.`color`.`rgb`(`embedding_vector_dot` VECTOR)
        WITH { "dimension":1536, "similarity":"L2", "description":"IVF8,SQ4" }
 /* end::create-rgb-idx[] */
 
@@ -14,7 +14,7 @@ SELECT
     d.embedding_vector_dot[0:4], 
     ["..."]
   ) AS embedding_vector_dot
-FROM `vector-sample`.`color`.`rgb` AS d
+FROM `color-vector-sample`.`color`.`rgb` AS d
 WHERE d.id = "#87CEEB";
 /* end::rgb-entry[] */
 
@@ -28,28 +28,28 @@ SELECT
     d.couchbase_search_query.knn[0].vector[0:4], 
     ["..."]
   ) AS vector
-FROM `vector-sample`.`color`.`rgb-questions` AS d
+FROM `color-vector-sample`.`color`.`rgb-questions` AS d
 WHERE d.id = "#87CEEB";
 /* end::query-rgb-questions[] */
 
 /* tag::query-rgb-with-subquery[] */
 WITH question_vec AS (
         SELECT RAW couchbase_search_query.knn[0].vector  
-        FROM `vector-sample`.`color`.`rgb-questions` 
+        FROM `color-vector-sample`.`color`.`rgb-questions` 
         WHERE meta().id = "#87CEEB"),
     question_answer AS (
         SELECT wanted_similar_color_from_search
-        FROM `vector-sample`.`color`.`rgb-questions` 
+        FROM `color-vector-sample`.`color`.`rgb-questions` 
         WHERE meta().id = "#87CEEB")
 SELECT b.color, b.description, q.wanted_similar_color_from_search  
-       FROM `vector-sample`.`color`.`rgb` AS b, question_answer as q
+       FROM `color-vector-sample`.`color`.`rgb` AS b, question_answer as q
        ORDER BY APPROX_VECTOR_DISTANCE(b.embedding_vector_dot, 
        question_vec[0], "l2", 4)  LIMIT 3;
 /* end::query-rgb-with-subquery[] */
 
 /* tag::create-idx-brightness[] */
 CREATE VECTOR INDEX `color_desc_hyperscale_brightness` 
-       ON `vector-sample`.`color`.`rgb`(`embedding_vector_dot` VECTOR)
+       ON `color-vector-sample`.`color`.`rgb`(`embedding_vector_dot` VECTOR)
        INCLUDE (`brightness`)
        WITH { "dimension":1536, "similarity":"L2", "description":"IVF8,SQ4" }
 /* end::create-idx-brightness[] */
@@ -57,10 +57,10 @@ CREATE VECTOR INDEX `color_desc_hyperscale_brightness`
 /* tag::query-rgb-with-brightness[] */
 WITH question_vec AS (
         SELECT RAW couchbase_search_query.knn[0].vector  
-        FROM `vector-sample`.`color`.`rgb-questions` 
+        FROM `color-vector-sample`.`color`.`rgb-questions` 
         WHERE meta().id = "#87CEEB")
 SELECT b.color, b.description, b.brightness
-       FROM `vector-sample`.`color`.`rgb` AS b
+       FROM `color-vector-sample`.`color`.`rgb` AS b
        WHERE b.brightness > 170.0
        ORDER BY APPROX_VECTOR_DISTANCE(b.embedding_vector_dot, 
        question_vec[0], "l2", 4)  LIMIT 3;
@@ -68,7 +68,7 @@ SELECT b.color, b.description, b.brightness
 
 /* tag::create-rgb-no-persist[] */
 CREATE VECTOR INDEX `color_desc_hyperscale_no_persist` 
-       ON `vector-sample`.`color`.`rgb`(`embedding_vector_dot` VECTOR)
+       ON `color-vector-sample`.`color`.`rgb`(`embedding_vector_dot` VECTOR)
        WITH { "dimension":1536, "similarity":"L2", "description":"IVF8,SQ4", 
               "persist_full_vector": false};
 /* end::create-rgb-no-persist[] */
@@ -76,10 +76,10 @@ CREATE VECTOR INDEX `color_desc_hyperscale_no_persist`
 /* tag::rerank-before-example[] */
 WITH question_vec AS (
         SELECT RAW couchbase_search_query.knn[0].vector  
-        FROM `vector-sample`.`color`.`rgb-questions` 
+        FROM `color-vector-sample`.`color`.`rgb-questions` 
         WHERE meta().id = "#FFFFE0")
     SELECT b.color, b.description, b.id
-    FROM `vector-sample`.`color`.`rgb` AS b
+    FROM `color-vector-sample`.`color`.`rgb` AS b
     ORDER BY APPROX_VECTOR_DISTANCE(b.embedding_vector_dot, question_vec[0], "l2", 4)
     LIMIT 3;
 /* end::rerank-before-example[] */
@@ -87,10 +87,10 @@ WITH question_vec AS (
 /* tag::rerank-after-example[] */
 WITH question_vec AS (
         SELECT RAW couchbase_search_query.knn[0].vector  
-        FROM `vector-sample`.`color`.`rgb-questions` 
+        FROM `color-vector-sample`.`color`.`rgb-questions` 
         WHERE meta().id = "#FFFFE0")
     SELECT b.color, b.description, b.id
-    FROM `vector-sample`.`color`.`rgb` AS b
+    FROM `color-vector-sample`.`color`.`rgb` AS b
     ORDER BY APPROX_VECTOR_DISTANCE(b.embedding_vector_dot, question_vec[0], "l2", 4, TRUE)
     LIMIT 3;
 /* end::rerank-after-example[] */
@@ -99,14 +99,14 @@ WITH question_vec AS (
 /* tag::query-rgb-with-distance[] */
 WITH question_vec AS (
         SELECT RAW couchbase_search_query.knn[0].vector  
-        FROM `vector-sample`.`color`.`rgb-questions` 
+        FROM `color-vector-sample`.`color`.`rgb-questions` 
         WHERE meta().id = "#87CEEB"),
     question_answer AS (
         SELECT wanted_similar_color_from_search
-        FROM `vector-sample`.`color`.`rgb-questions` 
+        FROM `color-vector-sample`.`color`.`rgb-questions` 
         WHERE meta().id = "#87CEEB")
 SELECT b.color, b.description, q.wanted_similar_color_from_search, approx_distance  
-       FROM `vector-sample`.`color`.`rgb` AS b, question_answer as q, 
+       FROM `color-vector-sample`.`color`.`rgb` AS b, question_answer as q, 
        APPROX_VECTOR_DISTANCE(b.embedding_vector_dot, question_vec[0], "l2", 4) 
        as approx_distance
        ORDER BY approx_distance  LIMIT 3;
@@ -115,12 +115,12 @@ SELECT b.color, b.description, q.wanted_similar_color_from_search, approx_distan
 /* tag::untuned-query[] */
 WITH question_vec AS (
         SELECT RAW couchbase_search_query.knn[0].vector 
-        FROM `vector-sample`.`color`.`rgb-questions` 
+        FROM `color-vector-sample`.`color`.`rgb-questions` 
         WHERE meta().id = "#87CEEB"
     ), 
 colors AS (
     SELECT b.color
-    FROM `vector-sample`.`color`.`rgb` AS b
+    FROM `color-vector-sample`.`color`.`rgb` AS b
     ORDER BY APPROX_VECTOR_DISTANCE(b.embedding_vector_dot, question_vec[0], "l2")
     LIMIT 10 )
 SELECT RAW colors;
@@ -130,12 +130,12 @@ SELECT RAW colors;
 /* tag::exact-query[] */
 WITH question_vec AS (
         SELECT RAW couchbase_search_query.knn[0].vector 
-        FROM `vector-sample`.`color`.`rgb-questions` 
+        FROM `color-vector-sample`.`color`.`rgb-questions` 
         WHERE meta().id = "#87CEEB"
     ), 
 colors AS (
     SELECT b.color
-    FROM `vector-sample`.`color`.`rgb` AS b
+    FROM `color-vector-sample`.`color`.`rgb` AS b
     ORDER BY VECTOR_DISTANCE(b.embedding_vector_dot, question_vec[0], "l2")
     LIMIT 10 )
 SELECT RAW colors;
@@ -145,20 +145,20 @@ SELECT RAW colors;
 -- Get the vector for the question
 WITH question_vec AS (
     SELECT RAW couchbase_search_query.knn[0].vector
-    FROM `vector-sample`.`color`.`rgb-questions`
+    FROM `color-vector-sample`.`color`.`rgb-questions`
     WHERE meta().id = "#87CEEB"
 ),
 -- Exact Search results
 GroundTruthResults AS (
     SELECT b.color
-    FROM `vector-sample`.`color`.`rgb` AS b
+    FROM `color-vector-sample`.`color`.`rgb` AS b
     ORDER BY VECTOR_DISTANCE(b.embedding_vector_dot,
     question_vec[0], "l2") LIMIT 10
 ),
 -- Approximate Search results
 ApproximateResults AS (
     SELECT b.color
-    FROM `vector-sample`.`color`.`rgb` AS b
+    FROM `color-vector-sample`.`color`.`rgb` AS b
     ORDER BY APPROX_VECTOR_DISTANCE(b.embedding_vector_dot,
     question_vec[0], "l2") LIMIT 10
 )
@@ -182,20 +182,20 @@ LEFT JOIN
 -- Get the vector for the question
 WITH question_vec AS (
     SELECT RAW couchbase_search_query.knn[0].vector
-    FROM `vector-sample`.`color`.`rgb-questions`
+    FROM `color-vector-sample`.`color`.`rgb-questions`
     WHERE meta().id = "#87CEEB"
 ),
 -- Exact Search results
 GroundTruthResults AS (
     SELECT b.color
-    FROM `vector-sample`.`color`.`rgb` AS b
+    FROM `color-vector-sample`.`color`.`rgb` AS b
     ORDER BY VECTOR_DISTANCE(b.embedding_vector_dot,
     question_vec[0], "l2") LIMIT 10
 ),
 -- Approximate Search results, this timw with nProbes set to 4:
 ApproximateResults AS (
     SELECT b.color
-    FROM `vector-sample`.`color`.`rgb` AS b
+    FROM `color-vector-sample`.`color`.`rgb` AS b
     ORDER BY APPROX_VECTOR_DISTANCE(b.embedding_vector_dot,
     question_vec[0], "l2", 4) LIMIT 10
 )
@@ -219,12 +219,12 @@ LEFT JOIN
 /* tag::tuned-query[] */
 WITH question_vec AS (
         SELECT RAW couchbase_search_query.knn[0].vector 
-        FROM `vector-sample`.`color`.`rgb-questions` 
+        FROM `color-vector-sample`.`color`.`rgb-questions` 
         WHERE meta().id = "#87CEEB"
     ), 
 colors AS (
     SELECT b.color
-    FROM `vector-sample`.`color`.`rgb` AS b
+    FROM `color-vector-sample`.`color`.`rgb` AS b
     ORDER BY APPROX_VECTOR_DISTANCE(b.embedding_vector_dot, question_vec[0], "l2", 4)
     LIMIT 10 )
 SELECT RAW colors;

--- a/modules/vector-index/pages/composite-vector-index.adoc
+++ b/modules/vector-index/pages/composite-vector-index.adoc
@@ -52,6 +52,19 @@ See xref:vector-index:vectors-and-indexes-overview.adoc#vector_similarity[Vector
 
 include::vector-search:partial$download-sample-partial.adoc[]
 
+include::vector-search:partial$download-sample-partial.adoc[]
+
+In addition, to get the best results with the examples on this page, download the following sample dataset:
+
+https://cbc-remote-execution-examples-prod.s3.amazonaws.com/color_data_2vectors.zip[Download color_data_2vectors.zip]
+
+When you have downloaded `color_data_2vectors.zip`, unzip it, then xref:guides:load.adoc[import] the `rgb_questions.json` file with the following settings:
+
+* Use the `color-vector-sample` bucket.
+* Use the `color` scope.
+* Create a new target collection called `rgb-questions` -- with a hyphen `-`, not an underscore `&lowbar;`.
+* To set your document keys, use the value of the `id` field from the JSON document.
+
 [#create-index]
 
 include::vector-index:partial$create-composite-index-capella-ui.adoc[opts=optional]
@@ -115,7 +128,7 @@ include::vector-index:example$composite-vector-data.json[tag=sample-doc]
 
 ==== Index the RGB Values
 
-The `rgb.json` file's `colorvect_l2` attribute defines an array containing the RGB values for the entry's color.
+The `rgb` collection's `colorvect_l2` attribute defines an array containing the RGB values for the entry's color.
 While this technically is not an embedded vector, you can still create a vector index column for this array.
 The following example creates a Composite Vector index for this attribute as an embedded vector as well as the color's name and brightness.
 

--- a/modules/vector-index/pages/composite-vector-index.adoc
+++ b/modules/vector-index/pages/composite-vector-index.adoc
@@ -98,7 +98,7 @@ include::partial$index-algorithm-settings.adoc[]
 The following examples show you how to create two Composite Vector index with a vector column using sample data.
 They both use the data from the `color_data_2vectors.zip` file mentioned earlier.
 
-The following query gets a single document from the `rgb` collection in the `vector-sample` bucket's `color` scope.
+The following query gets a single document from the `rgb` collection in the `color-vector-sample` bucket's `color` scope.
 It truncates the `embedding_vector_dot` attribute to the first four values to improve readability.
 
 [source,sqlpp]
@@ -366,7 +366,7 @@ In a production environment, your application calls the same embedding model it 
 
 For this example, you can use embedded vectors in the `rgb_questions.json` file that's in the `color_data_2vectors.zip` file.
 This file contains a `question` attribute containing a search prompt for a particular color.
-The following query gets a single document from the `rgb_questions` collection in the `vector-sample` bucket's `color` scope.
+The following query gets a single document from the `rgb_questions` collection in the `color-vector-sample` bucket's `color` scope.
 It truncates the `couchbase_search_query.knn.vector` attribute to the first four values to improve readability.
 
 [source,sqlpp]
@@ -394,7 +394,7 @@ include::vector-index:example$query-vectors-idx-whole.sqlpp[tags=!query-vectors-
 
 Click btn:[icon:github[\] View] to see and copy the entire query with all the vectors.
 
-Another option is to import the `rgb_questions.json` file into another collection in the `vector-sample` bucket's `color` scope named `rgb-questions`.
+Another option is to import the `rgb_questions.json` file into another collection in the `color-vector-sample` bucket's `color` scope named `rgb-questions`.
 Then you can use a subquery to get the vectors for the question and use it in your query of the `rgb` collection's `embedding_vector_dot` attribute:
 
 [source,sqlpp]

--- a/modules/vector-index/pages/hyperscale-vector-index.adoc
+++ b/modules/vector-index/pages/hyperscale-vector-index.adoc
@@ -117,7 +117,7 @@ There's also a field named `couchbase_search_query.knn.vector` that contains an 
 
 include::vector-search:partial$download-sample-partial.adoc[]
 
-The following query returns a sample document from the data in the `vector-sample.color.rgb` collection, truncating the embedded vector to 4 values to make the result readable:
+The following query returns a sample document from the data in the `color-vector-sample.color.rgb` collection, truncating the embedded vector to 4 values to make the result readable:
 
 [source,sqlpp]
 ----
@@ -205,7 +205,7 @@ You must supply a vector value in your query that Couchbase {product-name} can c
 In actual use, your application generates a vector for the query value using the same embedding model it used to embed the vectors in your documents.
 
 To avoid the complication of calling an embedding model, this example uses embedded vectors in the `rgb_questions.json` file that's included in `color_data_2vectors.zip`.
-For this example, the contents of this file are loaded into a collection named `vector-sample.color.rgb-questions`.
+For this example, the contents of this file are loaded into a collection named `color-vector-sample.color.rgb-questions`.
 This collection contains a `question` attribute which is a search prompt for a particular color.
 The `couchbase_search_query.knn.vector` attribute contains the embedded vector for the `question` attribute.
 The following query lists several attributes from a document in the collection.
@@ -224,7 +224,7 @@ include::vector-index:example$hyperscale-idx-data.json[tag=query-rgb-questions-o
 ----
 
 To use the embedded vector, you need to include the `couchbase_search_query.knn.vector` attribute in your query's `SELECT` statement.
-You can either directly copy and paste the entire array into your query or use a subquery to retrieve it from the `vector-sample.color.rgb-questions` collection.
+You can either directly copy and paste the entire array into your query or use a subquery to retrieve it from the `color-vector-sample.color.rgb-questions` collection.
 The following example uses a subquery to get the vector, and also includes the `wanted_similar_color_from_search` attribute in the output which shows you the color that the query should return.
 
 [source,sqlpp]

--- a/modules/vector-index/pages/hyperscale-vector-index.adoc
+++ b/modules/vector-index/pages/hyperscale-vector-index.adoc
@@ -63,6 +63,17 @@ See xref:vector-index:vectors-and-indexes-overview.adoc#vector_similarity[Vector
 
 include::vector-search:partial$download-sample-partial.adoc[]
 
+In addition, to get the best results with the examples on this page, download the following sample dataset:
+
+https://cbc-remote-execution-examples-prod.s3.amazonaws.com/color_data_2vectors.zip[Download color_data_2vectors.zip]
+
+When you have downloaded `color_data_2vectors.zip`, unzip it, then xref:guides:load.adoc[import] the `rgb_questions.json` file with the following settings:
+
+* Use the `color-vector-sample` bucket.
+* Use the `color` scope.
+* Create a new target collection called `rgb-questions` -- with a hyphen `-`, not an underscore `&lowbar;`.
+* To set your document keys, use the value of the `id` field from the JSON document.
+
 [#create-index]
 
 include::vector-index:partial$create-hyperscale-index-capella-ui.adoc[opts=optional]
@@ -112,10 +123,8 @@ include::partial$index-algorithm-settings.adoc[]
 [#examples]
 === Create Hyperscale Vector Index Example
 
-The examples in this section use a dataset that contains information about colors including a text description of the color.
-There's also a field named `couchbase_search_query.knn.vector` that contains an embedded vector for the color description.
-
-include::vector-search:partial$download-sample-partial.adoc[]
+The examples in this section use the `color-vector-sample.color.rgb` collection.
+This contains information about colors, including a text description of the color.
 
 The following query returns a sample document from the data in the `color-vector-sample.color.rgb` collection, truncating the embedded vector to 4 values to make the result readable:
 
@@ -132,7 +141,7 @@ The result of running the query is:
 include::vector-index:example$hyperscale-idx-data.json[tag=rgb-document]
 ----
 
-The following example creates an Hyperscale vector index for the vector column named `embedding-vector-dot`.
+The following example creates an Hyperscale Vector index for the vector column named `embedding-vector-dot`.
 
 [source,sqlpp]
 ----

--- a/modules/vector-index/pages/vector-index-best-practices.adoc
+++ b/modules/vector-index/pages/vector-index-best-practices.adoc
@@ -210,6 +210,9 @@ The following example uses the `VECTOR_DISTANCE` function instead of the `APPROX
 include::vector-index:example$hyperscale-idx-examples.sqlpp[tag=exact-query]
 ----
 
+TIP: If the query fails and Couchbase Capella advises you to create a primary index, click btn:[Build Primary Index].
+When the primary index is created, run the query again.
+
 Running the query returns the following results:
 
 [source,json]

--- a/modules/vector-search/examples/run-vector-search-generate-embed.go
+++ b/modules/vector-search/examples/run-vector-search-generate-embed.go
@@ -74,7 +74,7 @@ func main() {
     username := os.Getenv("CB_USERNAME")
     password := os.Getenv("CB_PASSWORD")
 	// Make sure to change the bucket, and scope names to match where you stored the sample data in your database. 
-    bucket_name := "vector-sample"
+    bucket_name := "color-vector-sample"
     scope_name := "color"
 
     cluster, err := gocb.Connect(connstr, gocb.ClusterOptions{

--- a/modules/vector-search/examples/run-vector-search-generate-embed.java
+++ b/modules/vector-search/examples/run-vector-search-generate-embed.java
@@ -67,7 +67,7 @@ public class RunVectorSearchGenerateEmbed {
 	String username = System.getenv("CB_USERNAME");
 	String password = System.getenv("CB_PASSWORD");
 // Make sure to change the bucket, scope, collection, and index names to match where you stored the sample data in your database. 
-	String bucketName = "vector-sample";
+	String bucketName = "color-vector-sample";
 	String scopeName = "color";
 	String collectionName = "rgb";
 	String searchIndexName = "color-index";

--- a/modules/vector-search/examples/run-vector-search-generate-embed.py
+++ b/modules/vector-search/examples/run-vector-search-generate-embed.py
@@ -22,7 +22,7 @@ client = OpenAI()
 pa = PasswordAuthenticator(os.getenv("CB_USERNAME"), os.getenv("CB_PASSWORD"))
 cluster = Cluster("couchbases://" + os.getenv("CB_HOSTNAME") + "/?ssl=no_verify", ClusterOptions(pa))
 # Make sure to change the bucket, scope, and index names to match where you stored the sample data in your database. 
-bucket = cluster.bucket("vector-sample")
+bucket = cluster.bucket("color-vector-sample")
 scope = bucket.scope("color")
 search_index = "color-index"
 try:

--- a/modules/vector-search/examples/run-vector-search-simple-color.go
+++ b/modules/vector-search/examples/run-vector-search-simple-color.go
@@ -16,7 +16,7 @@ func main() {
     username := os.Getenv("CB_USERNAME")
     password := os.Getenv("CB_PASSWORD")
 	// Make sure to change the bucket, and scope names to match where you stored the sample data in your database. 
-    bucket_name := "vector-sample"
+    bucket_name := "color-vector-sample"
     scope_name := "color"
 
     cluster, err := gocb.Connect(connstr, gocb.ClusterOptions{

--- a/modules/vector-search/examples/run-vector-search-simple-color.java
+++ b/modules/vector-search/examples/run-vector-search-simple-color.java
@@ -18,7 +18,7 @@ public class RunVectorSearchSimpleColor {
 	String username = System.getenv("CB_USERNAME");
 	String password = System.getenv("CB_PASSWORD");
     // Make sure to change the bucket, scope, collection, and index names to match where you stored the sample data in your database. 
-	String bucketName = "vector-sample";
+	String bucketName = "color-vector-sample";
 	String scopeName = "color";
 	String collectionName = "rgb";
 	String searchIndexName = "color-index";

--- a/modules/vector-search/examples/run-vector-search-simple-color.py
+++ b/modules/vector-search/examples/run-vector-search-simple-color.py
@@ -17,7 +17,7 @@ vector = [0.0,0.0,128.0]
 pa = PasswordAuthenticator(os.getenv("CB_USERNAME"), os.getenv("CB_PASSWORD"))
 cluster = Cluster("couchbases://" + os.getenv("CB_HOSTNAME") + "/?ssl=no_verify", ClusterOptions(pa))
 # Make sure to change the bucket, scope, and index names to match where you stored the sample data in your database.  
-bucket = cluster.bucket("vector-sample")
+bucket = cluster.bucket("color-vector-sample")
 scope = bucket.scope("color")
 search_index = "color-index"
 try:

--- a/modules/vector-search/examples/vector-search-index-payload.jsonc
+++ b/modules/vector-search/examples/vector-search-index-payload.jsonc
@@ -1,8 +1,8 @@
 {
   "type": "fulltext-index",
-  "name": "vector-sample.color.color-index",
+  "name": "color-vector-sample.color.color-index",
   "sourceType": "gocbcore",
-  "sourceName": "vector-sample",
+  "sourceName": "color-vector-sample",
   "planParams": {
     "maxPartitionsPerPIndex": 512,
     "indexPartitions": 1

--- a/modules/vector-search/partials/download-sample-partial.adoc
+++ b/modules/vector-search/partials/download-sample-partial.adoc
@@ -1,4 +1,4 @@
 You can import a sample dataset to use with the procedure or examples on this page. 
 
-Go to menu:Data Tools[Import] from your cluster and xref:clusters:data-service/import-data-documents.adoc#import-sample-data[import the vector-sample] sample data.
+Go to menu:Data Tools[Import] from your cluster and xref:clusters:data-service/import-data-documents.adoc#import-sample-data[import the color-vector-sample] sample data.
 


### PR DESCRIPTION
Docs issue: DOC-13644

For Capella only:
- Updates the name of the vector-sample bucket to `color-vector-sample`
- Adds instructions to import `rgb-questions`, which is not included by default
- Updates queries with `USE KEYS` to avoid creating primary indexes unless absolutely necessary &mdash; Query without Indexes is not available by default for paid service plans
- Updates some existing queries using the `rgb` collection, because the ID for each document has no `#` at the start, unlike when you import from`color_data_2vectors.zip`  

Document previews:
- [Vector Search Using Hyperscale Vector Indexes › Examples on this Page](https://preview.docs-test.couchbase.com/docs-devex-DOC-13644-color-vector-index/cloud/vector-index/hyperscale-vector-index.html#examples-on-this-page)
- [Filtered Search Using Composite Vector Indexes › Examples on this Page](https://preview.docs-test.couchbase.com/docs-devex-DOC-13644-color-vector-index/cloud/vector-index/composite-vector-index.html#examples-on-this-page)

... and many others, these are just the pages with the most changes.

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.