### PR TITLE
DOC-13651: Incorrect role names in GRANT and REVOKE

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/grant.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/grant.adoc
@@ -111,6 +111,6 @@ GRANT cluster_admin TO david, michael, robin;
 ====
 [source,sqlpp]
 ----
-GRANT cluster_admin, data_reader ON `travel-sample` TO debby;
+GRANT query_select, query_update ON `travel-sample` TO debby;
 ----
 ====

--- a/modules/n1ql/pages/n1ql-language-reference/grant.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/grant.adoc
@@ -15,14 +15,14 @@ Roles can be of the following two types:
 simple::
 Roles which apply generically to all keyspaces or resources in the cluster.
 +
-For example: `ClusterAdmin` or `BucketAdmin`
+For example: `cluster_admin` or `bucket_admin`
 
 parameterized by a keyspace::
 Roles which are defined for the scope of the specified keyspace only.
 The keyspace name is specified after ON.
 +
-For example: `pass:c[DataReader ON `travel-sample`]` +
-or `pass:c[Query_Select ON `travel-sample`]`
+For example: `pass:c[data_reader ON `travel-sample`]` +
+or `pass:c[query_select ON `travel-sample`]`
 
 NOTE: Only Full Administrators can run the GRANT statement.
 For more details about user roles, see {authorization-overview}[Authorization].
@@ -78,14 +78,11 @@ Refer to the {keyspace-ref}[CREATE INDEX] statement for details of the syntax.
 
 == Usage
 
-GRANT statements support legacy systems and have two forms:
+GRANT statements have two forms:
 
 .{counter:form}. Unparameterized Roles
 [source,sqlpp]
 ----
-GRANT Replication Admin, Query External Access
-   TO cchaplan, jgleason;
-
 GRANT replication_admin, query_external_access
    TO cchaplan, jgleason;
 ----
@@ -93,10 +90,6 @@ GRANT replication_admin, query_external_access
 .{counter:form}. Parameterized Roles
 [source,sqlpp]
 ----
-GRANT Query Select, Views Admin
-   ON orders, customers
-   TO bill, linda;
-
 GRANT query_select, views_admin
    ON orders, customers
    TO bill, linda;
@@ -106,18 +99,18 @@ NOTE: Mixing of parameterized and unparameterized roles or syntax is not allowed
 
 == Examples
 
-.Grant the role of Cluster Administrator to three people
+.Grant the role of Cluster Admin to three people
 ====
 [source,sqlpp]
 ----
-GRANT ClusterAdmin TO david, michael, robin;
+GRANT cluster_admin TO david, michael, robin;
 ----
 ====
 
-.Grant the roles of Cluster Administrator and Data Reader in the travel-sample keyspace to Debby
+.Grant the roles of Cluster Admin and Data Reader in the travel-sample keyspace to Debby
 ====
 [source,sqlpp]
 ----
-GRANT ClusterAdmin, DataReader ON `travel-sample` TO debby;
+GRANT cluster_admin, data_reader ON `travel-sample` TO debby;
 ----
 ====

--- a/modules/n1ql/pages/n1ql-language-reference/revoke.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/revoke.adoc
@@ -15,14 +15,14 @@ Roles can be of the following two types:
 simple::
 Roles which apply generically to all keyspaces/resources in the cluster.
 +
-For example: `ClusterAdmin` or `BucketAdmin`
+For example: `cluster_admin` or `bucket_admin`
 
 parameterized by a keyspace::
 Roles which are defined for the scope of the specified keyspace only.
 The keyspace name is specified after ON.
 +
-For example: `pass:c[DataReader ON `travel-sample`]` +
-or `pass:c[Query_Select ON `travel-sample`]`
+For example: `pass:c[data_reader ON `travel-sample`]` +
+or `pass:c[query_select ON `travel-sample`]`
 
 NOTE: Only Full Administrators can run the REVOKE statement.
 For more details about user roles, see
@@ -79,19 +79,19 @@ Refer to the {keyspace-ref}[CREATE INDEX] statement for details of the syntax.
 
 == Examples
 
-.Revoke the role of ClusterAdmin from three people
+.Revoke the role of Cluster Admin from three people
 ====
 [source,sqlpp]
 ----
-REVOKE ClusterAdmin FROM david, michael, robin
+REVOKE cluster_admin FROM david, michael, robin
 ----
 ====
 
-.Revoke the roles of ClusterAdmin and QueryUpdate in the travel-sample keyspace from debby
+.Revoke the roles of Cluster Admin and Query Update in the travel-sample keyspace from Debby
 ====
 [source,sqlpp]
 ----
-REVOKE ClusterAdmin, QueryUpdate
+REVOKE cluster_admin, query_update
     ON `travel-sample`
   FROM debby
 ----

--- a/modules/n1ql/pages/n1ql-language-reference/revoke.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/revoke.adoc
@@ -91,7 +91,7 @@ REVOKE cluster_admin FROM david, michael, robin
 ====
 [source,sqlpp]
 ----
-REVOKE cluster_admin, query_update
+REVOKE query_select, query_update
     ON `travel-sample`
   FROM debby
 ----


### PR DESCRIPTION
Docs issue: DOC-13651

Making the changes on 7.6 first so we don't get in the way of the 8.0 release 😄 

Preview URL:
- [GRANT](https://preview.docs-test.couchbase.com/docs-devex-DOC-13651-role-names/server/current/n1ql/n1ql-language-reference/grant.html)
- [REVOKE](https://preview.docs-test.couchbase.com/docs-devex-DOC-13651-role-names/server/current/n1ql/n1ql-language-reference/revoke.html)

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.