### PR TITLE
Fixing several typos

### DIFF
--- a/modules/vector-index/pages/vectors-and-indexes-overview.adoc
+++ b/modules/vector-index/pages/vectors-and-indexes-overview.adoc
@@ -26,7 +26,7 @@ Vectors for dissimilar data (articles discussing two different topics for exampl
 By comparing two vectors, you can find the similarity between the two pieces of data they represent.
 This similarity goes beyond just finding parts of the data that are identical (for example, finding similar words in two pieces of text).
 The vectors represent features such as the meaning of text rather than just superficial similarities.
-When two pieces of data have similar vectors, they are semantically related (having similar meanings or subjects).
+When two pieces of data have similar vectors, they're semantically related (having similar meanings or subjects).
 
 For example, suppose you have three text articles.
 The first is about feral cats, the second about domestic cats, and the third is about the UNIX/Linux `cat` command.
@@ -245,7 +245,7 @@ An IVF index trains itself during creation using a set of parameters you pass to
 . For each cluster it finds, it chooses a representative vector (called a centroid).
 . It creates a data structure called an inverted list that associates all vectors with their closest centroid.
 
-image::ivf-diagram-with-vectors.svg["A plot showing clusters of points in a 3D graph labelled and assigned to centroid vectors. The centroids then point to multiple vectors in an inverted list."]
+image::ivf-diagram-with-vectors.svg["A plot showing clusters of points in a 3D graph labeled and assigned to centroid vectors. The centroids then point to multiple vectors in an inverted list."]
 
 When you search using an IVF index, it first locates the centroids that are most relevant to the vector value you're searching for.
 It then searches just the vectors associated with those centroids in the inverted list.
@@ -319,14 +319,14 @@ Use PQ quantization when:
 * Your dataset is large (millions to billions of vectors).
 
 
-Hyoerscale Vector and Composite Vector indexes support PQ quantization.
+Hyperscale Vector and Composite Vector indexes support PQ quantization.
 Search Vector Indexes do not support it.
 
 [#sq]
 === Scalar Quantization (SQ)
 Scalar Quantization is a simpler form of quantization than PQ.
 Instead of breaking the vector into subspaces, it quantizes each dimension of the vector independently.
-Its quantized vectors are larger, but are a more precise represenation than than those quantized using PQ.
+Its quantized vectors are larger, but are a more precise representation than those quantized using PQ.
 
 
 SQ follows these steps to process vectors:


### PR DESCRIPTION
Fixes several typos in the Use Vector Indexes for AI Applications topic (appears in both Server and Capella documentation).

Preview is here: https://preview.docs-test.couchbase.com/docs-devex-DOC-13675_typo_fix/server/current/vector-index/vectors-and-indexes-overview.html#pq

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.