### PR TITLE
[AV-115725]Add AI Functions Error Condition

### DIFF
--- a/modules/n1ql/partials/errors/finderr.json
+++ b/modules/n1ql/partials/errors/finderr.json
@@ -978,7 +978,8 @@
       "description": "Indicates a syntax error occurred during statement parsing.",
       "user_action": [
         "Correct the syntax and re-submit the request.  Look for incorrectly spelled keywords, use of reserved words as identifiers, incorrect or omitted punctuation and delimiters or invalid grammar.",
-        "If using the cbq-shell, the \\syntax command may help with grammar issues."
+        "If using the cbq-shell, the \\syntax command may help with grammar issues.",
+        "If using AI Functions, make sure the function you're using is enabled and associated with an LLM."
       ]
     },
     {


### PR DESCRIPTION
Need to add an error: 

```
[
  {
    "code": 3000,
    "column": 16,
    "line": 4,
    "msg": "Invalid function ai_sentiment (resolving to default:ai_sentiment) (near line 4, column 16)"
  }
]
```