### PR TITLE
NO ISSUE: Verify Server 8.0 on Capella

### DIFF
--- a/modules/indexes/pages/query-without-index.adoc
+++ b/modules/indexes/pages/query-without-index.adoc
@@ -42,8 +42,8 @@ If there is a primary index or any suitable secondary index available for the ke
 [discrete]
 ===== RBAC Privileges
 
-Users must have the *Query Use Sequential Scans* role on the keyspace to be able to execute a request with a sequential scan.
-For more details about user roles, see
+Your client must have the *Query Use Sequential Scans* role on the keyspace to be able to execute a request with a sequential scan.
+For more details about cluster access privileges, see
 {authorization-overview}[].
 
 === Examples

--- a/modules/n1ql/pages/n1ql-language-reference/advise.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/advise.adoc
@@ -66,8 +66,8 @@ Similarly, if the query is already using the optimal covering index, the index a
 
 == Prerequisites
 
-To execute the ADVISE statement, you must have the privileges required for the {sqlpp} statement for which you want advice.
-For more details about user roles, see xref:clusters:manage-database-users.adoc[].
+To execute the ADVISE statement, your client must have the privileges required for the {sqlpp} statement for which you want advice.
+For more details about cluster access privileges, see xref:clusters:manage-database-users.adoc[].
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/altergroup.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/altergroup.adoc
@@ -69,7 +69,7 @@ image::n1ql-language-reference/rbac-role.png["Syntax diagram: refer to source co
 [horizontal]
 
 role::
-One of the xref:learn:security/authorization-overview.adoc[RBAC role names predefined] by Couchbase Server.
+One of the xref:clusters:manage-database-users.adoc[RBAC role names predefined] by Couchbase Server.
 +
 The following roles have short forms that can be used as well:
 

--- a/modules/n1ql/pages/n1ql-language-reference/altergroup.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/altergroup.adoc
@@ -23,8 +23,7 @@ If you want to add or remove specific roles without affecting the others, use th
 
 == RBAC Privileges
 
-To execute the ALTER GROUP statement, you must have either the Full Admin or the Security Admin role.
-For more information about user roles, see xref:learn:security/authorization-overview.adoc[Authorization].
+To execute the ALTER GROUP statement, you must be an xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] or xref:projects:project-roles.adoc#project-owner-role[`Project Owner`].
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/altersequence.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/altersequence.adoc
@@ -39,8 +39,8 @@ Similarly, when you restore a bucket, sequences are restored in accordance with 
 == Prerequisites
 
 .RBAC Privileges
-To execute the ALTER SEQUENCE statement, you must have the _Query Manage Sequences_ privilege granted on the scope.
-For more details about user roles, see {authorization-overview}[].
+To execute the ALTER SEQUENCE statement, your client must have the _Query Manage Sequences_ privilege granted on the scope.
+For more details about cluster access privileges, see {authorization-overview}[].
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/alteruser.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/alteruser.adoc
@@ -19,8 +19,7 @@ It updates the entire group list, so any existing groups not included in the new
 
 == RBAC Privileges
 
-To execute the ALTER USER statement, you must have either the Full Admin or the Security Admin role.
-For more information about user roles, see xref:learn:security/authorization-overview.adoc[Authorization].
+To execute the ALTER USER statement, you must be an xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] or xref:projects:project-roles.adoc#project-owner-role[`Project Owner`].
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/altervectorindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/altervectorindex.adoc
@@ -5,7 +5,7 @@
 :imagesdir: ../../assets/images
 
 :rebalancing-the-index-service: xref:learn:clusters-and-availability/rebalance.adoc#rebalancing-the-index-service
-:console-indexes: xref:manage:manage-ui/manage-ui.adoc#console-indexes
+:console-indexes: xref:clusters:index-service/manage-indexes.adoc
 :query-context: xref:n1ql:n1ql-intro/queriesandresults.adoc#query-context
 :identifiers: xref:n1ql-language-reference/identifiers.adoc
 :logical-hierarchy: xref:n1ql:n1ql-intro/queriesandresults.adoc#logical-hierarchy

--- a/modules/n1ql/pages/n1ql-language-reference/build-index.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/build-index.adoc
@@ -30,7 +30,7 @@ The full index build operation happens in the background.
 Index metadata provides a state field.
 The index state may be `scheduled for creation`, `deferred`, `building`, `pending`, `online`, `offline`, or `abridged`.
 This state field and other index metadata can be queried using {querying-indexes}[system:indexes].
-You can also monitor the index state using the Couchbase Web Console.
+You can also monitor the index state using the Capella UI.
 
 If you attempt to build an index which is still scheduled for background creation, the request fails.
 
