### PR TITLE
DOC-13239: queryN1QLFeatCtrl misspelled

### DIFF
--- a/modules/indexes/pages/query-without-index.adoc
+++ b/modules/indexes/pages/query-without-index.adoc
@@ -317,7 +317,7 @@ You can get or set the N1QL Feature Controller setting in any of the following w
 |REST API
 |Cluster-level
 |xref:n1ql-rest-settings:index.adoc[]
-|`queryN1qlFeatCtrl`
+|`queryN1QLFeatCtrl`
 
 |REST API
 |Node-level

--- a/modules/indexes/pages/query-without-index.adoc
+++ b/modules/indexes/pages/query-without-index.adoc
@@ -17,12 +17,12 @@ For instructions on how to install the sample bucket, see {install-sample-bucket
 
 == Sequential Scans
 
-If a keyspace does not have any suitable primary or secondary indexes for a query, the Query service can fall back on a sequential scan of the data to retrieve the document keys.
+If a keyspace does not have any suitable primary or secondary indexes for a query, the Query Service can fall back on a sequential scan of the data to retrieve the document keys.
 A sequential scan uses an underlying mechanism known as a K/V range scan.
 
-Sequential scans are intended for simple, ready access to data, and are not intended as a high performance solution.
+Sequential scans are intended for easy access to data, and are not intended as a high performance solution.
 
-Sequential scans are best suited to small collections where key order is unimportant, or where the overhead of maintaining an index can't be justified.
+Sequential scans are best suited to small collections where key order is unimportant, or where the overhead of maintaining an index cannot be justified.
 For larger collections and greater performance, define the appropriate indexes to speed up your queries.
 For ordered document key operations, a primary index provides the same functionality, and will outperform a sequential scan.
 
@@ -32,7 +32,7 @@ NOTE: Sequential scans are unavailable on ephemeral buckets.
 
 To query an index using sequential scan, run the query as usual.
 
-If there is a primary index or any suitable secondary index available for the keyspace, the Query service uses that in preference to sequential scan.
+If there is a primary index or any suitable secondary index available for the keyspace, the Query Service uses that in preference to sequential scan.
 
 === Prerequisites
 
@@ -40,7 +40,7 @@ If there is a primary index or any suitable secondary index available for the ke
 ===== RBAC Privileges
 
 Users must have the *Query Use Sequential Scans* role on the keyspace to be able to execute a request with a sequential scan.
-For more details about user roles, see
+For more information about user roles, see
 {authorization-overview}[].
 
 === Examples
@@ -204,7 +204,7 @@ In most cases, this indicates that you should create an index to support the req
 
 Statistics on sequential scan usage are also available in request profiling information.
 
-For more details, see xref:n1ql:n1ql-manage/monitoring-n1ql-query.adoc[].
+For more information, see xref:n1ql:n1ql-manage/monitoring-n1ql-query.adoc[].
 
 === Examples
 
@@ -341,7 +341,7 @@ To switch on sequential scans globally:
 
 . Set N1QL Feature Controller to the resulting value.
 
-Note that the xref:n1ql:n1ql-language-reference/infer.adoc[INFER] command also uses K/V range scan, the mechanism that underlies sequential scan.
+The xref:n1ql:n1ql-language-reference/infer.adoc[INFER] command also uses K/V range scan, the mechanism that underlies sequential scan.
 If you turn off sequential scan globally, then INFER can no longer use sequential scan either.
 
 === Examples

--- a/modules/n1ql/pages/n1ql-manage/query-settings.adoc
+++ b/modules/n1ql/pages/n1ql-manage/query-settings.adoc
@@ -215,10 +215,10 @@ a| [%hardbreaks]
 <<queryCompletedMaxPlanSize,queryCompletedMaxPlanSize>>
 <<queryCompletedThreshold,queryCompletedThreshold>>
 <<queryLogLevel,queryLogLevel>>
+<<queryN1QLFeatCtrl,queryN1QLFeatCtrl>>
 <<queryNodeQuota,queryNodeQuota>>
 <<queryNodeQuotaValPercent,queryNodeQuotaValPercent>>
 <<queryNumCpus,queryNumCpus>>
-<<queryN1QLFeatCtrl,queryN1QLFeatCtrl>>
 <<queryPreparedLimit,queryPreparedLimit>>
 
 a| [%hardbreaks]
@@ -229,10 +229,10 @@ a| [%hardbreaks]
 <<completed-max-plan-size,completed-max-plan-size>>
 <<completed-threshold,completed-threshold>>
 <<loglevel,loglevel>>
+<<n1ql-feat-ctrl,n1ql-feat-ctrl>>
 <<node-quota,node-quota>>
 <<node-quota-val-percent,node-quota-val-percent>>
 <<num-cpus,num-cpus>>
-<<n1ql-feat-ctrl,n1ql-feat-ctrl>>
 <<prepared-limit,prepared-limit>>
 
 a| N/A

--- a/modules/n1ql/pages/n1ql-manage/query-settings.adoc
+++ b/modules/n1ql/pages/n1ql-manage/query-settings.adoc
@@ -218,7 +218,7 @@ a| [%hardbreaks]
 <<queryNodeQuota,queryNodeQuota>>
 <<queryNodeQuotaValPercent,queryNodeQuotaValPercent>>
 <<queryNumCpus,queryNumCpus>>
-<<queryN1qlFeatCtrl,queryN1qlFeatCtrl>>
+<<queryN1QLFeatCtrl,queryN1QLFeatCtrl>>
 <<queryPreparedLimit,queryPreparedLimit>>
 
 a| [%hardbreaks]


### PR DESCRIPTION
Jira issue: DOC-13239

This PR fixes `queryN1qlFeatCtrl` → `queryN1QLFeatCtrl` in the DevEx docs.
Follows https://github.com/couchbaselabs/cb-swagger/pull/175, which fixed the error in the REST API docs. 

Documentation preview:
- [Configure Queries](https://preview.docs-test.couchbase.com/docs-devex-DOC-13239-n1ql-feat-ctrl/server/current/n1ql/n1ql-manage/query-settings.html)
- [Query without Indexes](https://preview.docs-test.couchbase.com/docs-devex-DOC-13239-n1ql-feat-ctrl/server/current/indexes/query-without-index.html)
- [Query Settings REST API](https://preview.docs-test.couchbase.com/docs-devex-DOC-13239-n1ql-feat-ctrl/server/current/n1ql-rest-settings/index.html#queryN1QLFeatCtrl)

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.

Tested locally to make sure all instances were caught:

```
# Query: queryN1qlFeatCtrl
# Flags: CaseSensitive
# Including: ./docs-site/preview
# ContextLines: 1

No Results
```

This needs to be backported as far as 7.0, although it's probably not worth updating the REST API docs prior to 7.6, as the swagger2markup toolchain no longer works.
