### PR TITLE
[DOC-13677] Remove incorrect lines from GRANT and REVOKE statements

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/grant.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/grant.adoc
@@ -21,11 +21,7 @@ parameterized by a keyspace::
 Roles which are defined for the context of the specified keyspace only.
 Specify the keyspace name after the keyword ON.
 +
-The keyspace must be fully qualified and must include the bucket, scope, and collection names.
-Even if you're granting a role to an entire bucket, you must specify the default scope (`_default`) and default collection (`_default`).
-Using only the bucket name is not sufficient.
-+
-For example: `pass:c[data_reader ON `travel-sample`.`_default`.`_default`]` +
+For example: `pass:c[data_reader ON `travel-sample`]` +
 or `pass:c[query_select ON `travel-sample`.`inventory`.`airline`]`
 
 NOTE: Only Full Administrators can run the GRANT statement.
@@ -120,7 +116,7 @@ GRANT replication_admin, query_external_access
 [source,sqlpp]
 ----
 GRANT query_select, views_admin
-   ON `retail`.`customers`.`orders`
+   ON orders, customers
    TO bill, linda;
 ----
 
@@ -136,18 +132,18 @@ GRANT cluster_admin TO david, michael, robin;
 ----
 ====
 
-.Grant Query Select and Data Reader roles on a keyspace to a specific user
+.Grant Query Select and Data Reader roles on the `travel-sample` keyspace to a specific user
 ====
 [source,sqlpp]
 ----
-GRANT query_select, data_reader ON `travel-sample`.`_default`.`_default` TO debby;
+GRANT query_select, data_reader ON `travel-sample` TO debby;
 ----
 ====
 
-.Grant the role of Data Reader on a keyspace to a specific group
+.Grant the role of Data Reader on the `travel-sample` keyspace to a specific group
 ====
 [source,sqlpp]
 ----
-GRANT data_reader ON `travel-sample`.`inventory`.`hotel` TO GROUP sales;
+GRANT data_reader ON `travel-sample` TO GROUP sales;
 ----
 ====

--- a/modules/n1ql/pages/n1ql-language-reference/revoke.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/revoke.adoc
@@ -21,11 +21,7 @@ parameterized by a keyspace::
 Roles which are defined for the context of the specified keyspace only.
 Specify the keyspace name after the keyword ON.
 +
-The keyspace must be fully qualified and must include the bucket, scope, and collection names. 
-Even if you're revoking a role from an entire bucket, you must specify the default scope (`_default`) and default collection (`_default`).
-Using only the bucket name is not sufficient.
-+
-For example: `pass:c[data_reader ON `travel-sample`.`_default`.`_default`]` +
+For example: `pass:c[data_reader ON `travel-sample`]` +
 or `pass:c[query_select ON `travel-sample`.`inventory`.`airline`]`
 
 NOTE: Only Full Administrators can run the REVOKE statement.
@@ -115,22 +111,22 @@ REVOKE cluster_admin FROM david, michael, robin
 ----
 ====
 
-.Revoke Query Select and Query Update roles on a keyspace from a specific user
+.Revoke Query Select and Data Reader roles on the `travel-sample` keyspace from a specific user
 ====
 [source,sqlpp]
 ----
-REVOKE query_select, query_update
-  ON `travel-sample`.`_default`.`_default`
+REVOKE query_select, data_reader
+  ON `travel-sample`
   FROM debby
 ----
 ====
 
-.Revoke the Query Update role on a keyspace from a specific group
+.Revoke the Data Reader role on the `travel-sample` keyspace from a specific group
 ====
 [source,sqlpp]
 ----
 REVOKE query_update
-  ON `travel-sample`.`inventory`.`hotel`
+  ON `travel-sample`
   FROM GROUP sales
 ----
 ====


### PR DESCRIPTION
Jira: DOC-13677

Removed misleading text (added in 8.0) from GRANT and REVOKE statements, and aligned roles across examples for consistency. 

Doc previews:

- [GRANT](https://preview.docs-test.couchbase.com/docs-devex-DOC-13677-fix-grant-revoke/server/current/n1ql/n1ql-language-reference/grant.html)
- [REVOKE](https://preview.docs-test.couchbase.com/docs-devex-DOC-13677-fix-grant-revoke/server/current/n1ql/n1ql-language-reference/revoke.html)