@@ -63,8 +63,8 @@ If the data set changes dramatically, you must drop and rebuild the index to upd
 [discrete]
 ===== RBAC Privileges
 
-User executing the BUILD INDEX statement must have the _Query Manage Index_ privilege granted on the keyspace.
-For more details about user roles, see
+The client executing the BUILD INDEX statement must have the _Query Manage Index_ privilege granted on the keyspace.
+For more details about cluster access privileges, see
 {authorization-overview}[].
 
 == Syntax

--- a/modules/n1ql/pages/n1ql-language-reference/comma.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/comma.adoc
@@ -37,8 +37,8 @@ Refer to the examples below for further details.
 
 == Prerequisites
 
-For you to select data from keyspace or expression, you must have the [.param]`query_select` privilege on that keyspace.
-For more details about user roles, see {authorization}[].
+To select data from keyspace or expression, your client must have the [.param]`query_select` privilege on that keyspace.
+For more details about cluster access privileges, see {authorization}[].
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/creategroup.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/creategroup.adoc
@@ -17,8 +17,7 @@ When you add users to a group, they automatically inherit the roles assigned to 
 
 == RBAC Privileges
 
-To execute the CREATE GROUP statement, you must have either the Full Admin or the Security Admin role.
-For more information about user roles, see xref:learn:security/authorization-overview.adoc[Authorization].
+To execute the CREATE GROUP statement, you must be an xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] or xref:projects:project-roles.adoc#project-owner-role[`Project Owner`].
 
 == Syntax
 
@@ -74,7 +73,7 @@ image::n1ql-language-reference/rbac-role.png["Syntax diagram: refer to source co
 [horizontal]
 
 role::
-One of the xref:learn:security/authorization-overview.adoc[RBAC role names predefined] by Couchbase Server.
+One of the xref:clusters:manage-database-users.adoc[RBAC role names predefined] by Couchbase Server.
 +
 For the following roles, you can use their short forms as well:
 

--- a/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
@@ -69,8 +69,8 @@ If the data set changes dramatically, you must drop and rebuild the index to upd
 [discrete]
 ===== RBAC Privileges
 
-To execute the {doctitle} statement, you must have the `Query Manage Index` privilege granted on the keyspace.
-For more information about user roles, see
+To execute the {doctitle} statement, your client must have the `Query Manage Index` privilege granted on the keyspace.
+For more information about cluster access privileges, see
 {authorization-overview}[].
 //end::prerequisites[]
 
@@ -545,7 +545,7 @@ Do not create (or drop) secondary indexes, Composite Vector indexes, or Hypersca
 Index metadata provides a state field.
 This state field and other index metadata can be queried using {querying-indexes}[system:indexes].
 The index state may be `scheduled for creation`, `deferred`, `building`, `pending`, `online`, `offline`, or `abridged`.
-You can also monitor the index state using the Couchbase Web Console.
+You can also monitor the index state using the Capella UI.
 
 [IMPORTANT]
 ====

--- a/modules/n1ql/pages/n1ql-language-reference/createprimaryindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createprimaryindex.adoc
@@ -44,8 +44,8 @@ See <<index-with,WITH Clause>> for more details.
 [discrete]
 ===== RBAC Privileges
 
-To execute the `CREATE PRIMARY INDEX` statement, you must have the `Query Manage Index` privilege granted on the keyspace.
-For more information about user roles, see
+To execute the `CREATE PRIMARY INDEX` statement, your client must have the `Query Manage Index` privilege granted on the keyspace.
+For more information about cluster access privileges, see
 {authorization-overview}[].
 
 == Syntax
@@ -251,7 +251,7 @@ If the value of this property is not less than the number of index nodes in the 
 Index metadata provides a state field.
 You can query this state field and other index metadata using {querying-indexes}[system:indexes].
 The index state may be `scheduled for creation`, `deferred`, `building`, `pending`, `online`, `offline`, or `abridged`.
-You can also monitor the index state using the Couchbase Web Console.
+You can also monitor the index state using the Capella UI.
 
 [IMPORTANT]
 ====

--- a/modules/n1ql/pages/n1ql-language-reference/createsequence.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createsequence.adoc
@@ -39,8 +39,8 @@ Similarly, when you restore a bucket, sequences are restored in accordance with 
 == Prerequisites
 
 .RBAC Privileges
-To execute the CREATE SEQUENCE statement, you must have the _Query Manage Sequences_ privilege granted on the scope.
-For more details about user roles, see {authorization-overview}[].
+To execute the CREATE SEQUENCE statement, your client must have the _Query Manage Sequences_ privilege granted on the scope.
+For more details about cluster access privileges, see {authorization-overview}[].
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/createuser.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createuser.adoc
@@ -18,8 +18,7 @@ If you do not specify a group, the user is not assigned to any group by default.
 
 == RBAC Privileges
 
-To execute the CREATE USER statement, you must have either the Full Admin or the Security Admin role.
-For more information about user roles, see xref:learn:security/authorization-overview.adoc[Authorization].
+To execute the CREATE USER statement, you must be an xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] or xref:projects:project-roles.adoc#project-owner-role[`Project Owner`].
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/createvectorindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createvectorindex.adoc
@@ -6,7 +6,7 @@
 :keywords: secondary, index, placement
 :description: The CREATE VECTOR INDEX statement allows you to create Hyperscale Vector indexes.
 
