### PR TITLE
[DOC-10270]: Explain that Couchbase Services automatically keep themselves up-to-date with the data service

### DIFF
--- a/modules/search/pages/search.adoc
+++ b/modules/search/pages/search.adoc
@@ -34,8 +34,13 @@ The Search Service has default components that you can use to customize a Search
 
 You need to create a Search index before you can use the Search Service to search the contents of your cluster from your application. 
 
-For more information about how to create a Search index, see xref:create-search-indexes.adoc[].  
+For more information about how to create a Search index, see xref:create-search-indexes.adoc[].
 
+[NOTE]
+.Updating the indexes
+====
+Search indexes are updated automatically, reflecting changes to the Data Service.
+====
 You can create a Search index: 
 
 * xref:create-search-index-ui.adoc[With the Couchbase {page-ui-name}]

--- a/modules/search/pages/search.adoc
+++ b/modules/search/pages/search.adoc
@@ -37,9 +37,9 @@ You need to create a Search index before you can use the Search Service to searc
 For more information about how to create a Search index, see xref:create-search-indexes.adoc[].
 
 [NOTE]
-.Updating the indexes
+.Updating Search indexes
 ====
-Search indexes are updated automatically, reflecting changes to the Data Service.
+Search indexes are updated automatically, reflecting changes from the Data Service.
 ====
 You can create a Search index: 
 


### PR DESCRIPTION


This pull request updates the documentation to include a clarification that Couchbase Services automatically keep their indexes synchronized with the data service.

### Changes
- Added a note explaining automatic index updates in the relevant documentation section.

### Checklist
- [ ] Unit tests added/updated
- [x] Documentation updated
- [ ] All checks pass