-:authorization-overview: xref:learn:security/authorization-overview.adoc
+:authorization-overview: xref:clusters:manage-database-users.adoc
 :index-replication: xref:indexes:index-replication.adoc#index-replication
 :console-indexes: xref:manage:manage-ui/manage-ui.adoc#console-indexes
 :query-context: xref:n1ql:n1ql-intro/queriesandresults.adoc#query-context

--- a/modules/n1ql/pages/n1ql-language-reference/createvectorindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createvectorindex.adoc
@@ -8,7 +8,7 @@
 
 :authorization-overview: xref:clusters:manage-database-users.adoc
 :index-replication: xref:indexes:index-replication.adoc#index-replication
-:console-indexes: xref:manage:manage-ui/manage-ui.adoc#console-indexes
+:console-indexes: xref:clusters:index-service/manage-indexes.adoc
 :query-context: xref:n1ql:n1ql-intro/queriesandresults.adoc#query-context
 :build-index: xref:n1ql-language-reference/build-index.adoc
 :identifiers: xref:n1ql-language-reference/identifiers.adoc

--- a/modules/n1ql/pages/n1ql-language-reference/delete.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/delete.adoc
@@ -22,9 +22,9 @@ include::partial$n1ql-language-reference/collapsible-style.adoc[]
 
 === RBAC Privileges
 
-To execute the DELETE statement, you must have the _Query Delete_ privilege granted on the target keyspace.
+To execute the DELETE statement, your client must have the _Query Delete_ privilege granted on the target keyspace.
 If the statement has any RETURNING clauses that need data read, then the _Query Select_ privilege is also required on the keyspaces referred in the respective clauses.
-For more details about user roles, see {authorization-overview}[].
+For more details about cluster access privileges, see {authorization-overview}[].
 
 .RBAC Examples
 [%collapsible]

--- a/modules/n1ql/pages/n1ql-language-reference/dropgroup.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropgroup.adoc
@@ -16,8 +16,7 @@ Users in the deleted group no longer inherit the roles granted to it.
 
 == RBAC Privileges
 
-To execute the DROP GROUP statement, you must have etiher the Full Admin or the Security Admin role.
-For more information about user roles, see xref:learn:security/authorization-overview.adoc[Authorization].
+To execute the DROP GROUP statement, you must be an xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] or xref:projects:project-roles.adoc#project-owner-role[`Project Owner`].
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/dropindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropindex.adoc
@@ -31,8 +31,8 @@ For compatibility with legacy versions of Couchbase Server, you can also use DRO
 [discrete]
 ===== RBAC Privileges
 
-To use the {doctitle} statement, you must have the `Query Manage Index` privilege on the keyspace or bucket.
-For more information about user roles, see
+To use the {doctitle} statement, your client must have the `Query Manage Index` privilege on the keyspace or bucket.
+For more information about cluster access privileges, see
 {authorization-overview}[].
 // end::prerequisites[]
 

--- a/modules/n1ql/pages/n1ql-language-reference/dropprimaryindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropprimaryindex.adoc
@@ -21,8 +21,8 @@ NOTE: For compatibility with legacy versions of Couchbase Server, you can also u
 [discrete]
 ===== RBAC Privileges
 
-To execute the DROP PRIMARY INDEX statement, you must have the `Query Manage Index` privilege granted on the keyspace.
-For more information about user roles, see {roles}[].
+To execute the DROP PRIMARY INDEX statement, your client must have the `Query Manage Index` privilege granted on the keyspace.
+For more information about cluster access privileges, see {roles}[].
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/dropsequence.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropsequence.adoc
@@ -22,8 +22,8 @@ include::./sequenceops.adoc[tags=overview]
 == Prerequisites
 
 .RBAC Privileges
-To execute the DROP SEQUENCE statement, you must have the _Query Manage Sequences_ privilege granted on the scope.
-For more details about user roles, see {authorization-overview}[].
+To execute the DROP SEQUENCE statement, your client must have the _Query Manage Sequences_ privilege granted on the scope.
+For more details about cluster access privileges, see {authorization-overview}[].
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/dropuser.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropuser.adoc
@@ -14,8 +14,7 @@ It removes the user from all groups and revokes all roles and privileges assigne
 
 == RBAC Privileges
 
-To execute the DROP USER statement, you must have either the Full Admin or the Security Admin role.
-For more information about user roles, see xref:learn:security/authorization-overview.adoc[Authorization].
+To execute the DROP USER statement, you must be an xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] or xref:projects:project-roles.adoc#project-owner-role[`Project Owner`].
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/dropvectorindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropvectorindex.adoc
@@ -5,7 +5,7 @@
 :page-toclevels: 2
 :imagesdir: ../../assets/images
 
-:authorization-overview: xref:learn:security/authorization-overview.adoc
+:authorization-overview: xref:clusters:manage-database-users.adoc
 :query-context: xref:n1ql:n1ql-intro/queriesandresults.adoc#query-context
 :logical-hierarchy: xref:n1ql-intro/queriesandresults.adoc#logical-hierarchy
 :identifiers: xref:n1ql-language-reference/identifiers.adoc

--- a/modules/n1ql/pages/n1ql-language-reference/explain.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/explain.adoc
@@ -11,8 +11,8 @@ include::partial$n1ql-language-reference/collapsible-style.adoc[]
 
 == Prerequisites
 
-To execute the EXPLAIN statement, you must have the privileges required for the {sqlpp} statement that is being explained.
-For more details about user roles, see
+To execute the EXPLAIN statement, your client must have the privileges required for the {sqlpp} statement that is being explained.
+For more details about cluster access privileges, see
 xref:clusters:manage-database-users.adoc[].
 
 .RBAC Examples
@@ -21,7 +21,7 @@ xref:clusters:manage-database-users.adoc[].
 ======
 include::ROOT:partial$query-context.adoc[tag=example]
 
-To execute the following statement, you must have the _Query Insert_ privilege on the `landmark` keyspace and the _Query Select_ privilege on the `pass:c[`beer-sample`]` keyspace.
+To execute the following statement, your client must have the _Query Insert_ privilege on the `landmark` keyspace and the _Query Select_ privilege on the `pass:c[`beer-sample`]` keyspace.
 
 [source,sqlpp]
 ----
@@ -30,7 +30,7 @@ EXPLAIN INSERT INTO landmark (KEY foo, VALUE bar)
         FROM `beer-sample` AS doc WHERE type = "brewery";
 ----
 
-To execute the following statement, you must have the _Query Insert_, _Query Update_, and _Query Select_ privileges on the `testbucket` keyspace.
+To execute the following statement, your client must have the _Query Insert_, _Query Update_, and _Query Select_ privileges on the `testbucket` keyspace.
 
 [source,sqlpp]
 ----

--- a/modules/n1ql/pages/n1ql-language-reference/from.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/from.adoc
@@ -32,8 +32,8 @@ It specifies the documents to be used as the input for a query.
 
 == Prerequisites
 
-For you to select data from keyspace or expression, you must have the [.param]`query_select` privilege on that keyspace.
-For more details about user roles, see
+To select data from keyspace or expression, your client must have the [.param]`query_select` privilege on that keyspace.
+For more details about cluster access privileges, see
 {authorization-overview}[].
 
 == Syntax

--- a/modules/n1ql/pages/n1ql-language-reference/grant.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/grant.adoc
@@ -28,8 +28,7 @@ Using only the bucket name is not sufficient.
 For example: `pass:c[data_reader ON `travel-sample`.`_default`.`_default`]` +
 or `pass:c[query_select ON `travel-sample`.`inventory`.`airline`]`
 
-NOTE: Only Full Administrators can run the GRANT statement.
-For more details about user roles, see {authorization-overview}[].
+NOTE: To run the GRANT statement, you must be an xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] or xref:projects:project-roles.adoc#project-owner-role[`Project Owner`].
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/hints.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/hints.adoc
@@ -21,8 +21,8 @@ If you do this, the `USE` clause and the hint comment are both marked as erroneo
 
 == Prerequisites
 
-For you to select data from a document or keyspace, you must have the [.param]`query_select` privilege on the document or keyspace.
-For more details about user roles, see
+To select data from a document or keyspace, your client must have the [.param]`query_select` privilege on the document or keyspace.
+For more details about cluster access privileges, see
 xref:clusters:manage-database-users.adoc[].
 
 == Syntax

--- a/modules/n1ql/pages/n1ql-language-reference/index-partitioning.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/index-partitioning.adoc
@@ -21,7 +21,7 @@ Benefits of a partitioned index include:
 * Provides a low-latency range query while allowing indexes to be scaled out as needed.
 --
 ////
-Partitioned indexes are displayed in the Couchbase Web Console with a `partitioned` indicator:
+Partitioned indexes are displayed in the Capella UI with a `partitioned` indicator:
 
 image::manage:manage-indexes/index-indicators.png[]
 ////

--- a/modules/n1ql/pages/n1ql-language-reference/infer.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/infer.adoc
@@ -21,10 +21,10 @@ The Query tab in the Couchbase Capella UI (available under the [.ui]*Data Tools*
 
 == RBAC Privileges
 
-To execute the INFER statement, you must have the _Query Select_ privilege granted on the target keyspace.
-For more details about user roles, see {authorization-overview}[].
+To execute the INFER statement, your client must have the _Query Select_ privilege granted on the target keyspace.
+For more details about cluster access privileges, see {authorization-overview}[].
 
-For example, to execute <<ex-1>> below, you must have the _Query Select_ privilege on the `route` keyspace.
+For example, to execute <<ex-1>> below, your client must have the _Query Select_ privilege on the `route` keyspace.
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/insert.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/insert.adoc
@@ -70,7 +70,7 @@ WARNING: You cannot insert documents into a SASL bucket if you have a read-only 
 
 === RBAC Privileges
 
-To execute the INSERT statement, you must have the _Query Insert_ privilege on the target keyspace.
+To execute the INSERT statement, your client must have the _Query Insert_ privilege on the target keyspace.
 
 If the statement has any SELECT or RETURNING data-read clauses, then the _Query Select_ privilege is also required on the keyspaces referred in the respective clauses.
 For more details about roles and privileges, see {authorization-overview}[].
@@ -81,7 +81,7 @@ For more details about roles and privileges, see {authorization-overview}[].
 ======
 include::ROOT:partial$query-context.adoc[tag=example]
 
-To execute the following statement, you must have the _Query Insert_ privilege on `hotel`.
+To execute the following statement, your client must have the _Query Insert_ privilege on `hotel`.
 
 [source,sqlpp]
 ----
@@ -89,7 +89,7 @@ INSERT INTO hotel (KEY, VALUE)
 VALUES ("key1", { "type" : "hotel", "name" : "new hotel" });
 ----
 
-To execute the following statement, you must have the _Query Insert_ and _Query Select_ privileges on `hotel`.
+To execute the following statement, your client must have the _Query Insert_ and _Query Select_ privileges on `hotel`.
 
 [source,sqlpp]
 ----
@@ -97,7 +97,7 @@ INSERT INTO hotel (KEY, VALUE)
 VALUES ("key1", { "type" : "hotel", "name" : "new hotel" }) RETURNING *;
 ----
 
-To execute the following statement, you must have the _Query Insert_ privilege on `hotel` and _Query Select_ privilege on `pass:c[`beer-sample`]`.
+To execute the following statement, your client must have the _Query Insert_ privilege on `hotel` and _Query Select_ privilege on `pass:c[`beer-sample`]`.
 
 [source,sqlpp]
 ----
@@ -106,7 +106,7 @@ SELECT META(doc).id AS foo, doc AS bar
 FROM `beer-sample` AS doc WHERE type = "brewery";
 ----
 
-To execute the following statement, you must have the _Query Insert_ and _Query Select_ privileges on `hotel`.
+To execute the following statement, your client must have the _Query Insert_ and _Query Select_ privileges on `hotel`.
 
 [source,sqlpp]
 ----

--- a/modules/n1ql/pages/n1ql-language-reference/join.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/join.adoc
@@ -21,8 +21,8 @@ For further details, refer to xref:n1ql-language-reference/comma.adoc[].
 
 == Prerequisites
 
-For you to select data from keyspace or expression, you must have the [.param]`query_select` privilege on that keyspace.
-For more details about user roles, see
+To select data from keyspace or expression, your client must have the [.param]`query_select` privilege on that keyspace.
+For more details about cluster access privileges, see
 xref:clusters:manage-database-users.adoc[].
 
 == Syntax

--- a/modules/n1ql/pages/n1ql-language-reference/let.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/let.adoc
@@ -26,8 +26,8 @@ Each `LET` alias needs to be unique within its scope.
 
 == Prerequisites
 
-The `LET` clause can only be used in a `SELECT` statement, and in order for you to select data from a document or keyspace, you must have the [.param]`query_select` privilege on the document or keyspace.
-For more details about user roles, see
+The `LET` clause can only be used in a `SELECT` statement, and to select data from a document or keyspace, your client must have the [.param]`query_select` privilege on the document or keyspace.
+For more details about cluster access privileges, see
 xref:clusters:manage-database-users.adoc[].
 
 == Syntax

--- a/modules/n1ql/pages/n1ql-language-reference/merge.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/merge.adoc
@@ -49,13 +49,13 @@ Since it is standard compliant and more flexible, we recommend you to use ANSI m
 
 == Privileges
 
-User executing the MERGE statement must have the following privileges:
+The client executing the MERGE statement must have the following privileges:
 
 * _Query Select_ privileges on the source keyspace
 * _Query Insert_, _Query Update_, or _Query Delete_ privileges on the target keyspace as per the MERGE actions
 * _Query Select_ privileges on the keyspaces referred in the RETURNING clause
 
-For more details about user roles, refer to
+For more details about cluster access privileges, refer to
 {authorization-overview}[].
 
 [NOTE]

--- a/modules/n1ql/pages/n1ql-language-reference/nest.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/nest.adoc
@@ -17,8 +17,8 @@ It enables you to create an input object by producing a single result of nesting
 
 == Prerequisites
 
-For you to select data from keyspace or expression, you must have the [.param]`query_select` privilege on that keyspace.
-For more details about user roles, see
+To select data from keyspace or expression, your client must have the [.param]`query_select` privilege on that keyspace.
+For more details about cluster access privileges, see
 xref:clusters:manage-database-users.adoc[].
 
 == Syntax

--- a/modules/n1ql/pages/n1ql-language-reference/orderby.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/orderby.adoc
@@ -14,8 +14,8 @@ In a SELECT statement, the ORDER BY clause sorts the result-set in ascending or 
 [#section_Prerequisites]
 == Prerequisites
 
-For you to select data from a document or keyspace, you must have the [.param]`query_select` privilege on the document or keyspace.
-For more details about user roles, see
+To select data from a document or keyspace, your client must have the [.param]`query_select` privilege on the document or keyspace.
+For more details about cluster access privileges, see
 xref:clusters:manage-database-users.adoc[].
 
 [#section_Syntax]

--- a/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
@@ -22,8 +22,8 @@ If you know that a statement text will be executed repeatedly, you can request t
 [[authorization]]
 === RBAC Privileges
 
-The user executing the PREPARE statement must have the RBAC privileges of the statement being prepared.
-For more details about user roles, refer to xref:clusters:manage-database-users.adoc[].
+The client executing the PREPARE statement must have the RBAC privileges of the statement being prepared.
+For more details about cluster access privileges, refer to xref:clusters:manage-database-users.adoc[].
 
 .RBAC Examples
 [%collapsible]

--- a/modules/n1ql/pages/n1ql-language-reference/revoke.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/revoke.adoc
@@ -28,8 +28,7 @@ Using only the bucket name is not sufficient.
 For example: `pass:c[data_reader ON `travel-sample`.`_default`.`_default`]` +
 or `pass:c[query_select ON `travel-sample`.`inventory`.`airline`]`
 
-NOTE: Only Full Administrators can run the REVOKE statement.
-For more details about user roles, see {authorization-overview}[].
+NOTE: To run the REVOKE statement, you must be an xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] or xref:projects:project-roles.adoc#project-owner-role[`Project Owner`].
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/selectclause.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/selectclause.adoc
@@ -17,8 +17,8 @@ In a `SELECT` statement, the `SELECT` clause determines the projection (result s
 [#section_Prerequisites]
 == Prerequisites
 
-For you to select data from a document or keyspace, you must have the [.param]`query_select` privilege on the document or keyspace.
-For more details about user roles, see
+To select data from a document or keyspace, your client must have the [.param]`query_select` privilege on the document or keyspace.
+For more details about cluster access privileges, see
 xref:clusters:manage-database-users.adoc[].
 
 [#section_Syntax]

--- a/modules/n1ql/pages/n1ql-language-reference/selectintro.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/selectintro.adoc
@@ -31,9 +31,9 @@ include::ROOT:partial$query-context.adoc[tag=statement]
 
 == Prerequisites
 
-The user executing the SELECT statement must have {query-select}[read] access to all keyspaces referred in the query.
+The client executing the SELECT statement must have {query-select}[read] access to all keyspaces referred in the query.
 Note that the SELECT statement may refer to one keyspace, multiple keyspaces, or no keyspaces at all.
-For more details about user roles, see xref:clusters:manage-database-users.adoc[].
+For more details about cluster access privileges, see xref:clusters:manage-database-users.adoc[].
 
 .RBAC Examples
 [%collapsible]

--- a/modules/n1ql/pages/n1ql-language-reference/sequenceops.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/sequenceops.adoc
@@ -63,8 +63,8 @@ The next value operator increments a given sequence and returns the next value.
 === Prerequisites
 
 .RBAC Privileges
-To use this operator, you must have the _Query Use Sequences_ privilege granted on the scope.
-For more details about user roles, see {authorization-overview}[].
+To use this operator, your client must have the _Query Use Sequences_ privilege granted on the scope.
+For more details about cluster access privileges, see {authorization-overview}[].
 
 === Syntax
 
@@ -287,8 +287,8 @@ This is useful when you need to refer to the same value again without generating
 === Prerequisites
 
 .RBAC Privileges
-To use this operator, you must have the _Query Use Sequences_ privilege granted on the scope.
-For more details about user roles, see {authorization-overview}[Authorization].
+To use this operator, your client must have the _Query Use Sequences_ privilege granted on the scope.
+For more details about cluster access privileges, see {authorization-overview}[Authorization].
 
 === Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/update.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/update.adoc
@@ -31,9 +31,9 @@ Refer to xref:clusters:data-service/import-data-documents.adoc#import-sample-dat
 
 === RBAC Privileges
 
-User executing the UPDATE statement must have the _Query Update_ privilege on the target keyspace.
+The client executing the UPDATE statement must have the _Query Update_ privilege on the target keyspace.
 If the statement has any clauses that needs data read, such as SELECT clause, or RETURNING clause, then _Query Select_ privilege is also required on the keyspaces referred in the respective clauses.
-For more details about user roles, see {authorization-overview}[].
+For more details about cluster access privileges, see {authorization-overview}[].
 
 [NOTE]
 A user with the _Data Writer_ privilege may set documents to expire.
@@ -45,21 +45,21 @@ When the document expires, the data service deletes the document, even though th
 ======
 include::ROOT:partial$query-context.adoc[tag=example]
 
-To execute the following statement, you must have the _Query Update_ privilege on `airport`.
+To execute the following statement, your client must have the _Query Update_ privilege on `airport`.
 
 [source,sqlpp]
 ----
 include::example$dml/update-rbac.n1ql[]
 ----
 
-To execute the following statement, you must have the _Query Update_ privilege on `airport` and _Query Select_ privilege on `pass:c[`beer-sample`]`.
+To execute the following statement, your client must have the _Query Update_ privilege on `airport` and _Query Select_ privilege on `pass:c[`beer-sample`]`.
 
 [source,sqlpp]
 ----
 include::example$dml/update-rbac-sub.n1ql[]
 ----
 
-To execute the following statement, you must have the _Query Update_ and _Query Select_ privileges on `airport`.
+To execute the following statement, your client must have the _Query Update_ and _Query Select_ privileges on `airport`.
 
 [source,sqlpp]
 ----

--- a/modules/n1ql/pages/n1ql-language-reference/upsert.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/upsert.adoc
@@ -38,9 +38,9 @@ Refer to xref:clusters:data-service/import-data-documents.adoc#import-sample-dat
 
 === RBAC Privileges
 
-User executing the UPSERT statement must have the _Query Update_ and _Query Insert_ privileges on the target keyspace.
+The client executing the UPSERT statement must have the _Query Update_ and _Query Insert_ privileges on the target keyspace.
 If the statement has any RETURNING clauses, then the _Query Select_ privilege is also required on the keyspaces referred in the respective clauses.
-For more details about user roles, see
+For more details about cluster access privileges, see
 {authorization-overview}[].
 
 [NOTE]
@@ -53,14 +53,14 @@ When the document expires, the data service deletes the document, even though th
 ======
 include::ROOT:partial$query-context.adoc[tag=example]
 
-To execute the following statement, you must have the _Query Update_ and _Query Insert_ privileges on `hotel`.
+To execute the following statement, your client must have the _Query Update_ and _Query Insert_ privileges on `hotel`.
 
 [source,sqlpp]
 ----
 include::example$dml/upsert-rbac.n1ql[]
 ----
 
-To execute the following statement, you must have the _Query Update_ and _Query Insert_ privileges on `hotel` and the _Query Select_ privilege on `hotel` also (for RETURNING clause).
+To execute the following statement, your client must have the _Query Update_ and _Query Insert_ privileges on `hotel` and the _Query Select_ privilege on `hotel` also (for RETURNING clause).
 
 [source,sqlpp]
 ----
@@ -73,7 +73,7 @@ include::example$dml/upsert-rbac-return.n1ql[]
 include::example$dml/upsert-rbac-return.jsonc[]
 ----
 
-To execute the following statement, you must have the _Query Update_ and _Query Insert_ privileges on `landmark` and _Query Select_ privilege on `pass:c[`beer-sample`]`.
+To execute the following statement, your client must have the _Query Update_ and _Query Insert_ privileges on `landmark` and _Query Select_ privilege on `pass:c[`beer-sample`]`.
 
 [source,sqlpp]
 ----

--- a/modules/n1ql/pages/n1ql-language-reference/with.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/with.adoc
@@ -22,8 +22,8 @@ A CTE that you create in one WITH clause may be referenced in a later WITH claus
 
 == Prerequisites
 
-The WITH clause can only be used preceding a SELECT statement, and in order for you to select data from a document or keyspace, you must have the [.param]`query_select` privilege on the document or keyspace.
-For more details about user roles, see
+The WITH clause can only be used preceding a SELECT statement, and to select data from a document or keyspace, your client must have the [.param]`query_select` privilege on the document or keyspace.
+For more details about cluster access privileges, see
 xref:clusters:manage-database-users.adoc[].
 
 == Syntax

--- a/modules/n1ql/partials/n1ql-language-reference/select-privilege.adoc
+++ b/modules/n1ql/partials/n1ql-language-reference/select-privilege.adoc
@@ -1,6 +1,6 @@
 == Prerequisites
 
-For you to select data from keyspace or expression, you must have the [.param]`query_select` privilege on that keyspace.
-For more details about user roles, see
+To select data from keyspace or expression, your client must have the [.param]`query_select` privilege on that keyspace.
+For more details about cluster access privileges, see
 xref:clusters:manage-database-users.adoc[].
 

--- a/modules/vector-index/pages/composite-vector-index.adoc
+++ b/modules/vector-index/pages/composite-vector-index.adoc
@@ -52,8 +52,6 @@ See xref:vector-index:vectors-and-indexes-overview.adoc#vector_similarity[Vector
 
 include::vector-search:partial$download-sample-partial.adoc[]
 
-include::vector-search:partial$download-sample-partial.adoc[]
-
 In addition, to get the best results with the examples on this page, download the following sample dataset:
 
 https://cbc-remote-execution-examples-prod.s3.amazonaws.com/color_data_2vectors.zip[Download color_data_2vectors.zip]

--- a/modules/vector-index/pages/composite-vector-index.adoc
+++ b/modules/vector-index/pages/composite-vector-index.adoc
@@ -29,7 +29,7 @@ For more information about how to deploy a new node and Services on your databas
 * You must have a bucket with scopes and collections in your database.
 For more information about how to create a bucket, see xref:clusters:data-service/manage-buckets.adoc[].
 
-* Your account must have the xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`], xref:projects:project-roles.adoc#project-owner-role[`Project Owner`], or xref:projects:project-roles.adoc#project-cluster-data-reader-writer[`Data Writer`] to be able to create an index.
+* Your account must have the xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`], xref:projects:project-roles.adoc#project-owner-role[`Project Owner`], or xref:projects:project-roles.adoc#project-cluster-data-reader-writer[`Data Writer`] role to be able to create an index.
 
 * You have documents in a collection that contain one or more vector embeddings.
 You can add a single vector to a Composite Vector index.

--- a/modules/vector-index/pages/hyperscale-vector-index.adoc
+++ b/modules/vector-index/pages/hyperscale-vector-index.adoc
@@ -32,7 +32,7 @@ Hyperscale Vector Indexes have the following requirements:
 * You must have the Index Service enabled on at least one node in your cluster.
 For more information about how to deploy a new node and Services on your database, see xref:clusters:modify-database.adoc#modify-existing-service[Modify the Cluster Configuration].
 
-* Your account must have the xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`], xref:projects:project-roles.adoc#project-owner-role[`Project Owner`], or xref:projects:project-roles.adoc#project-cluster-data-reader-writer[`Data Writer`] to be able to create an index.
+* Your account must have the xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`], xref:projects:project-roles.adoc#project-owner-role[`Project Owner`], or xref:projects:project-roles.adoc#project-cluster-data-reader-writer[`Data Writer`] role to be able to create an index.
 
 * You must have a bucket your database.
 For more information about how to create a bucket, see xref:clusters:data-service/manage-buckets.adoc[].


### PR DESCRIPTION
Fixes a few issues I noted when verifying Server 8.0 on Capella.

- Broken links to the cluster access privileges page
- Broken links to the Index tab in the Capella UI page
- Couchbase Web Console → Capella UI
- Fix typos and duplicated partials
- Fix roles for user and group statements
- Clarify that for most statements the "user roles" refers to cluster access privileges for the client 

The last two probably need further investigation and clarification. They'll be less wrong now than they were.