### PR TITLE
[DOC-13661] Update RBAC for SQL++ (Capella)

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/advise.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/advise.adoc
@@ -66,8 +66,8 @@ Similarly, if the query is already using the optimal covering index, the index a
 
 == Prerequisites
 
-To execute the ADVISE statement, your client must have the privileges required for the {sqlpp} statement for which you want advice.
-For more details about cluster access privileges, see xref:clusters:cluster-rbac.adoc[].
+To execute this statement, your client must have the privileges required for the {sqlpp} statement for which you want advice.
+For more information about cluster access privileges, see xref:clusters:cluster-rbac.adoc[].
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/advise.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/advise.adoc
@@ -66,7 +66,7 @@ Similarly, if the query is already using the optimal covering index, the index a
 
 == Prerequisites
 
-To execute this statement, your client must have the privileges required for the {sqlpp} statement for which you want advice.
+To execute this statement, your client must have necessary privileges for the {sqlpp} statement for which you want advice.
 For more information about cluster access privileges, see xref:clusters:cluster-rbac.adoc[].
 
 == Syntax

--- a/modules/n1ql/pages/n1ql-language-reference/advise.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/advise.adoc
@@ -67,7 +67,7 @@ Similarly, if the query is already using the optimal covering index, the index a
 == Prerequisites
 
 To execute the ADVISE statement, your client must have the privileges required for the {sqlpp} statement for which you want advice.
-For more details about cluster access privileges, see xref:clusters:manage-database-users.adoc[].
+For more details about cluster access privileges, see xref:clusters:cluster-rbac.adoc[].
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/alterbucket.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/alterbucket.adoc
@@ -24,11 +24,13 @@ For more information, see the <<alterbucket-syntax,Syntax>> section.
 
 == Prerequisites
 
-To execute the ALTER BUCKET statement, you must have at least one of the following roles:
+To execute the ALTER BUCKET statement in the Capella UI, you must have at least one of the following roles:
 
 * xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
 * xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]
 * xref:projects:project-roles.adoc#project-cluster-data-reader-writer[`Data Writer`]
+
+You cannot execute this statement using cluster access credentials. 
 
 [[alterbucket-syntax]]
 == Syntax

--- a/modules/n1ql/pages/n1ql-language-reference/alterbucket.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/alterbucket.adoc
@@ -17,20 +17,18 @@
 
 == Purpose
 
-Use the ALTER BUCKET statement to modify the configuration of a bucket in your Couchbase cluster. 
+Use the `ALTER BUCKET` statement to modify the configuration of a bucket in your Couchbase cluster. 
 You can update only a limited set of bucket settings.
 You cannot change its core properties such as the bucket name and type. 
 For more information, see the <<alterbucket-syntax,Syntax>> section.
 
-== RBAC Privileges
+== Prerequisites
 
-Only administrators with the following roles can execute the ALTER BUCKET statement:
+To execute the `ALTER BUCKET` statement, you must have at least one of the following roles:
 
-* Full Admin
-* Cluster Admin
-* Bucket Admin (if privileges are extended to the specific bucket or all buckets on the cluster)
-
-For more information about roles and privileges, see {roles}[Roles].
+* xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
+* xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]
+* xref:projects:project-roles.adoc#project-cluster-data-reader-writer[`Data Writer`]
 
 [[alterbucket-syntax]]
 == Syntax

--- a/modules/n1ql/pages/n1ql-language-reference/alterbucket.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/alterbucket.adoc
@@ -24,7 +24,7 @@ For more information, see the <<alterbucket-syntax,Syntax>> section.
 
 == Prerequisites
 
-To execute this statement in the Capella UI, you must have 1 of the following roles:
+To execute this statement in the Capella UI, you must have one of the following roles:
 
 * xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
 * xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]

--- a/modules/n1ql/pages/n1ql-language-reference/alterbucket.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/alterbucket.adoc
@@ -24,13 +24,13 @@ For more information, see the <<alterbucket-syntax,Syntax>> section.
 
 == Prerequisites
 
-To execute the ALTER BUCKET statement in the Capella UI, you must have at least 1 of the following roles:
+To execute this statement in the Capella UI, you must have 1 of the following roles:
 
 * xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
 * xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]
 * xref:projects:project-roles.adoc#project-cluster-data-reader-writer[`Data Writer`]
 
-You cannot execute this statement using cluster access credentials. 
+NOTE: You cannot execute this statement using xref:clusters:cluster-rbac.adoc[cluster access credentials]. 
 
 [[alterbucket-syntax]]
 == Syntax

--- a/modules/n1ql/pages/n1ql-language-reference/alterbucket.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/alterbucket.adoc
@@ -24,7 +24,7 @@ For more information, see the <<alterbucket-syntax,Syntax>> section.
 
 == Prerequisites
 
-To execute the ALTER BUCKET statement in the Capella UI, you must have at least one of the following roles:
+To execute the ALTER BUCKET statement in the Capella UI, you must have at least 1 of the following roles:
 
 * xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
 * xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]

--- a/modules/n1ql/pages/n1ql-language-reference/alterbucket.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/alterbucket.adoc
@@ -17,14 +17,14 @@
 
 == Purpose
 
-Use the `ALTER BUCKET` statement to modify the configuration of a bucket in your Couchbase cluster. 
+Use the ALTER BUCKET statement to modify the configuration of a bucket in your Couchbase cluster. 
 You can update only a limited set of bucket settings.
 You cannot change its core properties such as the bucket name and type. 
 For more information, see the <<alterbucket-syntax,Syntax>> section.
 
 == Prerequisites
 
-To execute the `ALTER BUCKET` statement, you must have at least one of the following roles:
+To execute the ALTER BUCKET statement, you must have at least one of the following roles:
 
 * xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
 * xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]

--- a/modules/n1ql/pages/n1ql-language-reference/altergroup.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/altergroup.adoc
@@ -12,18 +12,22 @@
 
 == Purpose
 
-Use the ALTER GROUP statement to modify an existing group within the Couchbase Server Role-Based Access Control (RBAC) system.
+Use the `ALTER GROUP` statement to modify an existing group within the Couchbase Server Role-Based Access Control (RBAC) system.
 You can update the group's description and its roles.
 You can either add new roles or remove all the existing ones.
 When you update a role for a group, all users in the group inherit the updated permissions automatically.
 
-CAUTION: When you add new roles to a group, the ALTER GROUP statement replaces the group's existing role assignments with the new ones you provide.
+CAUTION: When you add new roles to a group, the `ALTER GROUP` statement replaces the group's existing role assignments with the new ones you provide.
 It updates the entire role list, so any existing roles not included in the new list will be removed.
 If you want to add or remove specific roles without affecting the others, use the xref:n1ql:n1ql-language-reference/grant.adoc[GRANT] and xref:n1ql:n1ql-language-reference/revoke.adoc[REVOKE] statements instead.
 
-== RBAC Privileges
+== Prerequisites
 
-To execute the ALTER GROUP statement, you must be an xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] or xref:projects:project-roles.adoc#project-owner-role[`Project Owner`].
+To execute the `ALTER GROUP` statement, you must have at least one of the following roles:
+
+* xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
+* xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]
+* xref:projects:project-roles.adoc#project-cluster-data-reader-writer[`Data Writer`]
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/altergroup.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/altergroup.adoc
@@ -12,18 +12,18 @@
 
 == Purpose
 
-Use the `ALTER GROUP` statement to modify an existing group within the Couchbase Server Role-Based Access Control (RBAC) system.
+Use the ALTER GROUP statement to modify an existing group within the Couchbase Server Role-Based Access Control (RBAC) system.
 You can update the group's description and its roles.
 You can either add new roles or remove all the existing ones.
 When you update a role for a group, all users in the group inherit the updated permissions automatically.
 
-CAUTION: When you add new roles to a group, the `ALTER GROUP` statement replaces the group's existing role assignments with the new ones you provide.
+CAUTION: When you add new roles to a group, the ALTER GROUP statement replaces the group's existing role assignments with the new ones you provide.
 It updates the entire role list, so any existing roles not included in the new list will be removed.
 If you want to add or remove specific roles without affecting the others, use the xref:n1ql:n1ql-language-reference/grant.adoc[GRANT] and xref:n1ql:n1ql-language-reference/revoke.adoc[REVOKE] statements instead.
 
 == Prerequisites
 
-To execute the `ALTER GROUP` statement, you must have at least one of the following roles:
+To execute the ALTER GROUP statement, you must have at least one of the following roles:
 
 * xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
 * xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]

--- a/modules/n1ql/pages/n1ql-language-reference/altergroup.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/altergroup.adoc
@@ -23,11 +23,13 @@ If you want to add or remove specific roles without affecting the others, use th
 
 == Prerequisites
 
-To execute the ALTER GROUP statement, you must have at least one of the following roles:
+To execute the ALTER GROUP statement, you must have at least 1 of the following roles:
 
 * xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
 * xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]
 * xref:projects:project-roles.adoc#project-cluster-data-reader-writer[`Data Writer`]
+
+You cannot execute this statement using cluster access credentials. 
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/altergroup.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/altergroup.adoc
@@ -23,13 +23,13 @@ If you want to add or remove specific roles without affecting the others, use th
 
 == Prerequisites
 
-To execute the ALTER GROUP statement in the Capella UI, you must have at least 1 of the following roles:
+To execute this statement in the Capella UI, you must have 1 of the following roles:
 
 * xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
 * xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]
 * xref:projects:project-roles.adoc#project-cluster-data-reader-writer[`Data Writer`]
 
-You cannot execute this statement using cluster access credentials. 
+NOTE: You cannot execute this statement using xref:clusters:cluster-rbac.adoc[cluster access credentials]. 
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/altergroup.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/altergroup.adoc
@@ -23,7 +23,7 @@ If you want to add or remove specific roles without affecting the others, use th
 
 == Prerequisites
 
-To execute this statement in the Capella UI, you must have 1 of the following roles:
+To execute this statement in the Capella UI, you must have one of the following roles:
 
 * xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
 * xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]

--- a/modules/n1ql/pages/n1ql-language-reference/altergroup.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/altergroup.adoc
@@ -23,7 +23,7 @@ If you want to add or remove specific roles without affecting the others, use th
 
 == Prerequisites
 
-To execute the ALTER GROUP statement, you must have at least 1 of the following roles:
+To execute the ALTER GROUP statement in the Capella UI, you must have at least 1 of the following roles:
 
 * xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
 * xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]

--- a/modules/n1ql/pages/n1ql-language-reference/alterindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/alterindex.adoc
@@ -40,11 +40,17 @@ If a node goes down while an {doctitle} operation is happening, then the index w
 //tag::prerequisites[]
 == Prerequisites
 
-To execute the `{doctitle}` statement, your client must have 1 of the following privileges:
+To execute this statement, your client must have necessary privileges on the keyspace that contains the index.
+The required privilege depends on your xref:clusters:cluster-rbac.adoc#cluster-access-credential-types[cluster access credential type]. 
 
-* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`] privilege on the keyspace.
-* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Index`] privilege on the keyspace.
-
+[cols="1a,1a", options="header"]
+|===
+| Credential Type | Privilege 
+| Basic
+| xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`]
+| Advanced
+| xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Index`]
+|===
 //end::prerequisites[]
 
 == Syntax

--- a/modules/n1ql/pages/n1ql-language-reference/alterindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/alterindex.adoc
@@ -43,7 +43,7 @@ If a node goes down while an {doctitle} operation is happening, then the index w
 To execute the `{doctitle}` statement, your client must have 1 of the following privileges:
 
 * If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`] privilege on the keyspace.
-* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Index`] privilege on the keyspace.
+* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Index`] privilege on the keyspace.
 
 //end::prerequisites[]
 

--- a/modules/n1ql/pages/n1ql-language-reference/alterindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/alterindex.adoc
@@ -41,7 +41,11 @@ If a node goes down while an {doctitle} operation is happening, then the index w
 == Prerequisites
 
 To execute the `{doctitle}` statement, your client must have the `Write` privilege on the keyspace.
-For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
+To execute the `{doctitle}` statement, your client must have one of the following privileges:
+
+ * If you are using simple cluster access credentials, your client must have the xref:clusters:manage-database-users.adoc[`Write`] privilege on the keyspace.
+
+* If you are using advanced cluster access credentials, your client must have the xref:clusters:manage-database-users.adoc[`Query Index`] privilege on the keyspace.
 
 //end::prerequisites[]
 

--- a/modules/n1ql/pages/n1ql-language-reference/alterindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/alterindex.adoc
@@ -40,7 +40,9 @@ If a node goes down while an {doctitle} operation is happening, then the index w
 //tag::prerequisites[]
 == Prerequisites
 
-Only users with the RBAC role of `Administrator` are allowed to run the `{doctitle}` directive.
+To execute the `{doctitle}` statement, your client must have the `Write` privilege on the keyspace.
+For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
+
 //end::prerequisites[]
 
 == Syntax

--- a/modules/n1ql/pages/n1ql-language-reference/alterindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/alterindex.adoc
@@ -40,12 +40,10 @@ If a node goes down while an {doctitle} operation is happening, then the index w
 //tag::prerequisites[]
 == Prerequisites
 
-To execute the `{doctitle}` statement, your client must have the `Write` privilege on the keyspace.
-To execute the `{doctitle}` statement, your client must have one of the following privileges:
+To execute the `{doctitle}` statement, your client must have 1 of the following privileges:
 
- * If you are using simple cluster access credentials, your client must have the xref:clusters:manage-database-users.adoc[`Write`] privilege on the keyspace.
-
-* If you are using advanced cluster access credentials, your client must have the xref:clusters:manage-database-users.adoc[`Query Index`] privilege on the keyspace.
+* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`] privilege on the keyspace.
+* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Index`] privilege on the keyspace.
 
 //end::prerequisites[]
 

--- a/modules/n1ql/pages/n1ql-language-reference/altersequence.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/altersequence.adoc
@@ -38,7 +38,8 @@ Similarly, when you restore a bucket, sequences are restored in accordance with 
 
 == Prerequisites
 
-To execute the ALTER SEQUENCE statement, the client must have the xref:clusters:manage-database-users.adoc#database-role-write[`Write`] privilege on the scope.
+To execute the `ALTER SEQUENCE` statement, the client must have the `Write` privilege on the scope.
+For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 
 == Syntax
 
@@ -49,7 +50,7 @@ include::partial$grammar/ddl.ebnf[tag=alter-sequence]
 
 image::n1ql-language-reference/alter-sequence.png["Syntax diagram: refer to source code listing", align=left]
 
-The ALTER SEQUENCE statement provides two possible syntaxes for specifying options for a sequence.
+The `ALTER SEQUENCE` statement provides two possible syntaxes for specifying options for a sequence.
 
 // TODO: Automatic links in EBNF.
 

--- a/modules/n1ql/pages/n1ql-language-reference/altersequence.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/altersequence.adoc
@@ -38,10 +38,17 @@ Similarly, when you restore a bucket, sequences are restored in accordance with 
 
 == Prerequisites
 
-To execute the ALTER SEQUENCE statement, your client must have 1 of the following privileges:
+To execute this statement, your client must have necessary privileges on the scope that contains the sequence.
+The required privilege depends on your xref:clusters:cluster-rbac.adoc#cluster-access-credential-types[cluster access credential type].
 
-* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`] privilege on the scope.
-* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Manage Sequences`] privilege on the scope.
+[cols="1a,1a", options="header"]
+|===
+| Credential Type | Privilege 
+| Basic
+| xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`]
+| Advanced
+| xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Manage Sequences`]
+|===
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/altersequence.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/altersequence.adoc
@@ -38,9 +38,7 @@ Similarly, when you restore a bucket, sequences are restored in accordance with 
 
 == Prerequisites
 
-.RBAC Privileges
-To execute the ALTER SEQUENCE statement, your client must have the _Query Manage Sequences_ privilege granted on the scope.
-For more details about cluster access privileges, see {authorization-overview}[].
+To execute the ALTER SEQUENCE statement, the client must have the xref:clusters:manage-database-users.adoc#database-role-write[`Write`] privilege on the scope.
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/altersequence.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/altersequence.adoc
@@ -41,7 +41,7 @@ Similarly, when you restore a bucket, sequences are restored in accordance with 
 To execute the ALTER SEQUENCE statement, your client must have 1 of the following privileges:
 
 * If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`] privilege on the scope.
-* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Manage Sequences`] privilege on the scope.
+* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Manage Sequences`] privilege on the scope.
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/altersequence.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/altersequence.adoc
@@ -38,13 +38,10 @@ Similarly, when you restore a bucket, sequences are restored in accordance with 
 
 == Prerequisites
 
-ifdef::granular-rbac[]
-To execute the ALTER SEQUENCE statement, your client must have the _Query Manage Sequences_ privilege granted on the scope.
-For more details about cluster access privileges, see {authorization-overview}[].
-endif::granular-rbac[]
+To execute the ALTER SEQUENCE statement, your client must have 1 of the following privileges:
 
-To execute the ALTER SEQUENCE statement, your client must have the `Write` privilege on the scope.
-For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
+* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`] privilege on the scope.
+* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Manage Sequences`] privilege on the scope.
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/altersequence.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/altersequence.adoc
@@ -38,8 +38,10 @@ Similarly, when you restore a bucket, sequences are restored in accordance with 
 
 == Prerequisites
 
-//To execute the ALTER SEQUENCE statement, your client must have the _Query Manage Sequences_ privilege granted on the scope.
-//For more details about cluster access privileges, see {authorization-overview}[].
+ifdef::granular-rbac[]
+To execute the ALTER SEQUENCE statement, your client must have the _Query Manage Sequences_ privilege granted on the scope.
+For more details about cluster access privileges, see {authorization-overview}[].
+endif::granular-rbac[]
 
 To execute the ALTER SEQUENCE statement, your client must have the `Write` privilege on the scope.
 For more information about access privileges, see xref:clusters:manage-database-users.adoc[].

--- a/modules/n1ql/pages/n1ql-language-reference/altersequence.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/altersequence.adoc
@@ -38,6 +38,9 @@ Similarly, when you restore a bucket, sequences are restored in accordance with 
 
 == Prerequisites
 
+//To execute the ALTER SEQUENCE statement, your client must have the _Query Manage Sequences_ privilege granted on the scope.
+//For more details about cluster access privileges, see {authorization-overview}[].
+
 To execute the ALTER SEQUENCE statement, your client must have the `Write` privilege on the scope.
 For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 

--- a/modules/n1ql/pages/n1ql-language-reference/altersequence.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/altersequence.adoc
@@ -38,7 +38,7 @@ Similarly, when you restore a bucket, sequences are restored in accordance with 
 
 == Prerequisites
 
-To execute the `ALTER SEQUENCE` statement, the client must have the `Write` privilege on the scope.
+To execute the ALTER SEQUENCE statement, your client must have the `Write` privilege on the scope.
 For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 
 == Syntax
@@ -50,7 +50,7 @@ include::partial$grammar/ddl.ebnf[tag=alter-sequence]
 
 image::n1ql-language-reference/alter-sequence.png["Syntax diagram: refer to source code listing", align=left]
 
-The `ALTER SEQUENCE` statement provides two possible syntaxes for specifying options for a sequence.
+The ALTER SEQUENCE statement provides two possible syntaxes for specifying options for a sequence.
 
 // TODO: Automatic links in EBNF.
 

--- a/modules/n1ql/pages/n1ql-language-reference/alteruser.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/alteruser.adoc
@@ -19,7 +19,7 @@ It updates the entire group list, so any existing groups not included in the new
 
 == Prerequisites
 
-To execute the ALTER USER statement, you must have at least 1 of the following roles:
+To execute the ALTER USER statement in the Capella UI, you must have at least 1 of the following roles:
 
 * xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
 * xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]

--- a/modules/n1ql/pages/n1ql-language-reference/alteruser.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/alteruser.adoc
@@ -17,9 +17,13 @@ This statement helps manage access control and keeps user information up to date
 CAUTION: When you add new groups to a user, the ALTER USER statement replaces the user's existing group assignments with the new ones you provide. 
 It updates the entire group list, so any existing groups not included in the new list will be removed.
 
-== RBAC Privileges
+== Prerequisites
 
-To execute the ALTER USER statement, you must be an xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] or xref:projects:project-roles.adoc#project-owner-role[`Project Owner`].
+To execute the ALTER USER statement, you must have at least one of the following roles:
+
+* xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
+* xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]
+* xref:projects:project-roles.adoc#project-cluster-data-reader-writer[`Data Writer`]
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/alteruser.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/alteruser.adoc
@@ -9,17 +9,17 @@
 
 == Purpose
 
-Use the ALTER USER statement to update a local user's attributes, such as their password, full name, and group. 
+Use the `ALTER USER` statement to update a local user's attributes, such as their password, full name, and group. 
 You can add the user to new groups or remove them from all existing groups.
 
 This statement helps manage access control and keeps user information up to date within Couchbase Server.
 
-CAUTION: When you add new groups to a user, the ALTER USER statement replaces the user's existing group assignments with the new ones you provide. 
+CAUTION: When you add new groups to a user, the `ALTER USER` statement replaces the user's existing group assignments with the new ones you provide. 
 It updates the entire group list, so any existing groups not included in the new list will be removed.
 
 == Prerequisites
 
-To execute the ALTER USER statement, you must have at least one of the following roles:
+To execute the `ALTER USER` statement, you must have at least one of the following roles:
 
 * xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
 * xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]

--- a/modules/n1ql/pages/n1ql-language-reference/alteruser.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/alteruser.adoc
@@ -9,17 +9,17 @@
 
 == Purpose
 
-Use the `ALTER USER` statement to update a local user's attributes, such as their password, full name, and group. 
+Use the ALTER USER statement to update a local user's attributes, such as their password, full name, and group. 
 You can add the user to new groups or remove them from all existing groups.
 
 This statement helps manage access control and keeps user information up to date within Couchbase Server.
 
-CAUTION: When you add new groups to a user, the `ALTER USER` statement replaces the user's existing group assignments with the new ones you provide. 
+CAUTION: When you add new groups to a user, the ALTER USER statement replaces the user's existing group assignments with the new ones you provide. 
 It updates the entire group list, so any existing groups not included in the new list will be removed.
 
 == Prerequisites
 
-To execute the `ALTER USER` statement, you must have at least one of the following roles:
+To execute the ALTER USER statement, you must have at least one of the following roles:
 
 * xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
 * xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]

--- a/modules/n1ql/pages/n1ql-language-reference/alteruser.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/alteruser.adoc
@@ -19,11 +19,13 @@ It updates the entire group list, so any existing groups not included in the new
 
 == Prerequisites
 
-To execute the ALTER USER statement, you must have at least one of the following roles:
+To execute the ALTER USER statement, you must have at least 1 of the following roles:
 
 * xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
 * xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]
 * xref:projects:project-roles.adoc#project-cluster-data-reader-writer[`Data Writer`]
+
+You cannot execute this statement using cluster access credentials. 
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/alteruser.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/alteruser.adoc
@@ -19,7 +19,7 @@ It updates the entire group list, so any existing groups not included in the new
 
 == Prerequisites
 
-To execute this statement in the Capella UI, you must have 1 of the following roles:
+To execute this statement in the Capella UI, you must have one of the following roles:
 
 * xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
 * xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]

--- a/modules/n1ql/pages/n1ql-language-reference/alteruser.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/alteruser.adoc
@@ -19,13 +19,13 @@ It updates the entire group list, so any existing groups not included in the new
 
 == Prerequisites
 
-To execute the ALTER USER statement in the Capella UI, you must have at least 1 of the following roles:
+To execute this statement in the Capella UI, you must have 1 of the following roles:
 
 * xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
 * xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]
 * xref:projects:project-roles.adoc#project-cluster-data-reader-writer[`Data Writer`]
 
-You cannot execute this statement using cluster access credentials. 
+NOTE: You cannot execute this statement using xref:clusters:cluster-rbac.adoc[cluster access credentials]. 
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/build-index.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/build-index.adoc
@@ -60,6 +60,9 @@ If the data set changes dramatically, you must drop and rebuild the index to upd
 
 == Prerequisites
 
+// The client executing the BUILD INDEX statement must have the _Query Manage Index_ privilege granted on the keyspace.
+// For more details about cluster access privileges, see {authorization-overview}[].
+
 To execute the BUILD INDEX statement, your client must have the `Write` privilege on the keyspace.
 For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 

--- a/modules/n1ql/pages/n1ql-language-reference/build-index.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/build-index.adoc
@@ -60,12 +60,7 @@ If the data set changes dramatically, you must drop and rebuild the index to upd
 
 == Prerequisites
 
-[discrete]
-===== RBAC Privileges
-
-The client executing the BUILD INDEX statement must have the _Query Manage Index_ privilege granted on the keyspace.
-For more details about cluster access privileges, see
-{authorization-overview}[].
+To execute the BUILD INDEX statement, the client must have the xref:clusters:manage-database-users.adoc#database-role-write[`Write`] privilege on the keyspace.
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/build-index.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/build-index.adoc
@@ -60,13 +60,10 @@ If the data set changes dramatically, you must drop and rebuild the index to upd
 
 == Prerequisites
 
-ifdef::granular-rbac[]
-The client executing the BUILD INDEX statement must have the _Query Manage Index_ privilege granted on the keyspace.
-For more details about cluster access privileges, see {authorization-overview}[].
-endif::granular-rbac[]
+To execute the BUILD INDEX statement, your client must have 1 of the following privileges:
 
-To execute the BUILD INDEX statement, your client must have the `Write` privilege on the keyspace.
-For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
+* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`] privilege on the keyspace.
+* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Index`] privilege on the keyspace.
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/build-index.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/build-index.adoc
@@ -60,8 +60,10 @@ If the data set changes dramatically, you must drop and rebuild the index to upd
 
 == Prerequisites
 
-// The client executing the BUILD INDEX statement must have the _Query Manage Index_ privilege granted on the keyspace.
-// For more details about cluster access privileges, see {authorization-overview}[].
+ifdef::granular-rbac[]
+The client executing the BUILD INDEX statement must have the _Query Manage Index_ privilege granted on the keyspace.
+For more details about cluster access privileges, see {authorization-overview}[].
+endif::granular-rbac[]
 
 To execute the BUILD INDEX statement, your client must have the `Write` privilege on the keyspace.
 For more information about access privileges, see xref:clusters:manage-database-users.adoc[].

--- a/modules/n1ql/pages/n1ql-language-reference/build-index.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/build-index.adoc
@@ -63,7 +63,7 @@ If the data set changes dramatically, you must drop and rebuild the index to upd
 To execute the BUILD INDEX statement, your client must have 1 of the following privileges:
 
 * If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`] privilege on the keyspace.
-* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Index`] privilege on the keyspace.
+* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Index`] privilege on the keyspace.
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/build-index.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/build-index.adoc
@@ -19,12 +19,12 @@ include::partial$n1ql-language-reference/horizontal-style.adoc[]
 [abstract]
 {description}
 
-By default, CREATE INDEX or CREATE VECTOR INDEX starts building the created index after the creation stage is complete.
-However for more efficient building of multiple indexes, CREATE INDEX or CREATE VECTOR INDEX can mark indexes for deferred building using the `defer_build:true` option.
-BUILD INDEX is capable of building multiple indexes at once, and can utilize a single scan of documents in the keyspace to feed many index build operations.
+By default, `CREATE INDEX` or `CREATE VECTOR INDEX` starts building the created index after the creation stage is complete.
+However for more efficient building of multiple indexes, `CREATE INDEX` or `CREATE VECTOR INDEX` can mark indexes for deferred building using the `defer_build:true` option.
+`BUILD INDEX` is capable of building multiple indexes at once, and can utilize a single scan of documents in the keyspace to feed many index build operations.
 
-BUILD INDEX is an asynchronous operation.
-BUILD INDEX creates a task to build the primary or secondary GSI indexes and returns as soon as the task is queued for execution.
+`BUILD INDEX` is an asynchronous operation.
+`BUILD INDEX` creates a task to build the primary or secondary GSI indexes and returns as soon as the task is queued for execution.
 The full index build operation happens in the background.
 
 Index metadata provides a state field.
@@ -43,24 +43,25 @@ If you kick off multiple index build operations concurrently, then you may somet
 include::example$n1ql-language-reference/build-idx-error.jsonc[]
 ----
 
-To work around this issue, wait for index building to complete (that is, for all indexes to get to the online state), then issue the BUILD INDEX command again.
+To work around this issue, wait for index building to complete (that is, for all indexes to get to the online state), then issue the `BUILD INDEX` command again.
 ====
 
-BUILD INDEX is also idempotent.
+`BUILD INDEX` is also idempotent.
 On execution, the statement only builds indexes which have not already been built.
-If any of the indexes specified by BUILD INDEX have already been built, BUILD INDEX skips those indexes.
+If any of the indexes specified by `BUILD INDEX` have already been built, `BUILD INDEX` skips those indexes.
 
-When building an index which has automatic index replicas, all of the replicas are also built as part of the BUILD INDEX statement, without having to manually specify them.
+When building an index which has automatic index replicas, all of the replicas are also built as part of the `BUILD INDEX` statement, without having to manually specify them.
 
 Hyperscale Vector indexes and Composite Vector indexes require a codebook for the vector field.
 The codebook is the result of sampling the dataset and is saved as part of the index metadata.
 
-The codebook is created as part of the BUILD INDEX process, and is not incrementally updated.
+The codebook is created as part of the `BUILD INDEX` process, and is not incrementally updated.
 If the data set changes dramatically, you must drop and rebuild the index to update the codebook.
 
 == Prerequisites
 
-To execute the BUILD INDEX statement, the client must have the xref:clusters:manage-database-users.adoc#database-role-write[`Write`] privilege on the keyspace.
+To execute the `BUILD INDEX` statement, the client must have the `Write` privilege on the keyspace.
+For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 
 == Syntax
 
@@ -124,7 +125,7 @@ You can specify one index term, or multiple index terms separated by commas.
 An index term must be specified for each index to be built.
 
 Each index term may be an <<index-name>>, an <<index-expr>>, or a <<subquery-expr>>.
-The BUILD INDEX clause may contain a mixture of the different types of index term.
+The `BUILD INDEX` clause may contain a mixture of the different types of index term.
 
 [[index-name,index name]]
 ==== Index Name

--- a/modules/n1ql/pages/n1ql-language-reference/build-index.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/build-index.adoc
@@ -19,12 +19,12 @@ include::partial$n1ql-language-reference/horizontal-style.adoc[]
 [abstract]
 {description}
 
-By default, `CREATE INDEX` or `CREATE VECTOR INDEX` starts building the created index after the creation stage is complete.
-However for more efficient building of multiple indexes, `CREATE INDEX` or `CREATE VECTOR INDEX` can mark indexes for deferred building using the `defer_build:true` option.
-`BUILD INDEX` is capable of building multiple indexes at once, and can utilize a single scan of documents in the keyspace to feed many index build operations.
+By default, CREATE INDEX or CREATE VECTOR INDEX starts building the created index after the creation stage is complete.
+However for more efficient building of multiple indexes, CREATE INDEX or CREATE VECTOR INDEX can mark indexes for deferred building using the `defer_build:true` option.
+BUILD INDEX is capable of building multiple indexes at once, and can utilize a single scan of documents in the keyspace to feed many index build operations.
 
-`BUILD INDEX` is an asynchronous operation.
-`BUILD INDEX` creates a task to build the primary or secondary GSI indexes and returns as soon as the task is queued for execution.
+BUILD INDEX is an asynchronous operation.
+BUILD INDEX creates a task to build the primary or secondary GSI indexes and returns as soon as the task is queued for execution.
 The full index build operation happens in the background.
 
 Index metadata provides a state field.
@@ -43,24 +43,24 @@ If you kick off multiple index build operations concurrently, then you may somet
 include::example$n1ql-language-reference/build-idx-error.jsonc[]
 ----
 
-To work around this issue, wait for index building to complete (that is, for all indexes to get to the online state), then issue the `BUILD INDEX` command again.
+To work around this issue, wait for index building to complete (that is, for all indexes to get to the online state), then issue the BUILD INDEX command again.
 ====
 
-`BUILD INDEX` is also idempotent.
+BUILD INDEX is also idempotent.
 On execution, the statement only builds indexes which have not already been built.
-If any of the indexes specified by `BUILD INDEX` have already been built, `BUILD INDEX` skips those indexes.
+If any of the indexes specified by BUILD INDEX have already been built, BUILD INDEX skips those indexes.
 
-When building an index which has automatic index replicas, all of the replicas are also built as part of the `BUILD INDEX` statement, without having to manually specify them.
+When building an index which has automatic index replicas, all of the replicas are also built as part of the BUILD INDEX statement, without having to manually specify them.
 
 Hyperscale Vector indexes and Composite Vector indexes require a codebook for the vector field.
 The codebook is the result of sampling the dataset and is saved as part of the index metadata.
 
-The codebook is created as part of the `BUILD INDEX` process, and is not incrementally updated.
+The codebook is created as part of the BUILD INDEX process, and is not incrementally updated.
 If the data set changes dramatically, you must drop and rebuild the index to update the codebook.
 
 == Prerequisites
 
-To execute the `BUILD INDEX` statement, the client must have the `Write` privilege on the keyspace.
+To execute the BUILD INDEX statement, your client must have the `Write` privilege on the keyspace.
 For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 
 == Syntax
@@ -125,7 +125,7 @@ You can specify one index term, or multiple index terms separated by commas.
 An index term must be specified for each index to be built.
 
 Each index term may be an <<index-name>>, an <<index-expr>>, or a <<subquery-expr>>.
-The `BUILD INDEX` clause may contain a mixture of the different types of index term.
+The BUILD INDEX clause may contain a mixture of the different types of index term.
 
 [[index-name,index name]]
 ==== Index Name

--- a/modules/n1ql/pages/n1ql-language-reference/build-index.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/build-index.adoc
@@ -59,11 +59,17 @@ The codebook is created as part of the BUILD INDEX process, and is not increment
 If the data set changes dramatically, you must drop and rebuild the index to update the codebook.
 
 == Prerequisites
+To execute this statement, your client must have necessary privileges on the keyspace that contains the indexes.
+The required privilege depends on your xref:clusters:cluster-rbac.adoc#cluster-access-credential-types[cluster access credential type].
 
-To execute the BUILD INDEX statement, your client must have 1 of the following privileges:
-
-* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`] privilege on the keyspace.
-* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Index`] privilege on the keyspace.
+[cols="1a,1a", options="header"]
+|===
+| Credential Type | Privilege 
+| Basic
+| xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`]
+| Advanced
+| xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Index`]
+|===
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/comma.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/comma.adoc
@@ -37,6 +37,11 @@ Refer to the examples below for further details.
 
 == Prerequisites
 
+ifdef::granular-rbac[]
+To select data from keyspace or expression, your client must have the [.param]`query_select` privilege on that keyspace.
+For more details about cluster access privileges, see {authorization}[].
+endif::granular-rbac[]
+
 To select data from keyspace or expression, your client must have the `Read` privilege on that keyspace.
 For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 

--- a/modules/n1ql/pages/n1ql-language-reference/comma.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/comma.adoc
@@ -37,10 +37,17 @@ Refer to the examples below for further details.
 
 == Prerequisites
 
-To select data from a keyspace or expression, your client must have 1 of the following privileges:
+To select data from a keyspace or expression,, your client must have specific privileges on the keyspace or expression that you want to select from.
+The required privilege depends on your xref:clusters:cluster-rbac.adoc#cluster-access-credential-types[cluster access credential type].
 
-* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`] privilege on that keyspace.
-* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Read`] privilege on that keyspace.
+[cols="1a,1a", options="header"]
+|===
+| Credential Type | Privilege 
+| Basic
+| xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`]
+| Advanced
+| xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Read`]
+|===
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/comma.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/comma.adoc
@@ -40,7 +40,7 @@ Refer to the examples below for further details.
 To select data from a keyspace or expression, your client must have 1 of the following privileges:
 
 * If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`] privilege on that keyspace.
-* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Read`] privilege on that keyspace.
+* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Read`] privilege on that keyspace.
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/comma.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/comma.adoc
@@ -37,13 +37,10 @@ Refer to the examples below for further details.
 
 == Prerequisites
 
-ifdef::granular-rbac[]
-To select data from keyspace or expression, your client must have the [.param]`query_select` privilege on that keyspace.
-For more details about cluster access privileges, see {authorization}[].
-endif::granular-rbac[]
+To select data from a keyspace or expression, your client must have 1 of the following privileges:
 
-To select data from keyspace or expression, your client must have the `Read` privilege on that keyspace.
-For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
+* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`] privilege on that keyspace.
+* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Read`] privilege on that keyspace.
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/comma.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/comma.adoc
@@ -37,8 +37,8 @@ Refer to the examples below for further details.
 
 == Prerequisites
 
-To select data from keyspace or expression, your client must have the [.param]`query_select` privilege on that keyspace.
-For more details about cluster access privileges, see {authorization}[].
+To select data from keyspace or expression, your client must have the `Read` privilege on that keyspace.
+For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/createbucket.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createbucket.adoc
@@ -27,11 +27,13 @@ You can have a maximum of 30 buckets per cluster.
 
 == Prerequisites
 
-To execute the CREATE BUCKET statement, you must have at least one of the following roles:
+To execute the CREATE BUCKET statement in the Capella UI, you must have at least 1 of the following roles:
 
 * xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
 * xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]
 * xref:projects:project-roles.adoc#project-cluster-data-reader-writer[`Data Writer`]
+
+You cannot execute this statement using cluster access credentials. 
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/createbucket.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createbucket.adoc
@@ -17,7 +17,7 @@
 
 == Purpose
 
-Use the `CREATE BUCKET` statement to create a new bucket in your Couchbase cluster.
+Use the CREATE BUCKET statement to create a new bucket in your Couchbase cluster.
 A bucket is a top-level data container, similar to a database in relational database management systems.
 It stores documents and provides a logical grouping for data.
 
@@ -27,7 +27,7 @@ You can have a maximum of 30 buckets per cluster.
 
 == Prerequisites
 
-To execute the `CREATE BUCKET` statement, you must have at least one of the following roles:
+To execute the CREATE BUCKET statement, you must have at least one of the following roles:
 
 * xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
 * xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]

--- a/modules/n1ql/pages/n1ql-language-reference/createbucket.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createbucket.adoc
@@ -27,7 +27,7 @@ You can have a maximum of 30 buckets per cluster.
 
 == Prerequisites
 
-To execute this statement in the Capella UI, you must have 1 of the following roles:
+To execute this statement in the Capella UI, you must have one of the following roles:
 
 * xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
 * xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]

--- a/modules/n1ql/pages/n1ql-language-reference/createbucket.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createbucket.adoc
@@ -27,13 +27,13 @@ You can have a maximum of 30 buckets per cluster.
 
 == Prerequisites
 
-To execute the CREATE BUCKET statement in the Capella UI, you must have at least 1 of the following roles:
+To execute this statement in the Capella UI, you must have 1 of the following roles:
 
 * xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
 * xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]
 * xref:projects:project-roles.adoc#project-cluster-data-reader-writer[`Data Writer`]
 
-You cannot execute this statement using cluster access credentials. 
+NOTE: You cannot execute this statement using xref:clusters:cluster-rbac.adoc[cluster access credentials]. 
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/createbucket.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createbucket.adoc
@@ -17,7 +17,7 @@
 
 == Purpose
 
-Use the CREATE BUCKET statement to create a new bucket in your Couchbase cluster.
+Use the `CREATE BUCKET` statement to create a new bucket in your Couchbase cluster.
 A bucket is a top-level data container, similar to a database in relational database management systems.
 It stores documents and provides a logical grouping for data.
 
@@ -27,7 +27,7 @@ You can have a maximum of 30 buckets per cluster.
 
 == Prerequisites
 
-To execute the CREATE BUCKET statement, you must have at least one of the following roles:
+To execute the `CREATE BUCKET` statement, you must have at least one of the following roles:
 
 * xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
 * xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]

--- a/modules/n1ql/pages/n1ql-language-reference/createbucket.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createbucket.adoc
@@ -25,10 +25,13 @@ When you create a new bucket, a `_default` scope and a `_default` collection are
 The name of the bucket must be unique within the cluster and you cannot change it once you create the bucket.
 You can have a maximum of 30 buckets per cluster.
 
-== RBAC Privileges
+== Prerequisites
 
-To execute the CREATE BUCKET statement, you must have either the Full Admin or the Cluster Admin role.
-For more information about roles and privileges, see {roles}[Roles].
+To execute the CREATE BUCKET statement, you must have at least one of the following roles:
+
+* xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
+* xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]
+* xref:projects:project-roles.adoc#project-cluster-data-reader-writer[`Data Writer`]
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/createcollection.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createcollection.adoc
@@ -22,8 +22,17 @@ The `CREATE COLLECTION` statement enables you to create a named collection withi
 
 == Prerequisites
 
-To execute the CREATE COLLECTION statement, your client must have the `Write` privilege on the keyspace.
-For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
+To execute this statement, your client must have necessary privileges on the keyspace where you want to create the collection.
+The required privilege depends on your xref:clusters:cluster-rbac.adoc#cluster-access-credential-types[cluster access credential type]. 
+
+[cols="1a,1a", options="header"]
+|===
+| Credential Type | Privilege 
+| Basic
+| xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`]
+| Advanced
+| xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Scope Admin`]
+|===
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/createcollection.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createcollection.adoc
@@ -20,6 +20,11 @@ include::partial$n1ql-language-reference/horizontal-style.adoc[]
 [abstract]
 The `CREATE COLLECTION` statement enables you to create a named collection within a scope.
 
+== Prerequisites
+
+To execute the CREATE COLLECTION statement, your client must have the `Write` privilege on the keyspace.
+For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
+
 == Syntax
 
 [source,ebnf]

--- a/modules/n1ql/pages/n1ql-language-reference/createfunction.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createfunction.adoc
@@ -51,7 +51,11 @@ include::javascript-udfs:partial$sqlpp-managed-udfs.adoc[]
 
 == Prerequisites
 
-* To manage user-defined functions on your operational cluster, you must have the xref:projects:project-roles.adoc#project-owner-role[`Project Owner`] or the xref:projects:project-roles.adoc#project-cluster-data-reader-writer[`Cluster Data Reader/Writer`] role.
+To execute the CREATE FUNCTION statement, you must have at least one of the following roles:
+
+* xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
+* xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]
+* xref:projects:project-roles.adoc#project-cluster-data-reader-writer[`Data Writer`]
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/createfunction.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createfunction.adoc
@@ -51,12 +51,21 @@ include::javascript-udfs:partial$sqlpp-managed-udfs.adoc[]
 
 == Prerequisites
 
-To execute the `CREATE FUNCTION` statement, your client must have 1 of the following privileges:
+To execute this statement, your client must have privileges depending on your xref:clusters:cluster-rbac.adoc#cluster-access-credential-types[cluster access credential type] and whether the function is global or scoped.
 
-* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`] privilege on the keyspace or scope.
-* If you're using advanced cluster access credentials, your client must have:
-** The xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Global Function Manage`] privilege to create a global function.
-** The xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Manage`] privilege to create a function within a specific scope.
+[cols="1a,1,1a", options="header"]
+|===
+| Credential Type | Function Type | Privilege 
+| Basic
+| Global or scoped
+| xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`]
+| Advanced
+| Global
+| xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Global Function Manage`] 
+| Advanced
+| Scoped
+| xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Manage`]
+|===
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/createfunction.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createfunction.adoc
@@ -51,11 +51,12 @@ include::javascript-udfs:partial$sqlpp-managed-udfs.adoc[]
 
 == Prerequisites
 
-To execute the `CREATE FUNCTION` statement, you must have at least one of the following roles:
+To execute the `CREATE FUNCTION` statement, your client must have 1 of the following privileges:
 
-* xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
-* xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]
-* xref:projects:project-roles.adoc#project-cluster-data-reader-writer[`Data Writer`]
+* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`] privilege on the keyspace or scope.
+* If you're using advanced cluster access credentials, your client must have:
+** The xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Global Function Manage`] privilege to create a global function.
+** The xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Manage`] privilege to create a function within a specific scope.
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/createfunction.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createfunction.adoc
@@ -51,7 +51,7 @@ include::javascript-udfs:partial$sqlpp-managed-udfs.adoc[]
 
 == Prerequisites
 
-To execute this statement, your client must have privileges depending on your xref:clusters:cluster-rbac.adoc#cluster-access-credential-types[cluster access credential type] and whether the function is global or scoped.
+To execute this statement, your client must have necessary privileges depending on your xref:clusters:cluster-rbac.adoc#cluster-access-credential-types[cluster access credential type] and whether the function is global or scoped.
 
 [cols="1a,1,1a", options="header"]
 |===

--- a/modules/n1ql/pages/n1ql-language-reference/createfunction.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createfunction.adoc
@@ -51,7 +51,7 @@ include::javascript-udfs:partial$sqlpp-managed-udfs.adoc[]
 
 == Prerequisites
 
-To execute the CREATE FUNCTION statement, you must have at least one of the following roles:
+To execute the `CREATE FUNCTION` statement, you must have at least one of the following roles:
 
 * xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
 * xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]

--- a/modules/n1ql/pages/n1ql-language-reference/creategroup.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/creategroup.adoc
@@ -17,13 +17,13 @@ When you add users to a group, they automatically inherit the roles assigned to 
 
 == Prerequisites
 
-To execute the CREATE GROUP statement in the Capella UI, you must have at least 1 of the following roles:
+To execute this statement in the Capella UI, you must have 1 of the following roles:
 
 * xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
 * xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]
 * xref:projects:project-roles.adoc#project-cluster-data-reader-writer[`Data Writer`]
 
-You cannot execute this statement using cluster access credentials. 
+NOTE: You cannot execute this statement using xref:clusters:cluster-rbac.adoc[cluster access credentials]. 
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/creategroup.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/creategroup.adoc
@@ -9,7 +9,7 @@
 
 == Purpose
 
-Use the CREATE GROUP statement to define a new group within the Couchbase Server Role-Based Access Control (RBAC) system.
+Use the `CREATE GROUP` statement to define a new group within the Couchbase Server Role-Based Access Control (RBAC) system.
 You can specify the group's name, description, and assign it one or more roles.
 
 By creating groups, you can organize users and assign roles collectively.
@@ -17,7 +17,7 @@ When you add users to a group, they automatically inherit the roles assigned to 
 
 == Prerequisites
 
-To execute the CREATE GROUP statement, you must have at least one of the following roles:
+To execute the `CREATE GROUP` statement, you must have at least one of the following roles:
 
 * xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
 * xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]

--- a/modules/n1ql/pages/n1ql-language-reference/creategroup.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/creategroup.adoc
@@ -17,7 +17,7 @@ When you add users to a group, they automatically inherit the roles assigned to 
 
 == Prerequisites
 
-To execute this statement in the Capella UI, you must have 1 of the following roles:
+To execute this statement in the Capella UI, you must have one of the following roles:
 
 * xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
 * xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]

--- a/modules/n1ql/pages/n1ql-language-reference/creategroup.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/creategroup.adoc
@@ -9,7 +9,7 @@
 
 == Purpose
 
-Use the `CREATE GROUP` statement to define a new group within the Couchbase Server Role-Based Access Control (RBAC) system.
+Use the CREATE GROUP statement to define a new group within the Couchbase Server Role-Based Access Control (RBAC) system.
 You can specify the group's name, description, and assign it one or more roles.
 
 By creating groups, you can organize users and assign roles collectively.
@@ -17,7 +17,7 @@ When you add users to a group, they automatically inherit the roles assigned to 
 
 == Prerequisites
 
-To execute the `CREATE GROUP` statement, you must have at least one of the following roles:
+To execute the CREATE GROUP statement, you must have at least one of the following roles:
 
 * xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
 * xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]

--- a/modules/n1ql/pages/n1ql-language-reference/creategroup.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/creategroup.adoc
@@ -17,11 +17,13 @@ When you add users to a group, they automatically inherit the roles assigned to 
 
 == Prerequisites
 
-To execute the CREATE GROUP statement, you must have at least one of the following roles:
+To execute the CREATE GROUP statement in the Capella UI, you must have at least 1 of the following roles:
 
 * xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
 * xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]
 * xref:projects:project-roles.adoc#project-cluster-data-reader-writer[`Data Writer`]
+
+You cannot execute this statement using cluster access credentials. 
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/creategroup.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/creategroup.adoc
@@ -15,9 +15,13 @@ You can specify the group's name, description, and assign it one or more roles.
 By creating groups, you can organize users and assign roles collectively.
 When you add users to a group, they automatically inherit the roles assigned to that group.
 
-== RBAC Privileges
+== Prerequisites
 
-To execute the CREATE GROUP statement, you must be an xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] or xref:projects:project-roles.adoc#project-owner-role[`Project Owner`].
+To execute the CREATE GROUP statement, you must have at least one of the following roles:
+
+* xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
+* xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]
+* xref:projects:project-roles.adoc#project-cluster-data-reader-writer[`Data Writer`]
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
@@ -66,7 +66,7 @@ If the data set changes dramatically, you must drop and rebuild the index to upd
 //tag::prerequisites[]
 == Prerequisites
 
-To execute the `{doctitle}` statement, the client must have the `Write` privilege on the keyspace.
+To execute the `{doctitle}` statement, your client must have the `Write` privilege on the keyspace.
 For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 //end::prerequisites[]
 

--- a/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
@@ -66,8 +66,8 @@ If the data set changes dramatically, you must drop and rebuild the index to upd
 //tag::prerequisites[]
 == Prerequisites
 
-To execute the `{doctitle}` statement, the client must have the xref:clusters:manage-database-users.adoc#database-role-write[`Write`] privilege on the keyspace.
-
+To execute the `{doctitle}` statement, the client must have the `Write` privilege on the keyspace.
+For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 //end::prerequisites[]
 
 == Syntax

--- a/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
@@ -66,10 +66,17 @@ If the data set changes dramatically, you must drop and rebuild the index to upd
 //tag::prerequisites[]
 == Prerequisites
 
-To execute the `{doctitle}` statement, your client must have 1 of the following privileges:
+To execute this statement, your client must have necessary privileges on the keyspace where you want to create the index.
+The required privilege depends on your xref:clusters:cluster-rbac.adoc#cluster-access-credential-types[cluster access credential type]. 
 
-* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`] privilege on the keyspace.
-* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Index`] privilege on the keyspace.
+[cols="1a,1a", options="header"]
+|===
+| Credential Type | Privilege 
+| Basic
+| xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`]
+| Advanced
+| xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Index`]
+|===
 
 //end::prerequisites[]
 

--- a/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
@@ -66,12 +66,8 @@ If the data set changes dramatically, you must drop and rebuild the index to upd
 //tag::prerequisites[]
 == Prerequisites
 
-[discrete]
-===== RBAC Privileges
+To execute the `{doctitle}` statement, the client must have the xref:clusters:manage-database-users.adoc#database-role-write[`Write`] privilege on the keyspace.
 
-To execute the {doctitle} statement, your client must have the `Query Manage Index` privilege granted on the keyspace.
-For more information about cluster access privileges, see
-{authorization-overview}[].
 //end::prerequisites[]
 
 == Syntax

--- a/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
@@ -69,7 +69,7 @@ If the data set changes dramatically, you must drop and rebuild the index to upd
 To execute the `{doctitle}` statement, your client must have 1 of the following privileges:
 
 * If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`] privilege on the keyspace.
-* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Index`] privilege on the keyspace.
+* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Index`] privilege on the keyspace.
 
 //end::prerequisites[]
 

--- a/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
@@ -66,6 +66,11 @@ If the data set changes dramatically, you must drop and rebuild the index to upd
 //tag::prerequisites[]
 == Prerequisites
 
+ifdef::granular-rbac[]
+To execute the {doctitle} statement, your client must have the `Query Manage Index` privilege granted on the keyspace.
+For more information about cluster access privileges, see {authorization-overview}[].
+endif::granular-rbac[]
+
 To execute the `{doctitle}` statement, your client must have the `Write` privilege on the keyspace.
 For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 //end::prerequisites[]

--- a/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
@@ -66,13 +66,11 @@ If the data set changes dramatically, you must drop and rebuild the index to upd
 //tag::prerequisites[]
 == Prerequisites
 
-ifdef::granular-rbac[]
-To execute the {doctitle} statement, your client must have the `Query Manage Index` privilege granted on the keyspace.
-For more information about cluster access privileges, see {authorization-overview}[].
-endif::granular-rbac[]
+To execute the `{doctitle}` statement, your client must have 1 of the following privileges:
 
-To execute the `{doctitle}` statement, your client must have the `Write` privilege on the keyspace.
-For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
+* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`] privilege on the keyspace.
+* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Index`] privilege on the keyspace.
+
 //end::prerequisites[]
 
 == Syntax

--- a/modules/n1ql/pages/n1ql-language-reference/createprimaryindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createprimaryindex.adoc
@@ -41,10 +41,17 @@ See <<index-with,WITH Clause>> for more details.
 
 == Prerequisites
 
-To execute the `CREATE PRIMARY INDEX` statement, your client must have 1 of the following privileges:
+To execute this statement, your client must have necessary privileges on the keyspace where you want to create the index.
+The required privilege depends on your xref:clusters:cluster-rbac.adoc#cluster-access-credential-types[cluster access credential type]. 
 
-* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`] privilege on the keyspace.
-* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Index`] privilege on the keyspace.
+[cols="1a,1a", options="header"]
+|===
+| Credential Type | Privilege 
+| Basic
+| xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`]
+| Advanced
+| xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Index`]
+|===
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/createprimaryindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createprimaryindex.adoc
@@ -41,13 +41,10 @@ See <<index-with,WITH Clause>> for more details.
 
 == Prerequisites
 
-ifdef::granular-rbac[]
-To execute the `CREATE PRIMARY INDEX` statement, your client must have the `Query Manage Index` privilege granted on the keyspace.
-For more information about cluster access privileges, see {authorization-overview}[].
-endif::granular-rbac[]
+To execute the `CREATE PRIMARY INDEX` statement, your client must have 1 of the following privileges:
 
-To execute the `CREATE PRIMARY INDEX` statement, your client must have the `Write` privilege on the keyspace.
-For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
+* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`] privilege on the keyspace.
+* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Index`] privilege on the keyspace.
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/createprimaryindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createprimaryindex.adoc
@@ -41,7 +41,8 @@ See <<index-with,WITH Clause>> for more details.
 
 == Prerequisites
 
-To execute the CREATE PRIMARY INDEX statement, the client must have the xref:clusters:manage-database-users.adoc#database-role-write[`Write`] privilege on the keyspace.
+To execute the `CREATE PRIMARY INDEX` statement, the client must have the `Write` privilege on the keyspace.
+For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/createprimaryindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createprimaryindex.adoc
@@ -44,7 +44,7 @@ See <<index-with,WITH Clause>> for more details.
 To execute the `CREATE PRIMARY INDEX` statement, your client must have 1 of the following privileges:
 
 * If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`] privilege on the keyspace.
-* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Index`] privilege on the keyspace.
+* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Index`] privilege on the keyspace.
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/createprimaryindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createprimaryindex.adoc
@@ -41,7 +41,7 @@ See <<index-with,WITH Clause>> for more details.
 
 == Prerequisites
 
-To execute the `CREATE PRIMARY INDEX` statement, the client must have the `Write` privilege on the keyspace.
+To execute the `CREATE PRIMARY INDEX` statement, your client must have the `Write` privilege on the keyspace.
 For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 
 == Syntax

--- a/modules/n1ql/pages/n1ql-language-reference/createprimaryindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createprimaryindex.adoc
@@ -41,12 +41,7 @@ See <<index-with,WITH Clause>> for more details.
 
 == Prerequisites
 
-[discrete]
-===== RBAC Privileges
-
-To execute the `CREATE PRIMARY INDEX` statement, your client must have the `Query Manage Index` privilege granted on the keyspace.
-For more information about cluster access privileges, see
-{authorization-overview}[].
+To execute the CREATE PRIMARY INDEX statement, the client must have the xref:clusters:manage-database-users.adoc#database-role-write[`Write`] privilege on the keyspace.
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/createprimaryindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createprimaryindex.adoc
@@ -41,6 +41,11 @@ See <<index-with,WITH Clause>> for more details.
 
 == Prerequisites
 
+ifdef::granular-rbac[]
+To execute the `CREATE PRIMARY INDEX` statement, your client must have the `Query Manage Index` privilege granted on the keyspace.
+For more information about cluster access privileges, see {authorization-overview}[].
+endif::granular-rbac[]
+
 To execute the `CREATE PRIMARY INDEX` statement, your client must have the `Write` privilege on the keyspace.
 For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 

--- a/modules/n1ql/pages/n1ql-language-reference/createscope.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createscope.adoc
@@ -20,7 +20,8 @@ The `CREATE SCOPE` statement enables you to create a scope.
 
 == Prerequisites
 
-To execute the CREATE SCOPE statement, you must have the xref:clusters:manage-database-users.adoc#database-role-write[`Write`] privilege on the bucket.
+To execute the `CREATE SCOPE` statement, you must have the `Write` privilege on the bucket.
+For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/createscope.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createscope.adoc
@@ -18,6 +18,10 @@ include::partial$n1ql-language-reference/horizontal-style.adoc[]
 [abstract]
 The `CREATE SCOPE` statement enables you to create a scope.
 
+== Prerequisites
+
+To execute the CREATE SCOPE statement, you must have the xref:clusters:manage-database-users.adoc#database-role-write[`Write`] privilege on the bucket.
+
 == Syntax
 
 [source,ebnf]

--- a/modules/n1ql/pages/n1ql-language-reference/createscope.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createscope.adoc
@@ -20,8 +20,17 @@ The `CREATE SCOPE` statement enables you to create a scope.
 
 == Prerequisites
 
-To execute the `CREATE SCOPE` statement, you must have the `Write` privilege on the bucket.
-For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
+To execute this statement, your client must have necessary privileges on the keyspace where you want to create the scope.
+The required privilege depends on your xref:clusters:cluster-rbac.adoc#cluster-access-credential-types[cluster access credential type]. 
+
+[cols="1a,1a", options="header"]
+|===
+| Credential Type | Privilege 
+| Basic
+| xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`]
+| Advanced
+| xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Scope Admin`]
+|===
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/createsequence.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createsequence.adoc
@@ -38,6 +38,11 @@ Similarly, when you restore a bucket, sequences are restored in accordance with 
 
 == Prerequisites
 
+ifdef::granular-rbac[]
+To execute the CREATE SEQUENCE statement, your client must have the _Query Manage Sequences_ privilege granted on the scope.
+For more details about cluster access privileges, see {authorization-overview}[].
+endif::granular-rbac[]
+
 To execute the CREATE SEQUENCE statement, your client must have the `Write` privilege on the scope.
 For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 

--- a/modules/n1ql/pages/n1ql-language-reference/createsequence.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createsequence.adoc
@@ -38,10 +38,17 @@ Similarly, when you restore a bucket, sequences are restored in accordance with 
 
 == Prerequisites
 
-To execute the CREATE SEQUENCE statement, your client must have 1 of the following privileges:
+To execute this statement, your client must have necessary privileges on the scope where you want to create the sequence.
+The required privilege depends on your xref:clusters:cluster-rbac.adoc#cluster-access-credential-types[cluster access credential type]. 
 
-* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`] privilege on the scope.
-* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Manage Sequences`] privilege on the scope.
+[cols="1a,1a", options="header"]
+|===
+| Credential Type | Privilege 
+| Basic
+| xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`]
+| Advanced
+| xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Manage Sequences`]
+|===
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/createsequence.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createsequence.adoc
@@ -38,7 +38,8 @@ Similarly, when you restore a bucket, sequences are restored in accordance with 
 
 == Prerequisites
 
-To execute the CREATE SEQUENCE statement, the client must have the xref:clusters:manage-database-users.adoc#database-role-write[`Write`] privilege on the scope.
+To execute the `CREATE SEQUENCE` statement, the client must have the `Write` privilege on the scope.
+For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 
 == Syntax
 
@@ -49,7 +50,7 @@ include::{partialsdir}/grammar/ddl.ebnf[tag=create-sequence]
 
 image::n1ql-language-reference/create-sequence.png["Syntax diagram: refer to source code listing", align=left]
 
-The CREATE SCOPE statement provides two possible syntaxes for specifying options for a sequence.
+The `CREATE SCOPE` statement provides two possible syntaxes for specifying options for a sequence.
 
 // TODO: Automatic links in EBNF.
 

--- a/modules/n1ql/pages/n1ql-language-reference/createsequence.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createsequence.adoc
@@ -38,7 +38,7 @@ Similarly, when you restore a bucket, sequences are restored in accordance with 
 
 == Prerequisites
 
-To execute the `CREATE SEQUENCE` statement, the client must have the `Write` privilege on the scope.
+To execute the CREATE SEQUENCE statement, your client must have the `Write` privilege on the scope.
 For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 
 == Syntax
@@ -50,7 +50,7 @@ include::{partialsdir}/grammar/ddl.ebnf[tag=create-sequence]
 
 image::n1ql-language-reference/create-sequence.png["Syntax diagram: refer to source code listing", align=left]
 
-The `CREATE SCOPE` statement provides two possible syntaxes for specifying options for a sequence.
+The CREATE SCOPE statement provides two possible syntaxes for specifying options for a sequence.
 
 // TODO: Automatic links in EBNF.
 

--- a/modules/n1ql/pages/n1ql-language-reference/createsequence.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createsequence.adoc
@@ -38,13 +38,10 @@ Similarly, when you restore a bucket, sequences are restored in accordance with 
 
 == Prerequisites
 
-ifdef::granular-rbac[]
-To execute the CREATE SEQUENCE statement, your client must have the _Query Manage Sequences_ privilege granted on the scope.
-For more details about cluster access privileges, see {authorization-overview}[].
-endif::granular-rbac[]
+To execute the CREATE SEQUENCE statement, your client must have 1 of the following privileges:
 
-To execute the CREATE SEQUENCE statement, your client must have the `Write` privilege on the scope.
-For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
+* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`] privilege on the scope.
+* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Manage Sequences`] privilege on the scope.
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/createsequence.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createsequence.adoc
@@ -38,9 +38,7 @@ Similarly, when you restore a bucket, sequences are restored in accordance with 
 
 == Prerequisites
 
-.RBAC Privileges
-To execute the CREATE SEQUENCE statement, your client must have the _Query Manage Sequences_ privilege granted on the scope.
-For more details about cluster access privileges, see {authorization-overview}[].
+To execute the CREATE SEQUENCE statement, the client must have the xref:clusters:manage-database-users.adoc#database-role-write[`Write`] privilege on the scope.
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/createuser.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createuser.adoc
@@ -10,7 +10,7 @@
 == Purpose
 
 Creating a user is an essential step in managing access to your Couchbase environment. 
-You can use the CREATE USER statement to define a new local user in the Couchbase Server Role-Based Access Control (RBAC) system. 
+You can use the `CREATE USER` statement to define a new local user in the Couchbase Server Role-Based Access Control (RBAC) system. 
 By default, Couchbase Server assigns the user to the local authentication domain.
 
 When you create a user, you can specify their basic attributes such as username, password, full name, and assign them to one or more groups. 
@@ -18,7 +18,7 @@ If you do not specify a group, the user is not assigned to any group by default.
 
 == Prerequisites
 
-To execute the CREATE USER statement, you must have at least one of the following roles:
+To execute the `CREATE USER` statement, you must have at least one of the following roles:
 
 * xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
 * xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]

--- a/modules/n1ql/pages/n1ql-language-reference/createuser.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createuser.adoc
@@ -18,7 +18,7 @@ If you do not specify a group, the user is not assigned to any group by default.
 
 == Prerequisites
 
-To execute this statement in the Capella UI, you must have 1 of the following roles:
+To execute this statement in the Capella UI, you must have one of the following roles:
 
 * xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
 * xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]

--- a/modules/n1ql/pages/n1ql-language-reference/createuser.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createuser.adoc
@@ -10,7 +10,7 @@
 == Purpose
 
 Creating a user is an essential step in managing access to your Couchbase environment. 
-You can use the `CREATE USER` statement to define a new local user in the Couchbase Server Role-Based Access Control (RBAC) system. 
+You can use the CREATE USER statement to define a new local user in the Couchbase Server Role-Based Access Control (RBAC) system. 
 By default, Couchbase Server assigns the user to the local authentication domain.
 
 When you create a user, you can specify their basic attributes such as username, password, full name, and assign them to one or more groups. 
@@ -18,7 +18,7 @@ If you do not specify a group, the user is not assigned to any group by default.
 
 == Prerequisites
 
-To execute the `CREATE USER` statement, you must have at least one of the following roles:
+To execute the CREATE USER statement, you must have at least one of the following roles:
 
 * xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
 * xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]

--- a/modules/n1ql/pages/n1ql-language-reference/createuser.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createuser.adoc
@@ -16,9 +16,13 @@ By default, Couchbase Server assigns the user to the local authentication domain
 When you create a user, you can specify their basic attributes such as username, password, full name, and assign them to one or more groups. 
 If you do not specify a group, the user is not assigned to any group by default.
 
-== RBAC Privileges
+== Prerequisites
 
-To execute the CREATE USER statement, you must be an xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] or xref:projects:project-roles.adoc#project-owner-role[`Project Owner`].
+To execute the CREATE USER statement, you must have at least one of the following roles:
+
+* xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
+* xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]
+* xref:projects:project-roles.adoc#project-cluster-data-reader-writer[`Data Writer`]
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/createuser.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createuser.adoc
@@ -18,13 +18,13 @@ If you do not specify a group, the user is not assigned to any group by default.
 
 == Prerequisites
 
-To execute the CREATE USER statement in the Capella UI, you must have at least 1 of the following roles:
+To execute this statement in the Capella UI, you must have 1 of the following roles:
 
 * xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
 * xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]
 * xref:projects:project-roles.adoc#project-cluster-data-reader-writer[`Data Writer`]
 
-You cannot execute this statement using cluster access credentials.
+NOTE: You cannot execute this statement using xref:clusters:cluster-rbac.adoc[cluster access credentials]. 
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/createuser.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createuser.adoc
@@ -18,11 +18,13 @@ If you do not specify a group, the user is not assigned to any group by default.
 
 == Prerequisites
 
-To execute the CREATE USER statement, you must have at least one of the following roles:
+To execute the CREATE USER statement in the Capella UI, you must have at least 1 of the following roles:
 
 * xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
 * xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]
 * xref:projects:project-roles.adoc#project-cluster-data-reader-writer[`Data Writer`]
+
+You cannot execute this statement using cluster access credentials.
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/delete.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/delete.adoc
@@ -21,6 +21,12 @@ include::partial$n1ql-language-reference/collapsible-style.adoc[]
 
 == Prerequisites
 
+ifdef::granular-rbac[]
+To execute the DELETE statement, your client must have the _Query Delete_ privilege granted on the target keyspace.
+If the statement has any RETURNING clauses that need data read, then the _Query Select_ privilege is also required on the keyspaces referred in the respective clauses.
+For more details about cluster access privileges, see {authorization-overview}[].
+endif::granular-rbac[]
+
 To execute the DELETE statement, your client must have the `Write` privilege on the target keyspace.
 If the statement includes any `RETURNING` clauses that need data read, the client must also have `Read` privileges on the keyspaces referred in the respective clauses.
 For more information about access privileges, see xref:clusters:manage-database-users.adoc[].

--- a/modules/n1ql/pages/n1ql-language-reference/delete.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/delete.adoc
@@ -222,7 +222,7 @@ Refer to xref:clusters:data-service/import-data-documents.adoc#import-sample-dat
 [[Q1]]
 .Delete query containing a WHERE clause
 ====
-This example requires the _Query Delete_ privilege on `hotel`.
+This example requires the `Write` / `Query Delete` privilege on `hotel`.
 
 [source,sqlpp]
 ----
@@ -233,14 +233,14 @@ include::example$dml/delete-all.n1ql[]
 [[Q2]]
 .Delete queries containing a subquery
 ====
-This example requires the _Query Delete_ privilege on `airport` and the _Query Select_ privilege on `pass:c[`beer-sample`]`.
+This example requires the `Write` / `Query Delete` privilege on `airport` and the `Read` / `Query Read` privilege on `pass:c[`beer-sample`]`.
 
 [source,sqlpp]
 ----
 include::example$dml/delete-sub-other.n1ql[]
 ----
 
-This example requires the _Query Delete_ and _Query Select_ privileges on `airport`.
+This example requires `Write` / `Query Delete` and `Read` / `Query Read` privileges on `airport`.
 
 [source,sqlpp]
 ----
@@ -251,7 +251,7 @@ include::example$dml/delete-sub-same.n1ql[]
 [[Q3]]
 .Delete queries containing a RETURNING clause
 ====
-These examples require the _Query Delete_ and _Query Select_ privileges on `hotel`.
+These examples require `Write` / `Query Delete` and `Read` / `Query Read` privileges on `hotel`.
 
 [source,sqlpp]
 ----

--- a/modules/n1ql/pages/n1ql-language-reference/delete.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/delete.adoc
@@ -27,8 +27,9 @@ To execute the DELETE statement, your client must have 1 of the following privil
 * If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`] privilege on the target keyspace.
 If the statement includes any `RETURNING` clauses that need data read, the client must also have xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`]privileges on the keyspaces referred in the respective clauses.
 
-* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Delete`] privilege on the target keyspace.
-If the statement includes any `RETURNING` clauses that need data read, the client must also have xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Select`] privileges on the keyspaces referred in the respective clauses.
+* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Delete`] privilege on the target keyspace.
+If the statement includes any `RETURNING` clauses that need data read, the client must also have 
+xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Select`] privileges on the keyspaces referred in the respective clauses.
 
 .RBAC Examples
 [%collapsible]

--- a/modules/n1ql/pages/n1ql-language-reference/delete.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/delete.adoc
@@ -16,17 +16,14 @@
 include::partial$n1ql-language-reference/horizontal-style.adoc[]
 include::partial$n1ql-language-reference/collapsible-style.adoc[]
 
+[abstract]
 {description}
 
 == Prerequisites
 
-=== RBAC Privileges
-
-To execute the DELETE statement, the client must have the xref:clusters:manage-database-users.adoc#database-role-write[`Write`] privilege granted on the target keyspace.
-
-If the statement has any RETURNING clauses that need data read, then they must also have the xref:clusters:manage-database-users.adoc#database-role-read[`Read`] privilege on the keyspaces referred in the respective clauses.
-
-For more details about cluster access privileges, see {authorization-overview}[].
+To execute the `DELETE` statement, the client must have the `Write` privilege on the target keyspace.
+If the statement has any `RETURNING` clauses that need data read, then they must also have `Read` privileges on the keyspaces referred in the respective clauses.
+For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 
 .RBAC Examples
 [%collapsible]
@@ -80,7 +77,7 @@ returning-clause:: <<returning-clause>> icon:caret-down[]
 You can supply hints to the optimizer within a specially formatted hint comment. 
 For more information, see xref:n1ql-language-reference/optimizer-hints.adoc[].
 
-NOTE: DELETE statements support only index hints. 
+NOTE: `DELETE` statements support only index hints. 
 Other hints, such as join hints and ORDERED hints, are not supported.
 For an example of using an optimizer hint, see <<ex-delete-opt-hint>>.
 
@@ -182,7 +179,7 @@ include::partial$grammar/dql.ebnf[tag=offset-clause]
 
 image::n1ql-language-reference/offset-clause.png["Syntax diagram: refer to source code listing", align=left]
 
-Like the xref:n1ql-language-reference/offset.adoc[OFFSET clause] for a SELECT query, you can include an OFFSET clause in a DELETE statement to specify a number of objects to skip before beginning the deletion.
+Like the xref:n1ql-language-reference/offset.adoc[OFFSET clause] for a SELECT query, you can include an OFFSET clause in a `DELETE` statement to specify a number of objects to skip before beginning the deletion.
 This option can be useful for parallelizing a large delete operation.
 
 You can include the OFFSET clause either before or after the optional LIMIT clause. 

--- a/modules/n1ql/pages/n1ql-language-reference/delete.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/delete.adoc
@@ -21,15 +21,14 @@ include::partial$n1ql-language-reference/collapsible-style.adoc[]
 
 == Prerequisites
 
-ifdef::granular-rbac[]
-To execute the DELETE statement, your client must have the _Query Delete_ privilege granted on the target keyspace.
-If the statement has any RETURNING clauses that need data read, then the _Query Select_ privilege is also required on the keyspaces referred in the respective clauses.
-For more details about cluster access privileges, see {authorization-overview}[].
-endif::granular-rbac[]
 
-To execute the DELETE statement, your client must have the `Write` privilege on the target keyspace.
-If the statement includes any `RETURNING` clauses that need data read, the client must also have `Read` privileges on the keyspaces referred in the respective clauses.
-For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
+To execute the DELETE statement, your client must have 1 of the following privileges:
+
+* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`] privilege on the target keyspace.
+If the statement includes any `RETURNING` clauses that need data read, the client must also have xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`]privileges on the keyspaces referred in the respective clauses.
+
+* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Delete`] privilege on the target keyspace.
+If the statement includes any `RETURNING` clauses that need data read, the client must also have xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Select`] privileges on the keyspaces referred in the respective clauses.
 
 .RBAC Examples
 [%collapsible]

--- a/modules/n1ql/pages/n1ql-language-reference/delete.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/delete.adoc
@@ -21,22 +21,26 @@ include::partial$n1ql-language-reference/collapsible-style.adoc[]
 
 == Prerequisites
 
+To execute this statement, your client must have necessary privileges on the target keyspace.
+The required privileges depend on your xref:clusters:cluster-rbac.adoc#cluster-access-credential-types[cluster access credential type] and whether the statement includes a `RETURNING` clause.
 
-To execute the DELETE statement, your client must have 1 of the following privileges:
-
-* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`] privilege on the target keyspace.
-If the statement includes any `RETURNING` clauses that need data read, the client must also have xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`]privileges on the keyspaces referred in the respective clauses.
-
-* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Delete`] privilege on the target keyspace.
-If the statement includes any `RETURNING` clauses that need data read, the client must also have 
-xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Select`] privileges on the keyspaces referred in the respective clauses.
+[cols="1a,1a,1a", options="header"]
+|===
+| Credential Type | Privilege for DELETE | Privilege for RETURNING 
+| Basic
+| xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`]
+| xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`] on all keyspaces referenced in the clause
+| Advanced
+| xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Delete`]
+| xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Read`] on all keyspaces referenced in the clause
+|===
 
 .RBAC Examples
 [%collapsible]
 ====
 [cols="^25,^25,^25,^25"]
 |===
-| Delete Query Contains | Query Delete Permissions Needed | Query Select Permissions Needed | Example
+| Delete Query Contains | Query Delete Permissions Needed | Query Read Permissions Needed | Example
 
 | WHERE clause
 | Yes

--- a/modules/n1ql/pages/n1ql-language-reference/delete.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/delete.adoc
@@ -22,8 +22,10 @@ include::partial$n1ql-language-reference/collapsible-style.adoc[]
 
 === RBAC Privileges
 
-To execute the DELETE statement, your client must have the _Query Delete_ privilege granted on the target keyspace.
-If the statement has any RETURNING clauses that need data read, then the _Query Select_ privilege is also required on the keyspaces referred in the respective clauses.
+To execute the DELETE statement, the client must have the xref:clusters:manage-database-users.adoc#database-role-write[`Write`] privilege granted on the target keyspace.
+
+If the statement has any RETURNING clauses that need data read, then they must also have the xref:clusters:manage-database-users.adoc#database-role-read[`Read`] privilege on the keyspaces referred in the respective clauses.
+
 For more details about cluster access privileges, see {authorization-overview}[].
 
 .RBAC Examples

--- a/modules/n1ql/pages/n1ql-language-reference/delete.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/delete.adoc
@@ -21,8 +21,8 @@ include::partial$n1ql-language-reference/collapsible-style.adoc[]
 
 == Prerequisites
 
-To execute the `DELETE` statement, the client must have the `Write` privilege on the target keyspace.
-If the statement has any `RETURNING` clauses that need data read, then they must also have `Read` privileges on the keyspaces referred in the respective clauses.
+To execute the DELETE statement, your client must have the `Write` privilege on the target keyspace.
+If the statement includes any `RETURNING` clauses that need data read, the client must also have `Read` privileges on the keyspaces referred in the respective clauses.
 For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 
 .RBAC Examples
@@ -77,7 +77,7 @@ returning-clause:: <<returning-clause>> icon:caret-down[]
 You can supply hints to the optimizer within a specially formatted hint comment. 
 For more information, see xref:n1ql-language-reference/optimizer-hints.adoc[].
 
-NOTE: `DELETE` statements support only index hints. 
+NOTE: DELETE statements support only index hints. 
 Other hints, such as join hints and ORDERED hints, are not supported.
 For an example of using an optimizer hint, see <<ex-delete-opt-hint>>.
 
@@ -179,7 +179,7 @@ include::partial$grammar/dql.ebnf[tag=offset-clause]
 
 image::n1ql-language-reference/offset-clause.png["Syntax diagram: refer to source code listing", align=left]
 
-Like the xref:n1ql-language-reference/offset.adoc[OFFSET clause] for a SELECT query, you can include an OFFSET clause in a `DELETE` statement to specify a number of objects to skip before beginning the deletion.
+Like the xref:n1ql-language-reference/offset.adoc[OFFSET clause] for a SELECT query, you can include an OFFSET clause in a DELETE statement to specify a number of objects to skip before beginning the deletion.
 This option can be useful for parallelizing a large delete operation.
 
 You can include the OFFSET clause either before or after the optional LIMIT clause. 

--- a/modules/n1ql/pages/n1ql-language-reference/dropbucket.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropbucket.adoc
@@ -25,7 +25,7 @@ WARNING: This operation is irreversible, so use this statement with caution.
 
 == Prerequisites
 
-To execute this statement in the Capella UI, you must have 1 of the following roles:
+To execute this statement in the Capella UI, you must have one of the following roles:
 
 * xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
 * xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]

--- a/modules/n1ql/pages/n1ql-language-reference/dropbucket.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropbucket.adoc
@@ -17,7 +17,7 @@
 
 == Purpose
 
-Use the `DROP BUCKET` statement to permanently delete an existing bucket from your Couchbase cluster.
+Use the DROP BUCKET statement to permanently delete an existing bucket from your Couchbase cluster.
 Dropping a bucket deletes all data in the bucket, including documents, scopes, and collections.
 It also deletes all associated indexes, metadata, and other bucket resources.
 
@@ -25,7 +25,7 @@ WARNING: This operation is irreversible, so use this statement with caution.
 
 == Prerequisites
 
-To execute the `DROP BUCKET` statement, you must have at least one of the following roles:
+To execute the DROP BUCKET statement, you must have at least one of the following roles:
 
 * xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
 * xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]

--- a/modules/n1ql/pages/n1ql-language-reference/dropbucket.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropbucket.adoc
@@ -25,13 +25,13 @@ WARNING: This operation is irreversible, so use this statement with caution.
 
 == Prerequisites
 
-To execute the DROP BUCKET statement in the Capella UI, you must have at least 1 of the following roles:
+To execute this statement in the Capella UI, you must have 1 of the following roles:
 
 * xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
 * xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]
 * xref:projects:project-roles.adoc#project-cluster-data-reader-writer[`Data Writer`]
 
-You cannot execute this statement using cluster access credentials. 
+NOTE: You cannot execute this statement using xref:clusters:cluster-rbac.adoc[cluster access credentials]. 
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/dropbucket.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropbucket.adoc
@@ -25,11 +25,13 @@ WARNING: This operation is irreversible, so use this statement with caution.
 
 == Prerequisites
 
-To execute the DROP BUCKET statement, you must have at least one of the following roles:
+To execute the DROP BUCKET statement in the Capella UI, you must have at least 1 of the following roles:
 
 * xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
 * xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]
 * xref:projects:project-roles.adoc#project-cluster-data-reader-writer[`Data Writer`]
+
+You cannot execute this statement using cluster access credentials. 
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/dropbucket.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropbucket.adoc
@@ -17,21 +17,19 @@
 
 == Purpose
 
-Use the DROP BUCKET statement to permanently delete an existing bucket from your Couchbase cluster.
+Use the `DROP BUCKET` statement to permanently delete an existing bucket from your Couchbase cluster.
 Dropping a bucket deletes all data in the bucket, including documents, scopes, and collections.
 It also deletes all associated indexes, metadata, and other bucket resources.
 
 WARNING: This operation is irreversible, so use this statement with caution.
 
-== RBAC Privileges
+== Prerequisites
 
-Only administrators with the following roles can execute the DROP BUCKET statement:
+To execute the `DROP BUCKET` statement, you must have at least one of the following roles:
 
-* Full Admin
-* Cluster Admin
-* Bucket Admin (if privileges are extended to the specific bucket or all buckets on the cluster)
-
-For more information about roles and privileges, see {roles}[Roles].
+* xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
+* xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]
+* xref:projects:project-roles.adoc#project-cluster-data-reader-writer[`Data Writer`]
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/dropcollection.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropcollection.adoc
@@ -20,8 +20,17 @@ The `DROP COLLECTION` statement enables you to delete a named collection from a 
 
 == Prerequisites
 
-To execute the DROP COLLECTION statement, your client must have the `Write` privilege on the keyspace.
-For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
+To execute this statement, your client must have necessary privileges on the keyspace that contains the collection.
+The required privilege depends on your xref:clusters:cluster-rbac.adoc#cluster-access-credential-types[cluster access credential type]. 
+
+[cols="1a,1a", options="header"]
+|===
+| Credential Type | Privilege 
+| Basic
+| xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`]
+| Advanced
+| xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Scope Admin`]
+|===
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/dropcollection.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropcollection.adoc
@@ -18,6 +18,11 @@ include::partial$n1ql-language-reference/horizontal-style.adoc[]
 [abstract]
 The `DROP COLLECTION` statement enables you to delete a named collection from a scope.
 
+== Prerequisites
+
+To execute the DROP COLLECTION statement, your client must have the `Write` privilege on the keyspace.
+For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
+
 == Syntax
 
 [source,ebnf]

--- a/modules/n1ql/pages/n1ql-language-reference/dropfunction.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropfunction.adoc
@@ -12,12 +12,21 @@ include::partial$n1ql-language-reference/horizontal-style.adoc[]
 
 == Prerequisites
 
-To execute the `DROP FUNCTION` statement, your client must have 1 of the following privileges:
+To execute this statement, your client must have necessary privileges depending on your xref:clusters:cluster-rbac.adoc#cluster-access-credential-types[cluster access credential type] and whether the function is global or scoped.
 
-* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`] privilege on the keyspace or scope.
-* If you're using advanced cluster access credentials, your client must have:
-** The xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Global Function Manage`] privilege to delete a global function.
-** The xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Manage`] privilege to delete a function defined within a specific scope.
+[cols="1a,1,1a", options="header"]
+|===
+| Credential Type | Function Type | Privilege 
+| Basic
+| Global or scoped
+| xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`]
+| Advanced
+| Global
+| xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Global Function Manage`] 
+| Advanced
+| Scoped
+| xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Manage`]
+|===
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/dropfunction.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropfunction.adoc
@@ -12,11 +12,12 @@ include::partial$n1ql-language-reference/horizontal-style.adoc[]
 
 == Prerequisites
 
-To execute the `DROP FUNCTION` statement, you must have at least one of the following roles:
+To execute the `DROP FUNCTION` statement, your client must have 1 of the following privileges:
 
-* xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
-* xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]
-* xref:projects:project-roles.adoc#project-cluster-data-reader-writer[`Data Writer`]
+* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`] privilege on the keyspace or scope.
+* If you're using advanced cluster access credentials, your client must have:
+** The xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Global Function Manage`] privilege to delete a global function.
+** The xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Manage`] privilege to delete a function defined within a specific scope.
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/dropfunction.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropfunction.adoc
@@ -12,7 +12,11 @@ include::partial$n1ql-language-reference/horizontal-style.adoc[]
 
 == Prerequisites
 
-* To manage user-defined functions on your operational cluster, you must have the xref:projects:project-roles.adoc#project-owner-role[`Project Owner`] or the xref:projects:project-roles.adoc#project-cluster-data-reader-writer[`Cluster Data Reader/Writer`] role.
+To execute the `DROP FUNCTION` statement, you must have at least one of the following roles:
+
+* xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
+* xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]
+* xref:projects:project-roles.adoc#project-cluster-data-reader-writer[`Data Writer`]
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/dropgroup.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropgroup.adoc
@@ -14,9 +14,13 @@ You can use this statement to clean up groups that are no longer needed.
 Deleting a group removes all roles and privileges associated with the group.
 Users in the deleted group no longer inherit the roles granted to it.
 
-== RBAC Privileges
+== Prerequisites
 
-To execute the DROP GROUP statement, you must be an xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] or xref:projects:project-roles.adoc#project-owner-role[`Project Owner`].
+To execute the `DROP GROUP` statement, you must have at least one of the following roles:
+
+* xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
+* xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]
+* xref:projects:project-roles.adoc#project-cluster-data-reader-writer[`Data Writer`]
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/dropgroup.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropgroup.adoc
@@ -16,13 +16,13 @@ Users in the deleted group no longer inherit the roles granted to it.
 
 == Prerequisites
 
-To execute the DROP GROUP statement in the Capella UI, you must have at least 1 of the following roles:
+To execute this statement in the Capella UI, you must have 1 of the following roles:
 
 * xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
 * xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]
 * xref:projects:project-roles.adoc#project-cluster-data-reader-writer[`Data Writer`]
 
-You cannot execute this statement using cluster access credentials. 
+NOTE: You cannot execute this statement using xref:clusters:cluster-rbac.adoc[cluster access credentials]. 
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/dropgroup.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropgroup.adoc
@@ -16,7 +16,7 @@ Users in the deleted group no longer inherit the roles granted to it.
 
 == Prerequisites
 
-To execute the `DROP GROUP` statement, you must have at least one of the following roles:
+To execute the DROP GROUP statement, you must have at least one of the following roles:
 
 * xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
 * xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]

--- a/modules/n1ql/pages/n1ql-language-reference/dropgroup.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropgroup.adoc
@@ -16,11 +16,13 @@ Users in the deleted group no longer inherit the roles granted to it.
 
 == Prerequisites
 
-To execute the DROP GROUP statement, you must have at least one of the following roles:
+To execute the DROP GROUP statement in the Capella UI, you must have at least 1 of the following roles:
 
 * xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
 * xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]
 * xref:projects:project-roles.adoc#project-cluster-data-reader-writer[`Data Writer`]
+
+You cannot execute this statement using cluster access credentials. 
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/dropgroup.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropgroup.adoc
@@ -16,7 +16,7 @@ Users in the deleted group no longer inherit the roles granted to it.
 
 == Prerequisites
 
-To execute this statement in the Capella UI, you must have 1 of the following roles:
+To execute this statement in the Capella UI, you must have one of the following roles:
 
 * xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
 * xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]

--- a/modules/n1ql/pages/n1ql-language-reference/dropindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropindex.adoc
@@ -18,25 +18,18 @@ include::partial$n1ql-language-reference/horizontal-style.adoc[]
 {description}
 Dropping an index that has replicas will drop all of the replica indexes too.
 
-The {drop-vector-index}[DROP VECTOR INDEX] statement is a synonym for the DROP INDEX statement.
+The {drop-vector-index}[DROP VECTOR INDEX] statement is a synonym for the `DROP INDEX` statement.
 Both statements have the same functionality.
 
 [NOTE]
 To drop a primary index, use the {drop-primary-index}[DROP PRIMARY INDEX] statement.
-For compatibility with legacy versions of Couchbase Server, you can also use DROP INDEX or DROP VECTOR INDEX to drop a named primary index.
+For compatibility with legacy versions of Couchbase Server, you can also use `DROP INDEX` or `DROP VECTOR INDEX` to drop a named primary index.
 
 // tag::prerequisites[]
 == Prerequisites
 
-To use the {doctitle} statement, the client must have the `Write` privilege on the scope.
+To use the `{doctitle}` statement, the client must have the `Write` privilege on the keyspace or bucket.
 For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
-
-
-
-
-your client must have the `Query Manage Index` privilege on the keyspace or bucket.
-For more information about cluster access privileges, see
-{authorization-overview}[].
 // end::prerequisites[]
 
 == Syntax
@@ -49,7 +42,7 @@ include::partial$grammar/ddl.ebnf[tag=drop-index]
 image::n1ql-language-reference/drop-index.png["Syntax diagram: see source code listing", align=left]
 
 //tag::syntax-arguments[]
-The {doctitle} statement provides two possible syntaxes for specifying the index and the keyspace where the index is located.
+The `{doctitle}` statement provides two possible syntaxes for specifying the index and the keyspace where the index is located.
 
 // TODO: Automatic links in EBNF.
 
@@ -296,7 +289,7 @@ The `USING GSI` keywords are optional and may be omitted.
 //tag::usage[]
 == Usage
 
-When using memory-optimized indexes, {doctitle} is an expensive operation and may take a few minutes to complete.
+When using memory-optimized indexes, `{doctitle}` is an expensive operation and may take a few minutes to complete.
 
 If you drop an index with replicas while one of the index nodes is failed over, then only the replicas in the active index nodes are dropped.
 If the failed-over index node is recovered, then the orphan replica will be dropped when this failed-over indexer is added back to cluster.

--- a/modules/n1ql/pages/n1ql-language-reference/dropindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropindex.adoc
@@ -31,7 +31,7 @@ For compatibility with legacy versions of Couchbase Server, you can also use DRO
 To execute the {doctitle} statement, your client must have 1 of the following privileges:
 
 * If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`] privilege on the keyspace or bucket.
-* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Index`] privilege on the keyspace or bucket.
+* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Index`] privilege on the keyspace or bucket.
 
 // end::prerequisites[]
 

--- a/modules/n1ql/pages/n1ql-language-reference/dropindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropindex.adoc
@@ -28,10 +28,13 @@ For compatibility with legacy versions of Couchbase Server, you can also use DRO
 // tag::prerequisites[]
 == Prerequisites
 
-[discrete]
-===== RBAC Privileges
+To use the {doctitle} statement, the client must have the `Write` privilege on the scope.
+For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 
-To use the {doctitle} statement, your client must have the `Query Manage Index` privilege on the keyspace or bucket.
+
+
+
+your client must have the `Query Manage Index` privilege on the keyspace or bucket.
 For more information about cluster access privileges, see
 {authorization-overview}[].
 // end::prerequisites[]

--- a/modules/n1ql/pages/n1ql-language-reference/dropindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropindex.adoc
@@ -18,17 +18,17 @@ include::partial$n1ql-language-reference/horizontal-style.adoc[]
 {description}
 Dropping an index that has replicas will drop all of the replica indexes too.
 
-The {drop-vector-index}[DROP VECTOR INDEX] statement is a synonym for the `DROP INDEX` statement.
+The {drop-vector-index}[DROP VECTOR INDEX] statement is a synonym for the DROP INDEX statement.
 Both statements have the same functionality.
 
 [NOTE]
 To drop a primary index, use the {drop-primary-index}[DROP PRIMARY INDEX] statement.
-For compatibility with legacy versions of Couchbase Server, you can also use `DROP INDEX` or `DROP VECTOR INDEX` to drop a named primary index.
+For compatibility with legacy versions of Couchbase Server, you can also use DROP INDEX or DROP VECTOR INDEX to drop a named primary index.
 
 // tag::prerequisites[]
 == Prerequisites
 
-To use the `{doctitle}` statement, the client must have the `Write` privilege on the keyspace or bucket.
+To use the {doctitle} statement, your client must have the `Write` privilege on the keyspace or bucket.
 For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 // end::prerequisites[]
 
@@ -42,7 +42,7 @@ include::partial$grammar/ddl.ebnf[tag=drop-index]
 image::n1ql-language-reference/drop-index.png["Syntax diagram: see source code listing", align=left]
 
 //tag::syntax-arguments[]
-The `{doctitle}` statement provides two possible syntaxes for specifying the index and the keyspace where the index is located.
+The {doctitle} statement provides two possible syntaxes for specifying the index and the keyspace where the index is located.
 
 // TODO: Automatic links in EBNF.
 
@@ -289,7 +289,7 @@ The `USING GSI` keywords are optional and may be omitted.
 //tag::usage[]
 == Usage
 
-When using memory-optimized indexes, `{doctitle}` is an expensive operation and may take a few minutes to complete.
+When using memory-optimized indexes, {doctitle} is an expensive operation and may take a few minutes to complete.
 
 If you drop an index with replicas while one of the index nodes is failed over, then only the replicas in the active index nodes are dropped.
 If the failed-over index node is recovered, then the orphan replica will be dropped when this failed-over indexer is added back to cluster.

--- a/modules/n1ql/pages/n1ql-language-reference/dropindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropindex.adoc
@@ -28,6 +28,11 @@ For compatibility with legacy versions of Couchbase Server, you can also use DRO
 // tag::prerequisites[]
 == Prerequisites
 
+ifdef::granular-rbac[]
+To use the {doctitle} statement, your client must have the `Query Manage Index` privilege on the keyspace or bucket.
+For more information about cluster access privileges, see {authorization-overview}[].
+endif::granular-rbac[]
+
 To use the {doctitle} statement, your client must have the `Write` privilege on the keyspace or bucket.
 For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 // end::prerequisites[]

--- a/modules/n1ql/pages/n1ql-language-reference/dropindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropindex.adoc
@@ -28,10 +28,17 @@ For compatibility with legacy versions of Couchbase Server, you can also use DRO
 // tag::prerequisites[]
 == Prerequisites
 
-To execute the {doctitle} statement, your client must have 1 of the following privileges:
+To execute this statement, your client must have necessary privileges on the keyspace that contains the index.
+The required privilege depends on your xref:clusters:cluster-rbac.adoc#cluster-access-credential-types[cluster access credential type]. 
 
-* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`] privilege on the keyspace or bucket.
-* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Index`] privilege on the keyspace or bucket.
+[cols="1a,1a", options="header"]
+|===
+| Credential Type | Privilege 
+| Basic
+| xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`]
+| Advanced
+| xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Index`]
+|===
 
 // end::prerequisites[]
 

--- a/modules/n1ql/pages/n1ql-language-reference/dropindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropindex.adoc
@@ -28,13 +28,11 @@ For compatibility with legacy versions of Couchbase Server, you can also use DRO
 // tag::prerequisites[]
 == Prerequisites
 
-ifdef::granular-rbac[]
-To use the {doctitle} statement, your client must have the `Query Manage Index` privilege on the keyspace or bucket.
-For more information about cluster access privileges, see {authorization-overview}[].
-endif::granular-rbac[]
+To execute the {doctitle} statement, your client must have 1 of the following privileges:
 
-To use the {doctitle} statement, your client must have the `Write` privilege on the keyspace or bucket.
-For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
+* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`] privilege on the keyspace or bucket.
+* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Index`] privilege on the keyspace or bucket.
+
 // end::prerequisites[]
 
 == Syntax

--- a/modules/n1ql/pages/n1ql-language-reference/dropprimaryindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropprimaryindex.adoc
@@ -21,8 +21,8 @@ NOTE: For compatibility with legacy versions of Couchbase Server, you can also u
 [discrete]
 ===== RBAC Privileges
 
-To execute the DROP PRIMARY INDEX statement, your client must have the `Query Manage Index` privilege granted on the keyspace.
-For more information about cluster access privileges, see {roles}[].
+To execute the `DROP PRIMARY INDEX` statement, the client must have the `Write` privilege on the keyspace.
+For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/dropprimaryindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropprimaryindex.adoc
@@ -21,7 +21,7 @@ NOTE: For compatibility with legacy versions of Couchbase Server, you can also u
 [discrete]
 ===== RBAC Privileges
 
-To execute the `DROP PRIMARY INDEX` statement, the client must have the `Write` privilege on the keyspace.
+To execute the DROP PRIMARY INDEX statement, your client must have the `Write` privilege on the keyspace.
 For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 
 == Syntax

--- a/modules/n1ql/pages/n1ql-language-reference/dropprimaryindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropprimaryindex.adoc
@@ -18,11 +18,17 @@ NOTE: For compatibility with legacy versions of Couchbase Server, you can also u
 
 == Prerequisites
 
+To execute this statement, your client must have necessary privileges on the keyspace that contains the primary index.
+The required privilege depends on your xref:clusters:cluster-rbac.adoc#cluster-access-credential-types[cluster access credential type]. 
 
-To execute the DROP PRIMARY INDEX  statement, your client must have 1 of the following privileges:
-
-* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`] privilege on the keyspace.
-* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Index`] privilege on the keyspace.
+[cols="1a,1a", options="header"]
+|===
+| Credential Type | Privilege 
+| Basic
+| xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`]
+| Advanced
+| xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Index`]
+|===
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/dropprimaryindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropprimaryindex.adoc
@@ -22,7 +22,7 @@ NOTE: For compatibility with legacy versions of Couchbase Server, you can also u
 To execute the DROP PRIMARY INDEX  statement, your client must have 1 of the following privileges:
 
 * If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`] privilege on the keyspace.
-* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Index`] privilege on the keyspace.
+* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Index`] privilege on the keyspace.
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/dropprimaryindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropprimaryindex.adoc
@@ -18,13 +18,11 @@ NOTE: For compatibility with legacy versions of Couchbase Server, you can also u
 
 == Prerequisites
 
-ifdef::granular-rbac[]
-To execute the DROP PRIMARY INDEX statement, your client must have the `Query Manage Index` privilege granted on the keyspace.
-For more information about cluster access privileges, see {roles}[].
-endif::granular-rbac[]
 
-To execute the DROP PRIMARY INDEX statement, your client must have the `Write` privilege on the keyspace.
-For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
+To execute the DROP PRIMARY INDEX  statement, your client must have 1 of the following privileges:
+
+* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`] privilege on the keyspace.
+* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Index`] privilege on the keyspace.
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/dropprimaryindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropprimaryindex.adoc
@@ -18,8 +18,10 @@ NOTE: For compatibility with legacy versions of Couchbase Server, you can also u
 
 == Prerequisites
 
-[discrete]
-===== RBAC Privileges
+ifdef::granular-rbac[]
+To execute the DROP PRIMARY INDEX statement, your client must have the `Query Manage Index` privilege granted on the keyspace.
+For more information about cluster access privileges, see {roles}[].
+endif::granular-rbac[]
 
 To execute the DROP PRIMARY INDEX statement, your client must have the `Write` privilege on the keyspace.
 For more information about access privileges, see xref:clusters:manage-database-users.adoc[].

--- a/modules/n1ql/pages/n1ql-language-reference/dropscope.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropscope.adoc
@@ -17,6 +17,11 @@ include::partial$n1ql-language-reference/horizontal-style.adoc[]
 [abstract]
 The `DROP SCOPE` statement enables you to delete a scope.
 
+== Prerequisites
+
+To execute the DROP SCOPE statement, your client must have the `Write` privilege on the keyspace.
+For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
+
 == Syntax
 
 [source,ebnf]

--- a/modules/n1ql/pages/n1ql-language-reference/dropscope.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropscope.adoc
@@ -19,8 +19,17 @@ The `DROP SCOPE` statement enables you to delete a scope.
 
 == Prerequisites
 
-To execute the DROP SCOPE statement, your client must have the `Write` privilege on the keyspace.
-For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
+To execute this statement, your client must have necessary privileges on the keyspace that contains the scope.
+The required privilege depends on your xref:clusters:cluster-rbac.adoc#cluster-access-credential-types[cluster access credential type]. 
+
+[cols="1a,1a", options="header"]
+|===
+| Credential Type | Privilege 
+| Basic
+| xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`]
+| Advanced
+| xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Scope Admin`]
+|===
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/dropsequence.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropsequence.adoc
@@ -24,7 +24,7 @@ include::./sequenceops.adoc[tags=overview]
 To execute the DROP SEQUENCE statement, your client must have 1 of the following privileges:
 
 * If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`] privilege on the scope.
-* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Manage Sequences`] privilege on the scope.
+* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Manage Sequences`] privilege on the scope.
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/dropsequence.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropsequence.adoc
@@ -21,13 +21,10 @@ include::./sequenceops.adoc[tags=overview]
 
 == Prerequisites
 
-ifdef::granular-rbac[]
-To execute the DROP SEQUENCE statement, your client must have the _Query Manage Sequences_ privilege granted on the scope.
-For more details about cluster access privileges, see {authorization-overview}[].
-endif::granular-rbac[]
+To execute the DROP SEQUENCE statement, your client must have 1 of the following privileges:
 
-To execute the DROP SEQUENCE statement, your client must have the `Write` privilege on the scope.
-For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
+* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`] privilege on the scope.
+* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Manage Sequences`] privilege on the scope.
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/dropsequence.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropsequence.adoc
@@ -21,7 +21,7 @@ include::./sequenceops.adoc[tags=overview]
 
 == Prerequisites
 
-To execute the `DROP SEQUENCE` statement, the client must have the `Write` privilege on the scope.
+To execute the DROP SEQUENCE statement, your client must have the `Write` privilege on the scope.
 For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 
 == Syntax

--- a/modules/n1ql/pages/n1ql-language-reference/dropsequence.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropsequence.adoc
@@ -21,6 +21,11 @@ include::./sequenceops.adoc[tags=overview]
 
 == Prerequisites
 
+ifdef::granular-rbac[]
+To execute the DROP SEQUENCE statement, your client must have the _Query Manage Sequences_ privilege granted on the scope.
+For more details about cluster access privileges, see {authorization-overview}[].
+endif::granular-rbac[]
+
 To execute the DROP SEQUENCE statement, your client must have the `Write` privilege on the scope.
 For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 

--- a/modules/n1ql/pages/n1ql-language-reference/dropsequence.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropsequence.adoc
@@ -21,10 +21,17 @@ include::./sequenceops.adoc[tags=overview]
 
 == Prerequisites
 
-To execute the DROP SEQUENCE statement, your client must have 1 of the following privileges:
+To execute this statement, your client must have necessary privileges on the scope that contains the sequence.
+The required privilege depends on your xref:clusters:cluster-rbac.adoc#cluster-access-credential-types[cluster access credential type]. 
 
-* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`] privilege on the scope.
-* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Manage Sequences`] privilege on the scope.
+[cols="1a,1a", options="header"]
+|===
+| Credential Type | Privilege 
+| Basic
+| xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`]
+| Advanced
+| xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Manage Sequences`]
+|===
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/dropsequence.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropsequence.adoc
@@ -21,9 +21,8 @@ include::./sequenceops.adoc[tags=overview]
 
 == Prerequisites
 
-.RBAC Privileges
-To execute the DROP SEQUENCE statement, your client must have the _Query Manage Sequences_ privilege granted on the scope.
-For more details about cluster access privileges, see {authorization-overview}[].
+To execute the `DROP SEQUENCE` statement, the client must have the `Write` privilege on the scope.
+For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/dropuser.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropuser.adoc
@@ -14,11 +14,13 @@ It removes the user from all groups and revokes all roles and privileges assigne
 
 == Prerequisites
 
-To execute the DROP USER statement, you must have at least one of the following roles:
+To execute the DROP USER statement in the Capella UI, you must have at least one of the following roles:
 
 * xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
 * xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]
 * xref:projects:project-roles.adoc#project-cluster-data-reader-writer[`Data Writer`]
+
+You cannot execute this statement using cluster access credentials.
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/dropuser.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropuser.adoc
@@ -14,13 +14,13 @@ It removes the user from all groups and revokes all roles and privileges assigne
 
 == Prerequisites
 
-To execute the DROP USER statement in the Capella UI, you must have at least one of the following roles:
+To execute this statement in the Capella UI, you must have 1 of the following roles:
 
 * xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
 * xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]
 * xref:projects:project-roles.adoc#project-cluster-data-reader-writer[`Data Writer`]
 
-You cannot execute this statement using cluster access credentials.
+NOTE: You cannot execute this statement using xref:clusters:cluster-rbac.adoc[cluster access credentials]. 
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/dropuser.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropuser.adoc
@@ -14,7 +14,7 @@ It removes the user from all groups and revokes all roles and privileges assigne
 
 == Prerequisites
 
-To execute this statement in the Capella UI, you must have 1 of the following roles:
+To execute this statement in the Capella UI, you must have one of the following roles:
 
 * xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
 * xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]

--- a/modules/n1ql/pages/n1ql-language-reference/dropuser.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropuser.adoc
@@ -12,9 +12,13 @@
 This statement permanently removes a user from the Couchbase Server Role-Based Access Control (RBAC) system.
 It removes the user from all groups and revokes all roles and privileges assigned to that user.
 
-== RBAC Privileges
+== Prerequisites
 
-To execute the DROP USER statement, you must be an xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] or xref:projects:project-roles.adoc#project-owner-role[`Project Owner`].
+To execute the `DROP USER` statement, you must have at least one of the following roles:
+
+* xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
+* xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]
+* xref:projects:project-roles.adoc#project-cluster-data-reader-writer[`Data Writer`]
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/dropuser.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropuser.adoc
@@ -14,7 +14,7 @@ It removes the user from all groups and revokes all roles and privileges assigne
 
 == Prerequisites
 
-To execute the `DROP USER` statement, you must have at least one of the following roles:
+To execute the DROP USER statement, you must have at least one of the following roles:
 
 * xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
 * xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]

--- a/modules/n1ql/pages/n1ql-language-reference/dropvectorindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropvectorindex.adoc
@@ -19,12 +19,12 @@ include::partial$n1ql-language-reference/horizontal-style.adoc[]
 {description}
 Dropping an index that has replicas will drop all of the replica indexes too.
 
-The {drop-index}[DROP INDEX] statement is a synonym for the `DROP VECTOR INDEX` statement.
+The {drop-index}[DROP INDEX] statement is a synonym for the DROP VECTOR INDEX statement.
 Both statements have the same functionality.
 
 [NOTE]
 To drop a primary index, use the {drop-primary-index}[DROP PRIMARY INDEX] statement.
-For compatibility with legacy versions of Couchbase Server, you can also use `DROP INDEX` or `DROP VECTOR INDEX` to drop a named primary index.
+For compatibility with legacy versions of Couchbase Server, you can also use DROP INDEX or DROP VECTOR INDEX to drop a named primary index.
 
 include::dropindex.adoc[tags=prerequisites]
 

--- a/modules/n1ql/pages/n1ql-language-reference/dropvectorindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropvectorindex.adoc
@@ -19,12 +19,12 @@ include::partial$n1ql-language-reference/horizontal-style.adoc[]
 {description}
 Dropping an index that has replicas will drop all of the replica indexes too.
 
-The {drop-index}[DROP INDEX] statement is a synonym for the DROP VECTOR INDEX statement.
+The {drop-index}[DROP INDEX] statement is a synonym for the `DROP VECTOR INDEX` statement.
 Both statements have the same functionality.
 
 [NOTE]
 To drop a primary index, use the {drop-primary-index}[DROP PRIMARY INDEX] statement.
-For compatibility with legacy versions of Couchbase Server, you can also use DROP INDEX or DROP VECTOR INDEX to drop a named primary index.
+For compatibility with legacy versions of Couchbase Server, you can also use `DROP INDEX` or `DROP VECTOR INDEX` to drop a named primary index.
 
 include::dropindex.adoc[tags=prerequisites]
 

--- a/modules/n1ql/pages/n1ql-language-reference/execfunction.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/execfunction.adoc
@@ -21,7 +21,11 @@ If you do this, error `10101: Function not found` is generated.
 
 == Prerequisites
 
-* To manage user-defined functions on your operational cluster, you must have the xref:projects:project-roles.adoc#project-owner-role[`Project Owner`] or the xref:projects:project-roles.adoc#project-cluster-data-reader-writer[`Cluster Data Reader/Writer`] role.
+To run the `EXECUTE FUNCTION` statement, you must have at least one of the following roles:
+
+* xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
+* xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]
+* xref:projects:project-roles.adoc#project-cluster-data-reader-writer[`Data Writer`]
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/execfunction.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/execfunction.adoc
@@ -21,12 +21,22 @@ If you do this, error `10101: Function not found` is generated.
 
 == Prerequisites
 
-To execute the `EXECUTE FUNCTION` statement, your client must have 1 of the following privileges:
+To execute this statement, your client must have specific privileges on the target keyspace or scope.
+The required privileges depend on your xref:clusters:cluster-rbac.adoc#cluster-access-credential-types[cluster access credential type] and whether the function is global or scoped.
 
-* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`] privilege on the keyspace or scope.
-* If you're using advanced cluster access credentials, your client must have:
-** The xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Global Function Execute`] privilege to execute a global function.
-** The xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Execute`] privilege to execute a function defined within a specific scope.
+[cols="1a,1,1a", options="header"]
+|===
+| Credential Type | Function Type | Privilege 
+| Basic
+| Global or scoped
+| xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`]
+| Advanced
+| Global
+| xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Global Function Execute`] 
+| Advanced
+| Scoped
+| xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Execute`]
+|===
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/execfunction.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/execfunction.adoc
@@ -21,8 +21,7 @@ If you do this, error `10101: Function not found` is generated.
 
 == Prerequisites
 
-To execute this statement, your client must have specific privileges on the target keyspace or scope.
-The required privileges depend on your xref:clusters:cluster-rbac.adoc#cluster-access-credential-types[cluster access credential type] and whether the function is global or scoped.
+To execute this statement, your client must have necessary privileges depending on your xref:clusters:cluster-rbac.adoc#cluster-access-credential-types[cluster access credential type] and whether the function is global or scoped.
 
 [cols="1a,1,1a", options="header"]
 |===

--- a/modules/n1ql/pages/n1ql-language-reference/execfunction.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/execfunction.adoc
@@ -21,11 +21,12 @@ If you do this, error `10101: Function not found` is generated.
 
 == Prerequisites
 
-To run the `EXECUTE FUNCTION` statement, you must have at least one of the following roles:
+To execute the `EXECUTE FUNCTION` statement, your client must have 1 of the following privileges:
 
-* xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
-* xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]
-* xref:projects:project-roles.adoc#project-cluster-data-reader-writer[`Data Writer`]
+* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`] privilege on the keyspace or scope.
+* If you're using advanced cluster access credentials, your client must have:
+** The xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Global Function Execute`] privilege to execute a global function.
+** The xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Execute`] privilege to execute a function defined within a specific scope.
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/explain.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/explain.adoc
@@ -11,15 +11,13 @@ include::partial$n1ql-language-reference/collapsible-style.adoc[]
 
 == Prerequisites
 
-ifdef::granular-rbac[]
-To execute the EXPLAIN statement, your client must have the privileges required for the {sqlpp} statement that is being explained.
-For more details about cluster access privileges, see xref:clusters:manage-database-users.adoc[].
-endif::granular-rbac[]
+Irrespective of the type of cluster access credentials you are using (basic or advanced), your client must have the same privileges required to execute the query being explained.
 
-To execute the EXPLAIN statement, your client must have the same privileges required to execute the query being explained.
-For example, if you are explaining an INSERT statement, the client must have the `Write` privilege on the target keyspace.
+For example, if you're using basic cluster access credentials and if you are explaining an INSERT statement, the client must have the `Write` privilege on the target keyspace. 
 
-For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
+Similarly, if you're using advanced cluster access credentials and if you are explaining an INSERT statement, the client must have the `Query Insert` privilege on the target keyspace.
+
+For more information about cluster access privileges, see xref:clusters:cluster-rbac.adoc[].
 
 .RBAC Examples
 [%collapsible]

--- a/modules/n1ql/pages/n1ql-language-reference/explain.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/explain.adoc
@@ -11,14 +11,19 @@ include::partial$n1ql-language-reference/collapsible-style.adoc[]
 
 == Prerequisites
 
-To execute the `EXPLAIN` statement, your client must have the same privileges required to run the query being explained, regardless of whether you use basic or advanced cluster access credentials.
+To execute this statement, your client must have the same privileges required to run the query being explained.
+The required privileges depend on your xref:clusters:cluster-rbac.adoc#cluster-access-credential-types[cluster access credential type].
 
 For example, to explain an `INSERT` statement, your client must have:
 
-* The `Write` privilege on the target keyspace, if you're using basic cluster access credentials.
-* The `Query Insert` privilege on the target keyspace, if you're using advanced cluster access credentials.
-
-For more information about access privileges, see xref:clusters:cluster-rbac.adoc[Cluster Access].
+[cols="1a,1a", options="header"]
+|===
+| Credential Type | Privilege 
+| Basic
+| xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`]
+| Advanced
+| xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Insert`]
+|===
 
 .RBAC Examples
 [%collapsible]
@@ -26,8 +31,7 @@ For more information about access privileges, see xref:clusters:cluster-rbac.ado
 ======
 include::ROOT:partial$query-context.adoc[tag=example]
 
-The following example assumes you're using basic cluster access credentials.
-
+The following privileges apply if you use the basic cluster access credentials. 
 To execute the following statement, your client must have the `Write` privilege on `landmark` and the `Read` privilege on `beer-sample`.
 
 [source,sqlpp]

--- a/modules/n1ql/pages/n1ql-language-reference/explain.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/explain.adoc
@@ -11,6 +11,11 @@ include::partial$n1ql-language-reference/collapsible-style.adoc[]
 
 == Prerequisites
 
+ifdef::granular-rbac[]
+To execute the EXPLAIN statement, your client must have the privileges required for the {sqlpp} statement that is being explained.
+For more details about cluster access privileges, see xref:clusters:manage-database-users.adoc[].
+endif::granular-rbac[]
+
 To execute the EXPLAIN statement, your client must have the same privileges required to execute the query being explained.
 For example, if you are explaining an INSERT statement, the client must have the `Write` privilege on the target keyspace.
 
@@ -22,6 +27,10 @@ For more information about access privileges, see xref:clusters:manage-database-
 ======
 include::ROOT:partial$query-context.adoc[tag=example]
 
+ifdef::granular-rbac[]
+To execute the following statement, your client must have the _Query Insert_ privilege on the `landmark` keyspace and the _Query Select_ privilege on the `pass:c[`beer-sample`]` keyspace.
+endif::granular-rbac[]
+
 To execute the following statement, your client must have the `Write` privilege on `landmark` and the `Read` privilege on `beer-sample`.
 
 [source,sqlpp]
@@ -30,6 +39,10 @@ EXPLAIN INSERT INTO landmark (KEY foo, VALUE bar)
         SELECT META(doc).id AS foo, doc AS bar
         FROM `beer-sample` AS doc WHERE type = "brewery";
 ----
+
+ifdef::granular-rbac[]
+To execute the following statement, your client must have the _Query Insert_, _Query Update_, and _Query Select_ privileges on the `testbucket` keyspace.
+endif::granular-rbac[]
 
 To execute the following statement, your client must have both `Write` and `Read` privileges on `testbucket`.
 

--- a/modules/n1ql/pages/n1ql-language-reference/explain.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/explain.adoc
@@ -31,8 +31,7 @@ For example, to explain an `INSERT` statement, your client must have:
 ======
 include::ROOT:partial$query-context.adoc[tag=example]
 
-The following privileges apply if you use the basic cluster access credentials. 
-To execute the following statement, your client must have the `Write` privilege on `landmark` and the `Read` privilege on `beer-sample`.
+To execute the following statement, your client must have the `Write` / `Query Insert` privilege on `landmark` and the `Read` / `Query Read` privilege on `beer-sample`.
 
 [source,sqlpp]
 ----
@@ -41,11 +40,14 @@ EXPLAIN INSERT INTO landmark (KEY foo, VALUE bar)
         FROM `beer-sample` AS doc WHERE type = "brewery";
 ----
 
-To execute the following statement, your client must have both `Write` and `Read` privileges on `testbucket`.
+To execute the following statement, your client must have `Write` / `Query Update` and `Read` / `Query Read` privileges on `landmark`.
 
 [source,sqlpp]
 ----
-EXPLAIN UPSERT INTO testbucket VALUES ("key1", { "a" : "b" }) RETURNING meta().cas;
+EXPLAIN UPDATE landmark
+        USE KEYS "landmark_10090"
+        SET nickname = "Squiggly Bridge"
+        RETURNING landmark.nickname;
 ----
 ======
 ====

--- a/modules/n1ql/pages/n1ql-language-reference/explain.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/explain.adoc
@@ -11,9 +11,10 @@ include::partial$n1ql-language-reference/collapsible-style.adoc[]
 
 == Prerequisites
 
-To execute the `EXPLAIN` statement, your client must have the privileges required for the {sqlpp} statement that is being explained.
-For more details about cluster access privileges, see
-xref:clusters:manage-database-users.adoc[].
+To execute the EXPLAIN statement, your client must have the same privileges required to execute the query being explained.
+For example, if you are explaining an INSERT statement, the client must have the `Write` privilege on the target keyspace.
+
+For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 
 .RBAC Examples
 [%collapsible]
@@ -21,7 +22,7 @@ xref:clusters:manage-database-users.adoc[].
 ======
 include::ROOT:partial$query-context.adoc[tag=example]
 
-To execute the following statement, your client must have the _Query Insert_ privilege on the `landmark` keyspace and the _Query Select_ privilege on the `pass:c[`beer-sample`]` keyspace.
+To execute the following statement, your client must have the `Write` privilege on `landmark` and the `Read` privilege on `beer-sample`.
 
 [source,sqlpp]
 ----
@@ -30,7 +31,7 @@ EXPLAIN INSERT INTO landmark (KEY foo, VALUE bar)
         FROM `beer-sample` AS doc WHERE type = "brewery";
 ----
 
-To execute the following statement, your client must have the _Query Insert_, _Query Update_, and _Query Select_ privileges on the `testbucket` keyspace.
+To execute the following statement, your client must have both `Write` and `Read` privileges on `testbucket`.
 
 [source,sqlpp]
 ----

--- a/modules/n1ql/pages/n1ql-language-reference/explain.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/explain.adoc
@@ -11,7 +11,7 @@ include::partial$n1ql-language-reference/collapsible-style.adoc[]
 
 == Prerequisites
 
-To execute the EXPLAIN statement, your client must have the privileges required for the {sqlpp} statement that is being explained.
+To execute the `EXPLAIN` statement, your client must have the privileges required for the {sqlpp} statement that is being explained.
 For more details about cluster access privileges, see
 xref:clusters:manage-database-users.adoc[].
 

--- a/modules/n1ql/pages/n1ql-language-reference/explain.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/explain.adoc
@@ -11,13 +11,14 @@ include::partial$n1ql-language-reference/collapsible-style.adoc[]
 
 == Prerequisites
 
-Irrespective of the type of cluster access credentials you are using (basic or advanced), your client must have the same privileges required to execute the query being explained.
+To execute the `EXPLAIN` statement, your client must have the same privileges required to run the query being explained, regardless of whether you use basic or advanced cluster access credentials.
 
-For example, if you're using basic cluster access credentials and if you are explaining an INSERT statement, the client must have the `Write` privilege on the target keyspace. 
+For example, to explain an `INSERT` statement, your client must have:
 
-Similarly, if you're using advanced cluster access credentials and if you are explaining an INSERT statement, the client must have the `Query Insert` privilege on the target keyspace.
+* The `Write` privilege on the target keyspace, if you're using basic cluster access credentials.
+* The `Query Insert` privilege on the target keyspace, if you're using advanced cluster access credentials.
 
-For more information about cluster access privileges, see xref:clusters:cluster-rbac.adoc[].
+For more information about access privileges, see xref:clusters:cluster-rbac.adoc[Cluster Access].
 
 .RBAC Examples
 [%collapsible]
@@ -25,9 +26,7 @@ For more information about cluster access privileges, see xref:clusters:cluster-
 ======
 include::ROOT:partial$query-context.adoc[tag=example]
 
-ifdef::granular-rbac[]
-To execute the following statement, your client must have the _Query Insert_ privilege on the `landmark` keyspace and the _Query Select_ privilege on the `pass:c[`beer-sample`]` keyspace.
-endif::granular-rbac[]
+The following example assumes you're using basic cluster access credentials.
 
 To execute the following statement, your client must have the `Write` privilege on `landmark` and the `Read` privilege on `beer-sample`.
 
@@ -37,10 +36,6 @@ EXPLAIN INSERT INTO landmark (KEY foo, VALUE bar)
         SELECT META(doc).id AS foo, doc AS bar
         FROM `beer-sample` AS doc WHERE type = "brewery";
 ----
-
-ifdef::granular-rbac[]
-To execute the following statement, your client must have the _Query Insert_, _Query Update_, and _Query Select_ privileges on the `testbucket` keyspace.
-endif::granular-rbac[]
 
 To execute the following statement, your client must have both `Write` and `Read` privileges on `testbucket`.
 

--- a/modules/n1ql/pages/n1ql-language-reference/explainfunction.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/explainfunction.adoc
@@ -30,13 +30,24 @@ The following constraints apply:
 
 == Prerequisites
 
-To execute the EXPLAIN FUNCTION statement, you must have at least one of the following roles:
+To execute this statement, your client must have necessary privileges on the target keyspace or scope.
+The required privilege depends on your xref:clusters:cluster-rbac.adoc#cluster-access-credential-types[cluster access credential type] and whether the function is global or scoped.
 
-* xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
-* xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]
-* xref:projects:project-roles.adoc#project-cluster-data-reader-writer[`Data Writer`]
+[cols="1a,1,1a", options="header"]
+|===
+| Credential Type | Function Type | Privilege 
+| Basic
+| Global or scoped
+| xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`]
+| Advanced
+| Global
+| xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Global Function Execute`] 
+| Advanced
+| Scoped
+| xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Execute`]
+|===
 
-In addition, you must also have the necessary privileges required for the {sqlpp} statements inside the function.
+NOTE: You must also have necessary privileges required for the {sqlpp} statements inside the function.
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/explainfunction.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/explainfunction.adoc
@@ -30,8 +30,7 @@ The following constraints apply:
 
 == Prerequisites
 
-To execute this statement, your client must have necessary privileges on the target keyspace or scope.
-The required privilege depends on your xref:clusters:cluster-rbac.adoc#cluster-access-credential-types[cluster access credential type] and whether the function is global or scoped.
+To execute this statement, your client must have necessary privileges depending on your xref:clusters:cluster-rbac.adoc#cluster-access-credential-types[cluster access credential type] and whether the function is global or scoped.
 
 [cols="1a,1,1a", options="header"]
 |===

--- a/modules/n1ql/pages/n1ql-language-reference/explainfunction.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/explainfunction.adoc
@@ -13,24 +13,28 @@ include::partial$n1ql-language-reference/horizontal-style.adoc[]
 
 You can request the execution plan for an inline or external user-defined function.
 
-* For an inline function, EXPLAIN FUNCTION returns the query plans for all of the subqueries present in the function body.
+* For an inline function, `EXPLAIN FUNCTION` returns the query plans for all of the subqueries present in the function body.
 +
 For more information about inline functions, see xref:n1ql-language-reference/userfun.adoc[].
 
-* For an external function, EXPLAIN FUNCTION returns the query plans for all embedded {sqlpp} queries inside the referenced JavaScript body, or the line number on which a N1QL() call appears.
+* For an external function, `EXPLAIN FUNCTION` returns the query plans for all embedded {sqlpp} queries inside the referenced JavaScript body, or the line number on which a N1QL() call appears.
 Line numbers are calculated from the beginning of the JavaScript function definition.
 +
 For more information about user-defined functions with JavaScript, see xref:guides:javascript-udfs.adoc[].
 
 The following constraints apply:
 
-* If a user-defined function itself contains other, nested user-defined function executions, EXPLAIN FUNCTION generates the query plan for the specified function only, and not for its nested {sqlpp} queries.
+* If a user-defined function itself contains other, nested user-defined function executions, `EXPLAIN FUNCTION` generates the query plan for the specified function only, and not for its nested {sqlpp} queries.
 
-* If an external function defines an alias for a N1QL() call, EXPLAIN FUNCTION cannot return its line number.
+* If an external function defines an alias for a N1QL() call, `EXPLAIN FUNCTION` cannot return its line number.
 
 == Prerequisites
 
-* To manage user-defined functions on your operational cluster, you must have the xref:projects:project-roles.adoc#project-owner-role[`Project Owner`] or the xref:projects:project-roles.adoc#project-cluster-data-reader-writer[`Cluster Data Reader/Writer`] role.
+To execute the `EXPLAIN FUNCTION` statement, you must have at least one of the following roles:
+
+* xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
+* xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]
+* xref:projects:project-roles.adoc#project-cluster-data-reader-writer[`Data Writer`]
 
 You must also have the necessary privileges required for the {sqlpp} statements inside the function.
 

--- a/modules/n1ql/pages/n1ql-language-reference/explainfunction.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/explainfunction.adoc
@@ -13,30 +13,30 @@ include::partial$n1ql-language-reference/horizontal-style.adoc[]
 
 You can request the execution plan for an inline or external user-defined function.
 
-* For an inline function, `EXPLAIN FUNCTION` returns the query plans for all of the subqueries present in the function body.
+* For an inline function, EXPLAIN FUNCTION returns the query plans for all of the subqueries present in the function body.
 +
 For more information about inline functions, see xref:n1ql-language-reference/userfun.adoc[].
 
-* For an external function, `EXPLAIN FUNCTION` returns the query plans for all embedded {sqlpp} queries inside the referenced JavaScript body, or the line number on which a N1QL() call appears.
+* For an external function, EXPLAIN FUNCTION returns the query plans for all embedded {sqlpp} queries inside the referenced JavaScript body, or the line number on which a N1QL() call appears.
 Line numbers are calculated from the beginning of the JavaScript function definition.
 +
 For more information about user-defined functions with JavaScript, see xref:guides:javascript-udfs.adoc[].
 
 The following constraints apply:
 
-* If a user-defined function itself contains other, nested user-defined function executions, `EXPLAIN FUNCTION` generates the query plan for the specified function only, and not for its nested {sqlpp} queries.
+* If a user-defined function itself contains other, nested user-defined function executions, EXPLAIN FUNCTION generates the query plan for the specified function only, and not for its nested {sqlpp} queries.
 
-* If an external function defines an alias for a N1QL() call, `EXPLAIN FUNCTION` cannot return its line number.
+* If an external function defines an alias for a N1QL() call, EXPLAIN FUNCTION cannot return its line number.
 
 == Prerequisites
 
-To execute the `EXPLAIN FUNCTION` statement, you must have at least one of the following roles:
+To execute the EXPLAIN FUNCTION statement, you must have at least one of the following roles:
 
 * xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
 * xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]
 * xref:projects:project-roles.adoc#project-cluster-data-reader-writer[`Data Writer`]
 
-You must also have the necessary privileges required for the {sqlpp} statements inside the function.
+In addition, you must also have the necessary privileges required for the {sqlpp} statements inside the function.
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/from.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/from.adoc
@@ -32,9 +32,8 @@ It specifies the documents to be used as the input for a query.
 
 == Prerequisites
 
-To select data from keyspace or expression, your client must have the [.param]`query_select` privilege on that keyspace.
-For more details about cluster access privileges, see
-{authorization-overview}[].
+To select data from keyspace or expression, your client must have the `Read` privilege on that keyspace.
+For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/from.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/from.adoc
@@ -32,6 +32,11 @@ It specifies the documents to be used as the input for a query.
 
 == Prerequisites
 
+ifdef::granular-rbac[]
+To select data from keyspace or expression, your client must have the [.param]`query_select` privilege on that keyspace.
+For more details about cluster access privileges, see {authorization-overview}[].
+endif::granular-rbac[]
+
 To select data from keyspace or expression, your client must have the `Read` privilege on that keyspace.
 For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 

--- a/modules/n1ql/pages/n1ql-language-reference/from.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/from.adoc
@@ -35,7 +35,7 @@ It specifies the documents to be used as the input for a query.
 To select data from keyspace or expression, your client must have 1 of the following privileges:
 
 * If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`] privilege on that keyspace.
-* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Read`] privilege on that keyspace.
+* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Read`] privilege on that keyspace.
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/from.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/from.adoc
@@ -32,10 +32,17 @@ It specifies the documents to be used as the input for a query.
 
 == Prerequisites
 
-To select data from keyspace or expression, your client must have 1 of the following privileges:
+To select data from a keyspace or expression, your client must have necessary privileges on the keyspace.
+The required privilege depends on your xref:clusters:cluster-rbac.adoc#cluster-access-credential-types[cluster access credential type]. 
 
-* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`] privilege on that keyspace.
-* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Read`] privilege on that keyspace.
+[cols="1a,1a", options="header"]
+|===
+| Credential Type | Privilege 
+| Basic
+| xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`]
+| Advanced
+| xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Read`]
+|===
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/from.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/from.adoc
@@ -32,13 +32,10 @@ It specifies the documents to be used as the input for a query.
 
 == Prerequisites
 
-ifdef::granular-rbac[]
-To select data from keyspace or expression, your client must have the [.param]`query_select` privilege on that keyspace.
-For more details about cluster access privileges, see {authorization-overview}[].
-endif::granular-rbac[]
+To select data from keyspace or expression, your client must have 1 of the following privileges:
 
-To select data from keyspace or expression, your client must have the `Read` privilege on that keyspace.
-For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
+* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`] privilege on that keyspace.
+* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Read`] privilege on that keyspace.
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/grant.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/grant.adoc
@@ -26,7 +26,7 @@ or `pass:c[query_select ON `travel-sample`.`inventory`.`airline`]`
 
 == Prerequisites
 
-To execute this statement in the Capella UI, you must have 1 of the following roles:
+To execute this statement in the Capella UI, you must have one of the following roles:
 
 * xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
 * xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]

--- a/modules/n1ql/pages/n1ql-language-reference/grant.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/grant.adoc
@@ -26,11 +26,13 @@ or `pass:c[query_select ON `travel-sample`.`inventory`.`airline`]`
 
 == Prerequisites
 
-To execute the GRANT statement, you must have at least one of the following roles:
+To execute this statement in the Capella UI, you must have 1 of the following roles:
 
 * xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
 * xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]
 * xref:projects:project-roles.adoc#project-cluster-data-reader-writer[`Data Writer`]
+
+NOTE: You cannot execute this statement using xref:clusters:cluster-rbac.adoc[cluster access credentials]. 
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/grant.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/grant.adoc
@@ -24,7 +24,13 @@ Specify the keyspace name after the keyword ON.
 For example: `pass:c[data_reader ON `travel-sample`]` +
 or `pass:c[query_select ON `travel-sample`.`inventory`.`airline`]`
 
-NOTE: To run the GRANT statement, you must be an xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] or xref:projects:project-roles.adoc#project-owner-role[`Project Owner`].
+== Prerequisites
+
+To execute the GRANT statement, you must have at least one of the following roles:
+
+* xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
+* xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]
+* xref:projects:project-roles.adoc#project-cluster-data-reader-writer[`Data Writer`]
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/hints.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/hints.adoc
@@ -21,13 +21,10 @@ If you do this, the `USE` clause and the hint comment are both marked as erroneo
 
 == Prerequisites
 
-ifdef::granular-rbac[]
-To select data from a document or keyspace, your client must have the [.param]`query_select` privilege on the document or keyspace.
-For more details about cluster access privileges, see xref:clusters:manage-database-users.adoc[].
-endif::granular-rbac[]
+To select data from a document or keyspace, your client must have 1 of the following privileges:
 
-To select data from a document or keyspace, your client must have the `Read` privilege on the document or keyspace.
-For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
+* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`] privilege on the document or keyspace.
+* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Read`] privilege on the document or keyspace.
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/hints.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/hints.adoc
@@ -24,7 +24,7 @@ If you do this, the `USE` clause and the hint comment are both marked as erroneo
 To select data from a document or keyspace, your client must have 1 of the following privileges:
 
 * If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`] privilege on the document or keyspace.
-* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Read`] privilege on the document or keyspace.
+* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Read`] privilege on the document or keyspace.
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/hints.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/hints.adoc
@@ -21,7 +21,7 @@ If you do this, the `USE` clause and the hint comment are both marked as erroneo
 
 == Prerequisites
 
-To select data from a document or keyspace, your client must have necessary privileges on the target keyspace or document.
+To select data from a document or keyspace, your client must have necessary privileges on the document or keyspace.
 The required privilege depends on your xref:clusters:cluster-rbac.adoc#cluster-access-credential-types[cluster access credential type]. 
 
 [cols="1a,1a", options="header"]

--- a/modules/n1ql/pages/n1ql-language-reference/hints.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/hints.adoc
@@ -21,6 +21,11 @@ If you do this, the `USE` clause and the hint comment are both marked as erroneo
 
 == Prerequisites
 
+ifdef::granular-rbac[]
+To select data from a document or keyspace, your client must have the [.param]`query_select` privilege on the document or keyspace.
+For more details about cluster access privileges, see xref:clusters:manage-database-users.adoc[].
+endif::granular-rbac[]
+
 To select data from a document or keyspace, your client must have the `Read` privilege on the document or keyspace.
 For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 

--- a/modules/n1ql/pages/n1ql-language-reference/hints.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/hints.adoc
@@ -21,9 +21,8 @@ If you do this, the `USE` clause and the hint comment are both marked as erroneo
 
 == Prerequisites
 
-To select data from a document or keyspace, your client must have the [.param]`query_select` privilege on the document or keyspace.
-For more details about cluster access privileges, see
-xref:clusters:manage-database-users.adoc[].
+To select data from a document or keyspace, your client must have the `Read` privilege on the document or keyspace.
+For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/hints.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/hints.adoc
@@ -21,10 +21,17 @@ If you do this, the `USE` clause and the hint comment are both marked as erroneo
 
 == Prerequisites
 
-To select data from a document or keyspace, your client must have 1 of the following privileges:
+To select data from a document or keyspace, your client must have necessary privileges on the target keyspace or document.
+The required privilege depends on your xref:clusters:cluster-rbac.adoc#cluster-access-credential-types[cluster access credential type]. 
 
-* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`] privilege on the document or keyspace.
-* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Read`] privilege on the document or keyspace.
+[cols="1a,1a", options="header"]
+|===
+| Credential Type | Privilege 
+| Basic
+| xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`]
+| Advanced
+| xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Read`]
+|===
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/infer.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/infer.adoc
@@ -12,19 +12,19 @@
 include::partial$n1ql-language-reference/horizontal-style.adoc[]
 
 {description}
-Since a keyspace can contain documents with varying structures, the `INFER` statement is statistical in nature rather than deterministic.
+Since a keyspace can contain documents with varying structures, the INFER statement is statistical in nature rather than deterministic.
 You can specify the sample size that must be used to analyze and identify the structure of documents in a keyspace.
 
-NOTE: The [.cmd]`describe` statement introduced in the Couchbase Server 4.1 release has been renamed to `INFER`.
+NOTE: The [.cmd]`describe` statement introduced in the Couchbase Server 4.1 release has been renamed to INFER.
 
-The Query tab in the Couchbase Capella UI (available under the [.ui]*Data Tools* tab) uses the `INFER` statement to display the structure of documents in the {bucket-analyzer}[Data Insights] area when you expand the keyspace name.
+The Query tab in the Couchbase Capella UI (available under the [.ui]*Data Tools* tab) uses the INFER statement to display the structure of documents in the {bucket-analyzer}[Data Insights] area when you expand the keyspace name.
 
 == Prerequisites
 
-To execute the `INFER` statement, the client must have the `Read` privilege on the target keyspace.
-For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
+To execute the INFER statement, your client must have the `Read` privilege on the target keyspace.
+For example, to execute the query in <<ex-1>>, the client must have the `Read` privilege on the `route` keyspace.
 
-For example, to execute <<ex-1>> below, your client must have the `Read` privilege on the `route` keyspace.
+For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 
 == Syntax
 
@@ -37,7 +37,7 @@ image::n1ql-language-reference/infer.png["Syntax diagram: refer to source code l
 
 The `COLLECTION` or `KEYSPACE` keywords are optional.
 These keywords are purely a visual mnemonic;
-including either of them makes no difference to the operation of the `INFER` statement.
+including either of them makes no difference to the operation of the INFER statement.
 
 // TODO: Automatic links from EBNF
 
@@ -75,7 +75,7 @@ Refer to the {keyspace-ref}[CREATE INDEX] statement for details of the syntax.
 [[infer-parameters]]
 === Options
 
-An object with one or more of the following properties to guide the `INFER` statement.
+An object with one or more of the following properties to guide the INFER statement.
 
 [.var]`sample_size`:: Specifies the number of documents to randomly sample in the keyspace when inferring the schema.
 The default sample size is 1000 documents.
@@ -99,7 +99,7 @@ If set to a non-negative value, the statement skips fields that are at a nesting
 The resulting field includes a `nestingDepth` property indicating the depth of the field, with `0` indicating a top-level field.
 
 [[infer-flags]]
-[.var]`flags`:: An array of strings representing flags that can control the behavior of the `INFER` statement. 
+[.var]`flags`:: An array of strings representing flags that can control the behavior of the INFER statement. 
 You can specify one or more of the following flags:
 +
 [cols="1,2", options="header"]
@@ -179,12 +179,12 @@ Details for Documents and Subdocuments::
 Details for Document Keys:: 
 [.out]`~meta`;; Contains the `id` property that holds the document keys.
 +
-By default, the `INFER` statement includes this attribute in the output. 
+By default, the INFER statement includes this attribute in the output. 
 However, you can control this behavior using the `flags` option in the WITH clause.
 +
 --
-* If you do not use `flags`, `INFER` automatically includes the `~meta` attribute.
-* If you add any value for `flags`, `INFER` will not return `~meta` unless you explicitly specify the `include_key` flag.
+* If you do not use `flags`, INFER automatically includes the `~meta` attribute.
+* If you add any value for `flags`, INFER will not return `~meta` unless you explicitly specify the `include_key` flag.
 For more information about the available flags, see <<infer-flags,flags>>.
 --
 NOTE: The `~meta` attribute is only available in Couchbase Server 8.0 and later.

--- a/modules/n1ql/pages/n1ql-language-reference/infer.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/infer.adoc
@@ -21,7 +21,7 @@ The Query tab in the Couchbase Capella UI (available under the [.ui]*Data Tools*
 
 == Prerequisites
 
-To execute this statement, your client must have specific privileges on the target keyspace.
+To execute this statement, your client must have necessary privileges on the target keyspace.
 The required privilege depends on your xref:clusters:cluster-rbac.adoc#cluster-access-credential-types[cluster access credential type]. 
 
 [cols="1a,1a", options="header"]

--- a/modules/n1ql/pages/n1ql-language-reference/infer.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/infer.adoc
@@ -21,10 +21,17 @@ The Query tab in the Couchbase Capella UI (available under the [.ui]*Data Tools*
 
 == Prerequisites
 
-To execute the INFER statement, your client must have 1 of the following privileges:
+To execute this statement, your client must have specific privileges on the target keyspace.
+The required privilege depends on your xref:clusters:cluster-rbac.adoc#cluster-access-credential-types[cluster access credential type]. 
 
-* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`] privilege on the target keyspace.
-* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Read`] privilege on the target keyspace.
+[cols="1a,1a", options="header"]
+|===
+| Credential Type | Privilege 
+| Basic
+| xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`]
+| Advanced
+| xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Read`]
+|===
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/infer.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/infer.adoc
@@ -24,7 +24,7 @@ The Query tab in the Couchbase Capella UI (available under the [.ui]*Data Tools*
 To execute the INFER statement, your client must have 1 of the following privileges:
 
 * If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`] privilege on the target keyspace.
-* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Read`] privilege on the target keyspace.
+* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Read`] privilege on the target keyspace.
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/infer.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/infer.adoc
@@ -12,19 +12,19 @@
 include::partial$n1ql-language-reference/horizontal-style.adoc[]
 
 {description}
-Since a keyspace can contain documents with varying structures, the INFER statement is statistical in nature rather than deterministic.
+Since a keyspace can contain documents with varying structures, the `INFER` statement is statistical in nature rather than deterministic.
 You can specify the sample size that must be used to analyze and identify the structure of documents in a keyspace.
 
-NOTE: The [.cmd]`describe` statement introduced in the Couchbase Server 4.1 release has been renamed to INFER.
+NOTE: The [.cmd]`describe` statement introduced in the Couchbase Server 4.1 release has been renamed to `INFER`.
 
-The Query tab in the Couchbase Capella UI (available under the [.ui]*Data Tools* tab) uses the INFER statement to display the structure of documents in the {bucket-analyzer}[Data Insights] area when you expand the keyspace name.
+The Query tab in the Couchbase Capella UI (available under the [.ui]*Data Tools* tab) uses the `INFER` statement to display the structure of documents in the {bucket-analyzer}[Data Insights] area when you expand the keyspace name.
 
-== RBAC Privileges
+== Prerequisites
 
-To execute the INFER statement, your client must have the _Query Select_ privilege granted on the target keyspace.
-For more details about cluster access privileges, see {authorization-overview}[].
+To execute the `INFER` statement, the client must have the `Read` privilege on the target keyspace.
+For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 
-For example, to execute <<ex-1>> below, your client must have the _Query Select_ privilege on the `route` keyspace.
+For example, to execute <<ex-1>> below, your client must have the `Read` privilege on the `route` keyspace.
 
 == Syntax
 
@@ -37,7 +37,7 @@ image::n1ql-language-reference/infer.png["Syntax diagram: refer to source code l
 
 The `COLLECTION` or `KEYSPACE` keywords are optional.
 These keywords are purely a visual mnemonic;
-including either of them makes no difference to the operation of the INFER statement.
+including either of them makes no difference to the operation of the `INFER` statement.
 
 // TODO: Automatic links from EBNF
 
@@ -75,7 +75,7 @@ Refer to the {keyspace-ref}[CREATE INDEX] statement for details of the syntax.
 [[infer-parameters]]
 === Options
 
-An object with one or more of the following properties to guide the INFER statement.
+An object with one or more of the following properties to guide the `INFER` statement.
 
 [.var]`sample_size`:: Specifies the number of documents to randomly sample in the keyspace when inferring the schema.
 The default sample size is 1000 documents.
@@ -99,7 +99,7 @@ If set to a non-negative value, the statement skips fields that are at a nesting
 The resulting field includes a `nestingDepth` property indicating the depth of the field, with `0` indicating a top-level field.
 
 [[infer-flags]]
-[.var]`flags`:: An array of strings representing flags that can control the behavior of the INFER statement. 
+[.var]`flags`:: An array of strings representing flags that can control the behavior of the `INFER` statement. 
 You can specify one or more of the following flags:
 +
 [cols="1,2", options="header"]
@@ -179,12 +179,12 @@ Details for Documents and Subdocuments::
 Details for Document Keys:: 
 [.out]`~meta`;; Contains the `id` property that holds the document keys.
 +
-By default, the INFER statement includes this attribute in the output. 
+By default, the `INFER` statement includes this attribute in the output. 
 However, you can control this behavior using the `flags` option in the WITH clause.
 +
 --
-* If you do not use `flags`, INFER automatically includes the `~meta` attribute.
-* If you add any value for `flags`, INFER will not return `~meta` unless you explicitly specify the `include_key` flag.
+* If you do not use `flags`, `INFER` automatically includes the `~meta` attribute.
+* If you add any value for `flags`, `INFER` will not return `~meta` unless you explicitly specify the `include_key` flag.
 For more information about the available flags, see <<infer-flags,flags>>.
 --
 NOTE: The `~meta` attribute is only available in Couchbase Server 8.0 and later.

--- a/modules/n1ql/pages/n1ql-language-reference/infer.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/infer.adoc
@@ -21,16 +21,10 @@ The Query tab in the Couchbase Capella UI (available under the [.ui]*Data Tools*
 
 == Prerequisites
 
-ifdef::granular-rbac[]
-To execute the INFER statement, your client must have the _Query Select_ privilege granted on the target keyspace.
-For more details about cluster access privileges, see {authorization-overview}[].
-For example, to execute <<ex-1>> below, your client must have the _Query Select_ privilege on the `route` keyspace.
-endif::granular-rbac[]
+To execute the INFER statement, your client must have 1 of the following privileges:
 
-To execute the INFER statement, your client must have the `Read` privilege on the target keyspace.
-For example, to execute the query in <<ex-1>>, the client must have the `Read` privilege on the `route` keyspace.
-
-For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
+* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`] privilege on the target keyspace.
+* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Read`] privilege on the target keyspace.
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/infer.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/infer.adoc
@@ -21,6 +21,12 @@ The Query tab in the Couchbase Capella UI (available under the [.ui]*Data Tools*
 
 == Prerequisites
 
+ifdef::granular-rbac[]
+To execute the INFER statement, your client must have the _Query Select_ privilege granted on the target keyspace.
+For more details about cluster access privileges, see {authorization-overview}[].
+For example, to execute <<ex-1>> below, your client must have the _Query Select_ privilege on the `route` keyspace.
+endif::granular-rbac[]
+
 To execute the INFER statement, your client must have the `Read` privilege on the target keyspace.
 For example, to execute the query in <<ex-1>>, the client must have the `Read` privilege on the `route` keyspace.
 

--- a/modules/n1ql/pages/n1ql-language-reference/insert.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/insert.adoc
@@ -59,15 +59,6 @@ The INSERT statement must include the following:
 See and for details.
 * Optionally, you can specify the values or an expression to be returned after the INSERT statement completes successfully.
 
-=== Security Requirements
-
-To execute the INSERT statement, your client must have 1 of the following privileges:
-
-* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`] privilege on the target keyspace.
-* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Insert`] privilege on the target keyspace.
-
-WARNING: You cannot insert documents into a SASL bucket if you have a read-only role for the SASL bucket.
-
 === RBAC Privileges
 
 To execute this statement, your client must have necessary privileges on the target keyspace.

--- a/modules/n1ql/pages/n1ql-language-reference/insert.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/insert.adoc
@@ -70,15 +70,19 @@ WARNING: You cannot insert documents into a SASL bucket if you have a read-only 
 
 === RBAC Privileges
 
-ifdef::granular-rbac[]
-To execute the INSERT statement, your client must have the _Query Insert_ privilege on the target keyspace.
-If the statement has any SELECT or RETURNING data-read clauses, then the _Query Select_ privilege is also required on the keyspaces referred in the respective clauses.
-For more details about roles and privileges, see {authorization-overview}[].
-endif::granular-rbac[]
+To execute this statement, your client must have necessary privileges on the target keyspace.
+The required privileges depend on your xref:clusters:cluster-rbac.adoc#cluster-access-credential-types[cluster access credential type] and whether the statement includes a `SELECT` or `RETURNING` clause.
 
-To execute the INSERT statement, your client must have the `Write` privilege on the target keyspace.
-If the statement includes any clauses that read data, such as a SELECT clause or a RETURNING clause, the client must also have `Read` privileges on the keyspaces referenced in those clauses.
-For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
+[cols="1a,1a,1a", options="header"]
+|===
+| Credential Type | Privilege for INSERT | Privilege for SELECT or RETURNING
+| Basic
+| xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`]
+| xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`] on all keyspaces referenced in the clause
+| Advanced
+| xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Insert`]
+| xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Read`] on all keyspaces referenced in the clause
+|===
 
 .RBAC Examples
 [%collapsible]
@@ -86,9 +90,7 @@ For more information about access privileges, see xref:clusters:manage-database-
 ======
 include::ROOT:partial$query-context.adoc[tag=example]
 
-ifdef::granular-rbac[]
-// To execute the following statement, your client must have the _Query Insert_ privilege on `hotel`.
-endif::granular-rbac[]
+The following privileges apply if you use the basic cluster access credentials. 
 
 To execute the following statement, your client must have the `Write` privilege on `hotel`.
 
@@ -98,9 +100,6 @@ INSERT INTO hotel (KEY, VALUE)
 VALUES ("key1", { "type" : "hotel", "name" : "new hotel" });
 ----
 
-ifdef::granular-rbac[]
-// To execute the following statement, your client must have the _Query Insert_ and _Query Select_ privileges on `hotel`.
-endif::granular-rbac[]
 To execute the following statement, your client must have both `Write` and `Read` privileges on `hotel`.
 
 [source,sqlpp]
@@ -108,10 +107,6 @@ To execute the following statement, your client must have both `Write` and `Read
 INSERT INTO hotel (KEY, VALUE)
 VALUES ("key1", { "type" : "hotel", "name" : "new hotel" }) RETURNING *;
 ----
-
-ifdef::granular-rbac[]
-// To execute the following statement, your client must have the _Query Insert_ privilege on `hotel` and _Query Select_ privilege on `pass:c[`beer-sample`]`.
-endif::granular-rbac[]
 
 To execute the following statement, your client must have the `Write` privilege on `hotel` and the `Read` privilege on `beer-sample`.
 
@@ -121,10 +116,6 @@ INSERT INTO landmark (KEY foo, VALUE bar)
 SELECT META(doc).id AS foo, doc AS bar
 FROM `beer-sample` AS doc WHERE type = "brewery";
 ----
-
-ifdef::granular-rbac[]
-// To execute the following statement, your client must have the _Query Insert_ and _Query Select_ privileges on `hotel`.
-endif::granular-rbac[]
 
 To execute the following statement, your client must have both `Write` and `Read` privileges on `hotel`.
 

--- a/modules/n1ql/pages/n1ql-language-reference/insert.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/insert.adoc
@@ -61,18 +61,16 @@ See and for details.
 
 === Security Requirements
 
-You should have read-write permission to the keyspace, to be able to insert documents into a keyspace.
-Any user who has the keyspace credentials or any Couchbase administrator should be able to insert documents into a keyspace.
-This includes the keyspace administrator for the specified keyspace, the cluster administrator, and the full administrator roles.
-See {roles}[] for details about access privileges for various administrators.
+To insert documents into a keyspace, you must have write privileges on the target keyspace. 
+Any user with appropriate roles, such as Organization Owner, Project Owner, or Data Writer, can insert documents into a keyspace. 
+For more information about roles and access privileges, see {roles}[].
 
 WARNING: You cannot insert documents into a SASL bucket if you have a read-only role for the SASL bucket.
 
 === RBAC Privileges
 
-To execute the INSERT statement, the client must have the `Write` privilege on the target keyspace.
-If the statement has any SELECT or RETURNING data-read clauses, then they also need the `Read` privilege on the keyspaces referred in the respective clauses.
-
+To execute the INSERT statement, your client must have the `Write` privilege on the target keyspace.
+If the statement includes any clauses that reads data, such as a SELECT clause or a RETURNING clause, the client must also have `Read` privileges on the keyspaces referenced in those clauses.
 For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 
 .RBAC Examples
@@ -89,7 +87,7 @@ INSERT INTO hotel (KEY, VALUE)
 VALUES ("key1", { "type" : "hotel", "name" : "new hotel" });
 ----
 
-To execute the following statement, your client must have the `Write` and `Read` privileges on `hotel`.
+To execute the following statement, your client must have both `Write` and `Read` privileges on `hotel`.
 
 [source,sqlpp]
 ----
@@ -97,7 +95,7 @@ INSERT INTO hotel (KEY, VALUE)
 VALUES ("key1", { "type" : "hotel", "name" : "new hotel" }) RETURNING *;
 ----
 
-To execute the following statement, your client must have the `Write` privilege on `hotel` and `Read` privilege on `pass:c[`beer-sample`]`.
+To execute the following statement, your client must have the `Write` privilege on `hotel` and the `Read` privilege on `beer-sample`.
 
 [source,sqlpp]
 ----

--- a/modules/n1ql/pages/n1ql-language-reference/insert.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/insert.adoc
@@ -81,9 +81,7 @@ The required privileges depend on your xref:clusters:cluster-rbac.adoc#cluster-a
 ======
 include::ROOT:partial$query-context.adoc[tag=example]
 
-The following privileges apply if you use the basic cluster access credentials. 
-
-To execute the following statement, your client must have the `Write` privilege on `hotel`.
+To execute the following statement, your client must have the `Write` / `Query Insert` privilege on `hotel`.
 
 [source,sqlpp]
 ----
@@ -91,7 +89,7 @@ INSERT INTO hotel (KEY, VALUE)
 VALUES ("key1", { "type" : "hotel", "name" : "new hotel" });
 ----
 
-To execute the following statement, your client must have both `Write` and `Read` privileges on `hotel`.
+To execute the following statement, your client must have `Write` / `Query Insert` and `Read` / `Query Read` privileges on `hotel`.
 
 [source,sqlpp]
 ----
@@ -99,7 +97,7 @@ INSERT INTO hotel (KEY, VALUE)
 VALUES ("key1", { "type" : "hotel", "name" : "new hotel" }) RETURNING *;
 ----
 
-To execute the following statement, your client must have the `Write` privilege on `hotel` and the `Read` privilege on `beer-sample`.
+To execute the following statement, your client must have the `Write` / `Query Insert` privilege on `hotel` and the `Read` / `Query Read` privilege on `beer-sample`.
 
 [source,sqlpp]
 ----
@@ -108,7 +106,7 @@ SELECT META(doc).id AS foo, doc AS bar
 FROM `beer-sample` AS doc WHERE type = "brewery";
 ----
 
-To execute the following statement, your client must have both `Write` and `Read` privileges on `hotel`.
+To execute the following statement, your client must have `Write` / `Query Insert` and `Read` / `Query Read` privileges on `hotel`.
 
 [source,sqlpp]
 ----

--- a/modules/n1ql/pages/n1ql-language-reference/insert.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/insert.adoc
@@ -61,9 +61,10 @@ See and for details.
 
 === Security Requirements
 
-To insert documents into a keyspace, you must have write privileges on the target keyspace. 
-Any user with appropriate roles, such as Organization Owner, Project Owner, or Data Writer, can insert documents into a keyspace. 
-For more information about roles and access privileges, see {roles}[].
+To execute the INSERT statement, your client must have 1 of the following privileges:
+
+* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`] privilege on the target keyspace.
+* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Insert`] privilege on the target keyspace.
 
 WARNING: You cannot insert documents into a SASL bucket if you have a read-only role for the SASL bucket.
 

--- a/modules/n1ql/pages/n1ql-language-reference/insert.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/insert.adoc
@@ -75,7 +75,7 @@ The required privileges depend on your xref:clusters:cluster-rbac.adoc#cluster-a
 
 [cols="1a,1a,1a", options="header"]
 |===
-| Credential Type | Privilege for INSERT | Privilege for SELECT or RETURNING
+| Credential Type | Privilege for INSERT | Privilege for SELECT / RETURNING
 | Basic
 | xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`]
 | xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`] on all keyspaces referenced in the clause

--- a/modules/n1ql/pages/n1ql-language-reference/insert.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/insert.adoc
@@ -70,10 +70,10 @@ WARNING: You cannot insert documents into a SASL bucket if you have a read-only 
 
 === RBAC Privileges
 
-To execute the INSERT statement, your client must have the _Query Insert_ privilege on the target keyspace.
+To execute the INSERT statement, the client must have the `Write` privilege on the target keyspace.
+If the statement has any SELECT or RETURNING data-read clauses, then they also need the `Read` privilege on the keyspaces referred in the respective clauses.
 
-If the statement has any SELECT or RETURNING data-read clauses, then the _Query Select_ privilege is also required on the keyspaces referred in the respective clauses.
-For more details about roles and privileges, see {authorization-overview}[].
+For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 
 .RBAC Examples
 [%collapsible]
@@ -81,7 +81,7 @@ For more details about roles and privileges, see {authorization-overview}[].
 ======
 include::ROOT:partial$query-context.adoc[tag=example]
 
-To execute the following statement, your client must have the _Query Insert_ privilege on `hotel`.
+To execute the following statement, your client must have the `Write` privilege on `hotel`.
 
 [source,sqlpp]
 ----
@@ -89,7 +89,7 @@ INSERT INTO hotel (KEY, VALUE)
 VALUES ("key1", { "type" : "hotel", "name" : "new hotel" });
 ----
 
-To execute the following statement, your client must have the _Query Insert_ and _Query Select_ privileges on `hotel`.
+To execute the following statement, your client must have the `Write` and `Read` privileges on `hotel`.
 
 [source,sqlpp]
 ----
@@ -97,7 +97,7 @@ INSERT INTO hotel (KEY, VALUE)
 VALUES ("key1", { "type" : "hotel", "name" : "new hotel" }) RETURNING *;
 ----
 
-To execute the following statement, your client must have the _Query Insert_ privilege on `hotel` and _Query Select_ privilege on `pass:c[`beer-sample`]`.
+To execute the following statement, your client must have the `Write` privilege on `hotel` and `Read` privilege on `pass:c[`beer-sample`]`.
 
 [source,sqlpp]
 ----
@@ -106,7 +106,7 @@ SELECT META(doc).id AS foo, doc AS bar
 FROM `beer-sample` AS doc WHERE type = "brewery";
 ----
 
-To execute the following statement, your client must have the _Query Insert_ and _Query Select_ privileges on `hotel`.
+To execute the following statement, your client must have the `Write` and `Read` privileges on `hotel`.
 
 [source,sqlpp]
 ----

--- a/modules/n1ql/pages/n1ql-language-reference/insert.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/insert.adoc
@@ -69,6 +69,12 @@ WARNING: You cannot insert documents into a SASL bucket if you have a read-only 
 
 === RBAC Privileges
 
+ifdef::granular-rbac[]
+To execute the INSERT statement, your client must have the _Query Insert_ privilege on the target keyspace.
+If the statement has any SELECT or RETURNING data-read clauses, then the _Query Select_ privilege is also required on the keyspaces referred in the respective clauses.
+For more details about roles and privileges, see {authorization-overview}[].
+endif::granular-rbac[]
+
 To execute the INSERT statement, your client must have the `Write` privilege on the target keyspace.
 If the statement includes any clauses that read data, such as a SELECT clause or a RETURNING clause, the client must also have `Read` privileges on the keyspaces referenced in those clauses.
 For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
@@ -79,6 +85,10 @@ For more information about access privileges, see xref:clusters:manage-database-
 ======
 include::ROOT:partial$query-context.adoc[tag=example]
 
+ifdef::granular-rbac[]
+// To execute the following statement, your client must have the _Query Insert_ privilege on `hotel`.
+endif::granular-rbac[]
+
 To execute the following statement, your client must have the `Write` privilege on `hotel`.
 
 [source,sqlpp]
@@ -87,6 +97,9 @@ INSERT INTO hotel (KEY, VALUE)
 VALUES ("key1", { "type" : "hotel", "name" : "new hotel" });
 ----
 
+ifdef::granular-rbac[]
+// To execute the following statement, your client must have the _Query Insert_ and _Query Select_ privileges on `hotel`.
+endif::granular-rbac[]
 To execute the following statement, your client must have both `Write` and `Read` privileges on `hotel`.
 
 [source,sqlpp]
@@ -94,6 +107,10 @@ To execute the following statement, your client must have both `Write` and `Read
 INSERT INTO hotel (KEY, VALUE)
 VALUES ("key1", { "type" : "hotel", "name" : "new hotel" }) RETURNING *;
 ----
+
+ifdef::granular-rbac[]
+// To execute the following statement, your client must have the _Query Insert_ privilege on `hotel` and _Query Select_ privilege on `pass:c[`beer-sample`]`.
+endif::granular-rbac[]
 
 To execute the following statement, your client must have the `Write` privilege on `hotel` and the `Read` privilege on `beer-sample`.
 
@@ -103,6 +120,10 @@ INSERT INTO landmark (KEY foo, VALUE bar)
 SELECT META(doc).id AS foo, doc AS bar
 FROM `beer-sample` AS doc WHERE type = "brewery";
 ----
+
+ifdef::granular-rbac[]
+// To execute the following statement, your client must have the _Query Insert_ and _Query Select_ privileges on `hotel`.
+endif::granular-rbac[]
 
 To execute the following statement, your client must have both `Write` and `Read` privileges on `hotel`.
 

--- a/modules/n1ql/pages/n1ql-language-reference/insert.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/insert.adoc
@@ -70,7 +70,7 @@ WARNING: You cannot insert documents into a SASL bucket if you have a read-only 
 === RBAC Privileges
 
 To execute the INSERT statement, your client must have the `Write` privilege on the target keyspace.
-If the statement includes any clauses that reads data, such as a SELECT clause or a RETURNING clause, the client must also have `Read` privileges on the keyspaces referenced in those clauses.
+If the statement includes any clauses that read data, such as a SELECT clause or a RETURNING clause, the client must also have `Read` privileges on the keyspaces referenced in those clauses.
 For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 
 .RBAC Examples
@@ -104,7 +104,7 @@ SELECT META(doc).id AS foo, doc AS bar
 FROM `beer-sample` AS doc WHERE type = "brewery";
 ----
 
-To execute the following statement, your client must have the `Write` and `Read` privileges on `hotel`.
+To execute the following statement, your client must have both `Write` and `Read` privileges on `hotel`.
 
 [source,sqlpp]
 ----

--- a/modules/n1ql/pages/n1ql-language-reference/insert.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/insert.adoc
@@ -64,7 +64,7 @@ See and for details.
 To execute the INSERT statement, your client must have 1 of the following privileges:
 
 * If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`] privilege on the target keyspace.
-* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Insert`] privilege on the target keyspace.
+* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Insert`] privilege on the target keyspace.
 
 WARNING: You cannot insert documents into a SASL bucket if you have a read-only role for the SASL bucket.
 

--- a/modules/n1ql/pages/n1ql-language-reference/join.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/join.adoc
@@ -21,6 +21,11 @@ For further details, refer to xref:n1ql-language-reference/comma.adoc[].
 
 == Prerequisites
 
+ifdef::granular-rbac[]
+To select data from keyspace or expression, your client must have the [.param]`query_select` privilege on that keyspace.
+For more details about cluster access privileges, see xref:clusters:manage-database-users.adoc[].
+endif::granular-rbac[]
+
 To select data from keyspace or expression, your client must have the `Read` privilege on that keyspace.
 For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 

--- a/modules/n1ql/pages/n1ql-language-reference/join.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/join.adoc
@@ -21,13 +21,10 @@ For further details, refer to xref:n1ql-language-reference/comma.adoc[].
 
 == Prerequisites
 
-ifdef::granular-rbac[]
-To select data from keyspace or expression, your client must have the [.param]`query_select` privilege on that keyspace.
-For more details about cluster access privileges, see xref:clusters:manage-database-users.adoc[].
-endif::granular-rbac[]
+To select data from keyspace or expression, your client must have 1 of the following privileges:
 
-To select data from keyspace or expression, your client must have the `Read` privilege on that keyspace.
-For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
+* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`] privilege on the that keyspace.
+* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Read`] privilege on that keyspace.
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/join.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/join.adoc
@@ -24,7 +24,7 @@ For further details, refer to xref:n1ql-language-reference/comma.adoc[].
 To select data from keyspace or expression, your client must have 1 of the following privileges:
 
 * If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`] privilege on the that keyspace.
-* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Read`] privilege on that keyspace.
+* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Read`] privilege on that keyspace.
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/join.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/join.adoc
@@ -21,9 +21,8 @@ For further details, refer to xref:n1ql-language-reference/comma.adoc[].
 
 == Prerequisites
 
-To select data from keyspace or expression, your client must have the [.param]`query_select` privilege on that keyspace.
-For more details about cluster access privileges, see
-xref:clusters:manage-database-users.adoc[].
+To select data from keyspace or expression, your client must have the `Read` privilege on that keyspace.
+For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/join.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/join.adoc
@@ -21,10 +21,17 @@ For further details, refer to xref:n1ql-language-reference/comma.adoc[].
 
 == Prerequisites
 
-To select data from keyspace or expression, your client must have 1 of the following privileges:
+To select data from a keyspace or expression, your client must have necessary privileges on the keyspace.
+The required privilege depends on your xref:clusters:cluster-rbac.adoc#cluster-access-credential-types[cluster access credential type]. 
 
-* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`] privilege on the that keyspace.
-* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Read`] privilege on that keyspace.
+[cols="1a,1a", options="header"]
+|===
+| Credential Type | Privilege 
+| Basic
+| xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`]
+| Advanced
+| xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Read`]
+|===
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/let.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/let.adoc
@@ -26,7 +26,7 @@ Each `LET` alias needs to be unique within its scope.
 
 == Prerequisites
 
-The `LET` clause can only be used in a `SELECT` statement.
+Use the `LET` clause only in a `SELECT` statement.
 To select data from a document or keyspace, your client must have the `Read` privilege on the document or keyspace.
 For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 

--- a/modules/n1ql/pages/n1ql-language-reference/let.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/let.adoc
@@ -26,7 +26,7 @@ Each `LET` alias needs to be unique within its scope.
 
 == Prerequisites
 
-To select data from a document or keyspace, your client must have necessary privileges on the target keyspace or document. 
+To select data from a document or keyspace, your client must have necessary privileges on the document or keyspace.
 The required privilege depends on your xref:clusters:cluster-rbac.adoc#cluster-access-credential-types[cluster access credential type]. 
 
 [cols="1a,1a", options="header"]

--- a/modules/n1ql/pages/n1ql-language-reference/let.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/let.adoc
@@ -26,14 +26,10 @@ Each `LET` alias needs to be unique within its scope.
 
 == Prerequisites
 
-ifdef::granular-rbac[]
-The `LET` clause can only be used in a `SELECT` statement, and to select data from a document or keyspace, your client must have the [.param]`query_select` privilege on the document or keyspace.
-For more details about cluster access privileges, see xref:clusters:manage-database-users.adoc[].
-endif::granular-rbac[]
+To select data from a document or keyspace, your client must have 1 of the following privileges:
 
-Use the `LET` clause only in a `SELECT` statement.
-To select data from a document or keyspace, your client must have the `Read` privilege on the document or keyspace.
-For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
+* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`] privilege on the document or keyspace.
+* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Read`] privilege on the document or keyspace.
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/let.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/let.adoc
@@ -26,9 +26,9 @@ Each `LET` alias needs to be unique within its scope.
 
 == Prerequisites
 
-The `LET` clause can only be used in a `SELECT` statement, and to select data from a document or keyspace, your client must have the [.param]`query_select` privilege on the document or keyspace.
-For more details about cluster access privileges, see
-xref:clusters:manage-database-users.adoc[].
+The `LET` clause can only be used in a `SELECT` statement.
+To select data from a document or keyspace, your client must have the `Read` privilege on the document or keyspace.
+For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/let.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/let.adoc
@@ -29,7 +29,7 @@ Each `LET` alias needs to be unique within its scope.
 To select data from a document or keyspace, your client must have 1 of the following privileges:
 
 * If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`] privilege on the document or keyspace.
-* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Read`] privilege on the document or keyspace.
+* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Read`] privilege on the document or keyspace.
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/let.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/let.adoc
@@ -26,6 +26,11 @@ Each `LET` alias needs to be unique within its scope.
 
 == Prerequisites
 
+ifdef::granular-rbac[]
+The `LET` clause can only be used in a `SELECT` statement, and to select data from a document or keyspace, your client must have the [.param]`query_select` privilege on the document or keyspace.
+For more details about cluster access privileges, see xref:clusters:manage-database-users.adoc[].
+endif::granular-rbac[]
+
 Use the `LET` clause only in a `SELECT` statement.
 To select data from a document or keyspace, your client must have the `Read` privilege on the document or keyspace.
 For more information about access privileges, see xref:clusters:manage-database-users.adoc[].

--- a/modules/n1ql/pages/n1ql-language-reference/let.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/let.adoc
@@ -26,10 +26,17 @@ Each `LET` alias needs to be unique within its scope.
 
 == Prerequisites
 
-To select data from a document or keyspace, your client must have 1 of the following privileges:
+To select data from a document or keyspace, your client must have necessary privileges on the target keyspace or document. 
+The required privilege depends on your xref:clusters:cluster-rbac.adoc#cluster-access-credential-types[cluster access credential type]. 
 
-* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`] privilege on the document or keyspace.
-* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Read`] privilege on the document or keyspace.
+[cols="1a,1a", options="header"]
+|===
+| Credential Type | Privilege 
+| Basic
+| xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`]
+| Advanced
+| xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Read`]
+|===
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/merge.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/merge.adoc
@@ -49,14 +49,13 @@ Since it is standard compliant and more flexible, we recommend you to use ANSI m
 
 == Privileges
 
-The client executing the MERGE statement must have the following privileges:
+To execute the `MERGE` statement, the client must have the following privileges:
 
-* _Query Select_ privileges on the source keyspace
-* _Query Insert_, _Query Update_, or _Query Delete_ privileges on the target keyspace as per the MERGE actions
-* _Query Select_ privileges on the keyspaces referred in the RETURNING clause
+* `Read` privileges on the source keyspace
+* `Write` privileges on the target keyspace as per the `MERGE` actions
+* `Read` privileges on the keyspaces referred in the RETURNING clause
 
-For more details about cluster access privileges, refer to
-{authorization-overview}[].
+For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 
 [NOTE]
 A user with the _Data Writer_ privilege may set documents to expire.

--- a/modules/n1ql/pages/n1ql-language-reference/merge.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/merge.adoc
@@ -51,23 +51,18 @@ Since it is standard compliant and more flexible, we recommend you to use ANSI m
 
 To execute the MERGE statement, your client must have the following privileges:
 
-ifdef::granular-rbac[]
-* _Query Select_ privileges on the source keyspace
-* _Query Insert_, _Query Update_, or _Query Delete_ privileges on the target keyspace as per the MERGE actions
-* _Query Select_ privileges on the keyspaces referred in the RETURNING clause
-endif::granular-rbac[]
+* If you're using basic cluster access credentials:
+** `Read` privilege on the source keyspace.
+** `Write` privilege on the target keyspace as per the MERGE actions.
+** `Read` privileges on the keyspaces referred in the RETURNING clause.
 
-* `Read` privilege on the source keyspace
-* `Write` privilege on the target keyspace as per the MERGE actions
-* `Read` privileges on the keyspaces referred in the RETURNING clause
-
-For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
-
-ifdef::granular-rbac[]
-[NOTE]
-A user with the _Data Writer_ privilege may set documents to expire.
-When the document expires, the data service deletes the document, even though the user may not have the _Query Delete_ privilege.
-endif::granular-rbac[]
+* If you're using advanced cluster access credentials:
+** `Query Select` privilege on the source keyspace.
+** `Query Insert`, `Query Update`, or `Query Delete` privilege on the target keyspace as per the MERGE actions.
+** `Query Select` privileges on the keyspaces referred in the RETURNING clause.
++
+NOTE: A user with the `Data Manage` privilege can set documents to expire.
+When the document expires, the Data Service deletes the document, even though the user may not have the `Query Delete` privilege.
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/merge.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/merge.adoc
@@ -49,18 +49,22 @@ Since it is standard compliant and more flexible, we recommend you to use ANSI m
 
 == Privileges
 
-To execute the MERGE statement, your client must have the following privileges:
+To execute this statement, your client must have necessary privileges on all keyspaces referenced in the statement.
+The required privileges depend on your xref:clusters:cluster-rbac.adoc#cluster-access-credential-types[cluster access credential type]. 
 
-* If you're using basic cluster access credentials:
-** `Read` privilege on the source keyspace.
-** `Write` privilege on the target keyspace as per the MERGE actions.
-** `Read` privileges on the keyspaces referred in the RETURNING clause.
+[cols="1a,2a,1a", options="header"]
+|===
+| Credential Type | Privilege for MERGE | Privilege for RETURNING
+| Basic
+| * xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`] on the source keyspace
+* xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`] on the target keyspace for any MERGE action
+| xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`] on all keyspaces referenced in the clause
+| Advanced
+| * xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Select`] on the source keyspace
+* xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Insert` / `Query Update` / `Query Delete`] on the target keyspace for any MERGE action
+| xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Select`] on all keyspaces referenced in the clause
+|===
 
-* If you're using advanced cluster access credentials:
-** `Query Select` privilege on the source keyspace.
-** `Query Insert`, `Query Update`, or `Query Delete` privilege on the target keyspace as per the MERGE actions.
-** `Query Select` privileges on the keyspaces referred in the RETURNING clause.
-+
 NOTE: A user with the `Data Manage` privilege can set documents to expire.
 When the document expires, the Data Service deletes the document, even though the user may not have the `Query Delete` privilege.
 

--- a/modules/n1ql/pages/n1ql-language-reference/merge.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/merge.adoc
@@ -49,8 +49,8 @@ Since it is standard compliant and more flexible, we recommend you to use ANSI m
 
 == Privileges
 
-To execute this statement, your client must have necessary privileges on all keyspaces referenced in the statement.
-The required privileges depend on your xref:clusters:cluster-rbac.adoc#cluster-access-credential-types[cluster access credential type]. 
+To execute this statement, your client must have necessary privileges on the keyspaces referenced in it.
+The required privileges depend on your xref:clusters:cluster-rbac.adoc#cluster-access-credential-types[cluster access credential type] and whether the statement includes a `RETURNING` clause.
 
 [cols="1a,2a,1a", options="header"]
 |===

--- a/modules/n1ql/pages/n1ql-language-reference/merge.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/merge.adoc
@@ -61,10 +61,6 @@ For more information about access privileges, see xref:clusters:manage-database-
 A user with the _Data Writer_ privilege may set documents to expire.
 When the document expires, the data service deletes the document, even though the user may not have the _Query Delete_ privilege.
 
-
-NOTE: A user with the xref:projects:project-roles.adoc#project-cluster-data-reader-writer[Data Writer] privilege can set documents to expire.
-When the document expires, the data service deletes the document, even though the user may not have the xref:clusters:manage-database-users.adoc#database-role-write[Write] privilege.
-
 == Syntax
 
 [source,ebnf]

--- a/modules/n1ql/pages/n1ql-language-reference/merge.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/merge.adoc
@@ -51,15 +51,23 @@ Since it is standard compliant and more flexible, we recommend you to use ANSI m
 
 To execute the MERGE statement, your client must have the following privileges:
 
+ifdef::granular-rbac[]
+* _Query Select_ privileges on the source keyspace
+* _Query Insert_, _Query Update_, or _Query Delete_ privileges on the target keyspace as per the MERGE actions
+* _Query Select_ privileges on the keyspaces referred in the RETURNING clause
+endif::granular-rbac[]
+
 * `Read` privilege on the source keyspace
 * `Write` privilege on the target keyspace as per the MERGE actions
 * `Read` privileges on the keyspaces referred in the RETURNING clause
 
 For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 
+ifdef::granular-rbac[]
 [NOTE]
 A user with the _Data Writer_ privilege may set documents to expire.
 When the document expires, the data service deletes the document, even though the user may not have the _Query Delete_ privilege.
+endif::granular-rbac[]
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/merge.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/merge.adoc
@@ -49,10 +49,10 @@ Since it is standard compliant and more flexible, we recommend you to use ANSI m
 
 == Privileges
 
-To execute the `MERGE` statement, the client must have the following privileges:
+To execute the MERGE statement, your client must have the following privileges:
 
-* `Read` privileges on the source keyspace
-* `Write` privileges on the target keyspace as per the `MERGE` actions
+* `Read` privilege on the source keyspace
+* `Write` privilege on the target keyspace as per the MERGE actions
 * `Read` privileges on the keyspaces referred in the RETURNING clause
 
 For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
@@ -60,6 +60,10 @@ For more information about access privileges, see xref:clusters:manage-database-
 [NOTE]
 A user with the _Data Writer_ privilege may set documents to expire.
 When the document expires, the data service deletes the document, even though the user may not have the _Query Delete_ privilege.
+
+
+NOTE: A user with the xref:projects:project-roles.adoc#project-cluster-data-reader-writer[Data Writer] privilege can set documents to expire.
+When the document expires, the data service deletes the document, even though the user may not have the xref:clusters:manage-database-users.adoc#database-role-write[Write] privilege.
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/nest.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/nest.adoc
@@ -17,9 +17,8 @@ It enables you to create an input object by producing a single result of nesting
 
 == Prerequisites
 
-To select data from keyspace or expression, your client must have the [.param]`query_select` privilege on that keyspace.
-For more details about cluster access privileges, see
-xref:clusters:manage-database-users.adoc[].
+To select data from keyspace or expression, your client must have the `Read` privilege on that keyspace.
+For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/nest.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/nest.adoc
@@ -20,7 +20,7 @@ It enables you to create an input object by producing a single result of nesting
 To select data from keyspace or expression, your client must have 1 of the following privileges:
 
 * If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`] privilege on that keyspace.
-* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Read`] privilege on that keyspace.
+* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Read`] privilege on that keyspace.
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/nest.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/nest.adoc
@@ -17,10 +17,17 @@ It enables you to create an input object by producing a single result of nesting
 
 == Prerequisites
 
-To select data from keyspace or expression, your client must have 1 of the following privileges:
+To select data from keyspace or expression, your client must have necessary privileges on the keyspace.
+The required privilege depends on your xref:clusters:cluster-rbac.adoc#cluster-access-credential-types[cluster access credential type]. 
 
-* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`] privilege on that keyspace.
-* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Read`] privilege on that keyspace.
+[cols="1a,1a", options="header"]
+|===
+| Credential Type | Privilege 
+| Basic
+| xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`]
+| Advanced
+| xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Read`]
+|===
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/nest.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/nest.adoc
@@ -17,13 +17,10 @@ It enables you to create an input object by producing a single result of nesting
 
 == Prerequisites
 
-ifdef::granular-rbac[]
-To select data from keyspace or expression, your client must have the [.param]`query_select` privilege on that keyspace.
-For more details about cluster access privileges, see xref:clusters:manage-database-users.adoc[].
-endif::granular-rbac[]
+To select data from keyspace or expression, your client must have 1 of the following privileges:
 
-To select data from keyspace or expression, your client must have the `Read` privilege on that keyspace.
-For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
+* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`] privilege on that keyspace.
+* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Read`] privilege on that keyspace.
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/nest.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/nest.adoc
@@ -17,6 +17,11 @@ It enables you to create an input object by producing a single result of nesting
 
 == Prerequisites
 
+ifdef::granular-rbac[]
+To select data from keyspace or expression, your client must have the [.param]`query_select` privilege on that keyspace.
+For more details about cluster access privileges, see xref:clusters:manage-database-users.adoc[].
+endif::granular-rbac[]
+
 To select data from keyspace or expression, your client must have the `Read` privilege on that keyspace.
 For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 

--- a/modules/n1ql/pages/n1ql-language-reference/orderby.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/orderby.adoc
@@ -14,9 +14,8 @@ In a SELECT statement, the ORDER BY clause sorts the result-set in ascending or 
 [#section_Prerequisites]
 == Prerequisites
 
-To select data from a document or keyspace, your client must have the [.param]`query_select` privilege on the document or keyspace.
-For more details about cluster access privileges, see
-xref:clusters:manage-database-users.adoc[].
+To select data from a document or keyspace, your client must have the `Read` privilege on the document or keyspace.
+For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 
 [#section_Syntax]
 == Syntax

--- a/modules/n1ql/pages/n1ql-language-reference/orderby.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/orderby.adoc
@@ -17,7 +17,7 @@ In a SELECT statement, the ORDER BY clause sorts the result-set in ascending or 
 To select data from a document or keyspace, your client must have 1 of the following privileges:
 
 * If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`] privilege on the document or keyspace.
-* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Read`] privilege on the document or keyspace.
+* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Read`] privilege on the document or keyspace.
 
 [#section_Syntax]
 == Syntax

--- a/modules/n1ql/pages/n1ql-language-reference/orderby.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/orderby.adoc
@@ -14,13 +14,10 @@ In a SELECT statement, the ORDER BY clause sorts the result-set in ascending or 
 [#section_Prerequisites]
 == Prerequisites
 
-ifdef::granular-rbac[]
-To select data from a document or keyspace, your client must have the [.param]`query_select` privilege on the document or keyspace.
-For more details about cluster access privileges, see xref:clusters:manage-database-users.adoc[].
-endif::granular-rbac[]
+To select data from a document or keyspace, your client must have 1 of the following privileges:
 
-To select data from a document or keyspace, your client must have the `Read` privilege on the document or keyspace.
-For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
+* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`] privilege on the document or keyspace.
+* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Read`] privilege on the document or keyspace.
 
 [#section_Syntax]
 == Syntax

--- a/modules/n1ql/pages/n1ql-language-reference/orderby.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/orderby.adoc
@@ -14,10 +14,17 @@ In a SELECT statement, the ORDER BY clause sorts the result-set in ascending or 
 [#section_Prerequisites]
 == Prerequisites
 
-To select data from a document or keyspace, your client must have 1 of the following privileges:
+To select data from a document or keyspace, your client must have necessary privileges on the target keyspace or document.
+The required privilege depends on your xref:clusters:cluster-rbac.adoc#cluster-access-credential-types[cluster access credential type]. 
 
-* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`] privilege on the document or keyspace.
-* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Read`] privilege on the document or keyspace.
+[cols="1a,1a", options="header"]
+|===
+| Credential Type | Privilege 
+| Basic
+| xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`]
+| Advanced
+| xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Read`]
+|===
 
 [#section_Syntax]
 == Syntax

--- a/modules/n1ql/pages/n1ql-language-reference/orderby.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/orderby.adoc
@@ -14,7 +14,7 @@ In a SELECT statement, the ORDER BY clause sorts the result-set in ascending or 
 [#section_Prerequisites]
 == Prerequisites
 
-To select data from a document or keyspace, your client must have necessary privileges on the target keyspace or document.
+To select data from a document or keyspace, your client must have necessary privileges on the document or keyspace.
 The required privilege depends on your xref:clusters:cluster-rbac.adoc#cluster-access-credential-types[cluster access credential type]. 
 
 [cols="1a,1a", options="header"]

--- a/modules/n1ql/pages/n1ql-language-reference/orderby.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/orderby.adoc
@@ -14,6 +14,11 @@ In a SELECT statement, the ORDER BY clause sorts the result-set in ascending or 
 [#section_Prerequisites]
 == Prerequisites
 
+ifdef::granular-rbac[]
+To select data from a document or keyspace, your client must have the [.param]`query_select` privilege on the document or keyspace.
+For more details about cluster access privileges, see xref:clusters:manage-database-users.adoc[].
+endif::granular-rbac[]
+
 To select data from a document or keyspace, your client must have the `Read` privilege on the document or keyspace.
 For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 

--- a/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
@@ -20,11 +20,18 @@ If you know that a statement text will be executed repeatedly, you can request t
 [[authorization]]
 == Prerequisites
 
-To execute the PREPARE statement, your client must have the necessary RBAC privileges for the statement being prepared.
+To execute this statement, your client must have the necessary privileges depending on the xref:clusters:cluster-rbac.adoc#cluster-access-credential-types[cluster access credential type] and the statement being prepared.
 
-For example, if you're using basic cluster access credentials and if the statement being prepared is a SELECT statement, the client must have the `Read` privilege on the keyspaces being accessed. 
-Similarly, if you're using advanced cluster access credentials and if the statement being prepared is a SELECT statement, the client must have the `Query Read` privilege on the keyspaces being accessed.
-For more details about cluster access privileges, refer to xref:clusters:cluster-rbac.adoc[].
+For example, if the statement being prepared is a `SELECT` statement:
+
+[cols="1a,1a", options="header"]
+|===
+| Credential Type | Privilege 
+| Basic
+| xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`]
+| Advanced
+| xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Read`]
+|===
 
 .RBAC Examples
 [%collapsible]
@@ -32,9 +39,7 @@ For more details about cluster access privileges, refer to xref:clusters:cluster
 ======
 include::ROOT:partial$query-context.adoc[tag=example]
 
-ifdef::granular-rbac[]
-To execute the following statement, user must have the _Query Select_ privilege on both keyspaces `pass:c[airport]` and `pass:c[landmark]`.
-endif::granular-rbac[]
+The following privileges apply if you're using basic cluster access credentials. 
 
 To execute the following statement, user must have `Read` privileges on both keyspaces `pass:c[airport]` and `pass:c[landmark]`.
 
@@ -44,9 +49,6 @@ PREPARE SELECT * FROM airport
 WHERE city = (SELECT RAW city FROM landmark)
 ----
 
-ifdef::granular-rbac[]
-To execute the following statement, user must have the _Query Update_ and _Query Select_ privileges on `pass:c[hotel]`.
-endif::granular-rbac[]
 To execute the following statement, user must have both `Write` and `Read` privileges on `pass:c[hotel]`.
 
 [source,sqlpp]

--- a/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
@@ -30,6 +30,10 @@ For more details about cluster access privileges, refer to xref:clusters:manage-
 ======
 include::ROOT:partial$query-context.adoc[tag=example]
 
+ifdef::granular-rbac[]
+To execute the following statement, user must have the _Query Select_ privilege on both keyspaces `pass:c[airport]` and `pass:c[landmark]`.
+endif::granular-rbac[]
+
 To execute the following statement, user must have `Read` privileges on both keyspaces `pass:c[airport]` and `pass:c[landmark]`.
 
 [source,sqlpp]
@@ -38,6 +42,9 @@ PREPARE SELECT * FROM airport
 WHERE city = (SELECT RAW city FROM landmark)
 ----
 
+ifdef::granular-rbac[]
+To execute the following statement, user must have the _Query Update_ and _Query Select_ privileges on `pass:c[hotel]`.
+endif::granular-rbac[]
 To execute the following statement, user must have both `Write` and `Read` privileges on `pass:c[hotel]`.
 
 [source,sqlpp]

--- a/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
@@ -20,7 +20,8 @@ If you know that a statement text will be executed repeatedly, you can request t
 [[authorization]]
 == Prerequisites
 
-The client executing the `PREPARE` statement must have the RBAC privileges of the statement being prepared.
+To execute the PREPARE statement, your client must have the necessary RBAC privileges for the statement being prepared.
+For example, if the statement being prepared is a SELECT statement, the client must have the `Read` privilege on the keyspaces being accessed.
 For more details about cluster access privileges, refer to xref:clusters:manage-database-users.adoc[].
 
 .RBAC Examples
@@ -133,7 +134,7 @@ operator:: The execution plan of the statement being prepared.
 
 signature:: The signature of the statement being prepared.
 
-text:: The full `PREPARE` statement text.
+text:: The full PREPARE statement text.
 
 encoded_plan:: The full prepared statement in encoded format.
 This is included for backward compatibility.
@@ -177,7 +178,7 @@ ifdef::flag-devex-rest-api[]
 [[auto-prepare]]
 == Auto-Prepare
 
-When the _auto-prepare_ feature is active, a prepared statement is created every time you submit a {sqlpp} request, whether you use the `PREPARE` statement or not.
+When the _auto-prepare_ feature is active, a prepared statement is created every time you submit a {sqlpp} request, whether you use the PREPARE statement or not.
 
 The process is similar to creating a prepared statement without a local name:
 
@@ -193,7 +194,7 @@ The auto-prepare feature is inactive by default.
 You can turn the auto-prepare feature on or off using the `auto-prepare` service-level query setting.
 For more details, refer to xref:n1ql:n1ql-manage/query-settings.adoc#auto-prepare[Configure Queries].
 
-Auto-prepare is disabled for {sqlpp} requests which contain parameters, if they do not use the `PREPARE` statement.
+Auto-prepare is disabled for {sqlpp} requests which contain parameters, if they do not use the PREPARE statement.
 endif::flag-devex-rest-api[]
 
 [[auto-reprepare]]
@@ -231,7 +232,7 @@ You can turn the auto-execute feature on or off using the `auto_execute` request
 For more details, refer to xref:n1ql:n1ql-manage/query-settings.adoc#auto_execute[Configure Queries].
 
 ifdef::flag-devex-rest-api[]
-The auto-execute feature only works for {sqlpp} requests which actually contain the `PREPARE` statement.
+The auto-execute feature only works for {sqlpp} requests which actually contain the PREPARE statement.
 Prepared statements created by the <<auto-prepare,auto-prepare>> feature are not executed by the auto-execute feature.
 endif::flag-devex-rest-api[]
 

--- a/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
@@ -39,9 +39,7 @@ For example, if the statement being prepared is a `SELECT` statement:
 ======
 include::ROOT:partial$query-context.adoc[tag=example]
 
-The following privileges apply if you use the basic cluster access credentials. 
-
-To execute the following statement, user must have `Read` privileges on both keyspaces `pass:c[airport]` and `pass:c[landmark]`.
+To execute the following statement, user must have `Read` / `Query Read` privileges on both keyspaces `pass:c[airport]` and `pass:c[landmark]`.
 
 [source,sqlpp]
 ----
@@ -49,7 +47,7 @@ PREPARE SELECT * FROM airport
 WHERE city = (SELECT RAW city FROM landmark)
 ----
 
-To execute the following statement, user must have both `Write` and `Read` privileges on `pass:c[hotel]`.
+To execute the following statement, user must have `Write` / `Query Update` and `Read` / `Query Read` privileges on `pass:c[hotel]`.
 
 [source,sqlpp]
 ----

--- a/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
@@ -21,8 +21,10 @@ If you know that a statement text will be executed repeatedly, you can request t
 == Prerequisites
 
 To execute the PREPARE statement, your client must have the necessary RBAC privileges for the statement being prepared.
-For example, if the statement being prepared is a SELECT statement, the client must have the `Read` privilege on the keyspaces being accessed.
-For more details about cluster access privileges, refer to xref:clusters:manage-database-users.adoc[].
+
+For example, if you're using basic cluster access credentials and if the statement being prepared is a SELECT statement, the client must have the `Read` privilege on the keyspaces being accessed. 
+Similarly, if you're using advanced cluster access credentials and if the statement being prepared is a SELECT statement, the client must have the `Query Read` privilege on the keyspaces being accessed.
+For more details about cluster access privileges, refer to xref:clusters:cluster-rbac.adoc[].
 
 .RBAC Examples
 [%collapsible]

--- a/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
@@ -17,12 +17,10 @@ Sometimes planning may take more time than actually executing a request.
 
 If you know that a statement text will be executed repeatedly, you can request the {sqlpp} service to prepare the execution plan beforehand, and then request to execute the prepared plan as many times as needed, thereby avoiding the cost of repeated planning.
 
+[[authorization]]
 == Prerequisites
 
-[[authorization]]
-=== RBAC Privileges
-
-The client executing the PREPARE statement must have the RBAC privileges of the statement being prepared.
+The client executing the `PREPARE` statement must have the RBAC privileges of the statement being prepared.
 For more details about cluster access privileges, refer to xref:clusters:manage-database-users.adoc[].
 
 .RBAC Examples
@@ -31,7 +29,7 @@ For more details about cluster access privileges, refer to xref:clusters:manage-
 ======
 include::ROOT:partial$query-context.adoc[tag=example]
 
-To execute the following statement, user must have the _Query Select_ privilege on both keyspaces `pass:c[airport]` and `pass:c[landmark]`.
+To execute the following statement, user must have `Read` privileges on both keyspaces `pass:c[airport]` and `pass:c[landmark]`.
 
 [source,sqlpp]
 ----
@@ -39,7 +37,7 @@ PREPARE SELECT * FROM airport
 WHERE city = (SELECT RAW city FROM landmark)
 ----
 
-To execute the following statement, user must have the _Query Update_ and _Query Select_ privileges on `pass:c[hotel]`.
+To execute the following statement, user must have both `Write` and `Read` privileges on `pass:c[hotel]`.
 
 [source,sqlpp]
 ----
@@ -135,7 +133,7 @@ operator:: The execution plan of the statement being prepared.
 
 signature:: The signature of the statement being prepared.
 
-text:: The full PREPARE statement text.
+text:: The full `PREPARE` statement text.
 
 encoded_plan:: The full prepared statement in encoded format.
 This is included for backward compatibility.
@@ -179,7 +177,7 @@ ifdef::flag-devex-rest-api[]
 [[auto-prepare]]
 == Auto-Prepare
 
-When the _auto-prepare_ feature is active, a prepared statement is created every time you submit a {sqlpp} request, whether you use the PREPARE statement or not.
+When the _auto-prepare_ feature is active, a prepared statement is created every time you submit a {sqlpp} request, whether you use the `PREPARE` statement or not.
 
 The process is similar to creating a prepared statement without a local name:
 
@@ -195,7 +193,7 @@ The auto-prepare feature is inactive by default.
 You can turn the auto-prepare feature on or off using the `auto-prepare` service-level query setting.
 For more details, refer to xref:n1ql:n1ql-manage/query-settings.adoc#auto-prepare[Configure Queries].
 
-Auto-prepare is disabled for {sqlpp} requests which contain parameters, if they do not use the PREPARE statement.
+Auto-prepare is disabled for {sqlpp} requests which contain parameters, if they do not use the `PREPARE` statement.
 endif::flag-devex-rest-api[]
 
 [[auto-reprepare]]
@@ -233,7 +231,7 @@ You can turn the auto-execute feature on or off using the `auto_execute` request
 For more details, refer to xref:n1ql:n1ql-manage/query-settings.adoc#auto_execute[Configure Queries].
 
 ifdef::flag-devex-rest-api[]
-The auto-execute feature only works for {sqlpp} requests which actually contain the PREPARE statement.
+The auto-execute feature only works for {sqlpp} requests which actually contain the `PREPARE` statement.
 Prepared statements created by the <<auto-prepare,auto-prepare>> feature are not executed by the auto-execute feature.
 endif::flag-devex-rest-api[]
 

--- a/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
@@ -39,7 +39,7 @@ For example, if the statement being prepared is a `SELECT` statement:
 ======
 include::ROOT:partial$query-context.adoc[tag=example]
 
-The following privileges apply if you're using basic cluster access credentials. 
+The following privileges apply if you use the basic cluster access credentials. 
 
 To execute the following statement, user must have `Read` privileges on both keyspaces `pass:c[airport]` and `pass:c[landmark]`.
 

--- a/modules/n1ql/pages/n1ql-language-reference/revoke.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/revoke.adoc
@@ -26,7 +26,7 @@ or `pass:c[query_select ON `travel-sample`.`inventory`.`airline`]`
 
 == Prerequisites
 
-To execute this statement in the Capella UI, you must have 1 of the following roles:
+To execute this statement in the Capella UI, you must have one of the following roles:
 
 * xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
 * xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]

--- a/modules/n1ql/pages/n1ql-language-reference/revoke.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/revoke.adoc
@@ -26,11 +26,13 @@ or `pass:c[query_select ON `travel-sample`.`inventory`.`airline`]`
 
 == Prerequisites
 
-To execute the REVOKE statement, you must have at least one of the following roles:
+To execute this statement in the Capella UI, you must have 1 of the following roles:
 
 * xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
 * xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]
 * xref:projects:project-roles.adoc#project-cluster-data-reader-writer[`Data Writer`]
+
+NOTE: You cannot execute this statement using xref:clusters:cluster-rbac.adoc[cluster access credentials]. 
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/revoke.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/revoke.adoc
@@ -24,7 +24,13 @@ Specify the keyspace name after the keyword ON.
 For example: `pass:c[data_reader ON `travel-sample`]` +
 or `pass:c[query_select ON `travel-sample`.`inventory`.`airline`]`
 
-NOTE: To run the REVOKE statement, you must be an xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] or xref:projects:project-roles.adoc#project-owner-role[`Project Owner`].
+== Prerequisites
+
+To execute the REVOKE statement, you must have at least one of the following roles:
+
+* xref:organizations:organization-user-roles.adoc#organization-role-organization-owner[`Organization Owner`] 
+* xref:projects:project-roles.adoc#project-owner-role[`Project Owner`]
+* xref:projects:project-roles.adoc#project-cluster-data-reader-writer[`Data Writer`]
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/selectclause.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/selectclause.adoc
@@ -17,7 +17,7 @@ In a `SELECT` statement, the `SELECT` clause determines the projection (result s
 [#section_Prerequisites]
 == Prerequisites
 
-To select data from a document or keyspace, the client must have the `Read` privilege on the document or keyspace.
+To select data from a document or keyspace, your client must have the `Read` privilege on the document or keyspace.
 For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 
 [#section_Syntax]

--- a/modules/n1ql/pages/n1ql-language-reference/selectclause.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/selectclause.adoc
@@ -17,6 +17,11 @@ In a `SELECT` statement, the `SELECT` clause determines the projection (result s
 [#section_Prerequisites]
 == Prerequisites
 
+ifdef::granular-rbac[]
+To select data from a document or keyspace, your client must have the [.param]`query_select` privilege on the document or keyspace.
+For more details about cluster access privileges, see xref:clusters:manage-database-users.adoc[].
+endif::granular-rbac[]
+
 To select data from a document or keyspace, your client must have the `Read` privilege on the document or keyspace.
 For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 

--- a/modules/n1ql/pages/n1ql-language-reference/selectclause.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/selectclause.adoc
@@ -20,7 +20,7 @@ In a `SELECT` statement, the `SELECT` clause determines the projection (result s
 To select data from a document or keyspace, your client must have 1 of the following privileges:
 
 * If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`] privilege on the document or keyspace.
-* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Read`] privilege on the document or keyspace.
+* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Read`] privilege on the document or keyspace.
 
 [#section_Syntax]
 == Syntax

--- a/modules/n1ql/pages/n1ql-language-reference/selectclause.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/selectclause.adoc
@@ -17,9 +17,8 @@ In a `SELECT` statement, the `SELECT` clause determines the projection (result s
 [#section_Prerequisites]
 == Prerequisites
 
-To select data from a document or keyspace, your client must have the [.param]`query_select` privilege on the document or keyspace.
-For more details about cluster access privileges, see
-xref:clusters:manage-database-users.adoc[].
+To select data from a document or keyspace, the client must have the `Read` privilege on the document or keyspace.
+For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 
 [#section_Syntax]
 == Syntax

--- a/modules/n1ql/pages/n1ql-language-reference/selectclause.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/selectclause.adoc
@@ -17,7 +17,7 @@ In a `SELECT` statement, the `SELECT` clause determines the projection (result s
 [#section_Prerequisites]
 == Prerequisites
 
-To select data from a document or keyspace, your client must have necessary privileges on the target document or keyspace.
+To select data from a document or keyspace, your client must have necessary privileges on the document or keyspace.
 The required privilege depends on your xref:clusters:cluster-rbac.adoc#cluster-access-credential-types[cluster access credential type]. 
 
 [cols="1a,1a", options="header"]

--- a/modules/n1ql/pages/n1ql-language-reference/selectclause.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/selectclause.adoc
@@ -17,13 +17,10 @@ In a `SELECT` statement, the `SELECT` clause determines the projection (result s
 [#section_Prerequisites]
 == Prerequisites
 
-ifdef::granular-rbac[]
-To select data from a document or keyspace, your client must have the [.param]`query_select` privilege on the document or keyspace.
-For more details about cluster access privileges, see xref:clusters:manage-database-users.adoc[].
-endif::granular-rbac[]
+To select data from a document or keyspace, your client must have 1 of the following privileges:
 
-To select data from a document or keyspace, your client must have the `Read` privilege on the document or keyspace.
-For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
+* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`] privilege on the document or keyspace.
+* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Read`] privilege on the document or keyspace.
 
 [#section_Syntax]
 == Syntax

--- a/modules/n1ql/pages/n1ql-language-reference/selectclause.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/selectclause.adoc
@@ -17,10 +17,17 @@ In a `SELECT` statement, the `SELECT` clause determines the projection (result s
 [#section_Prerequisites]
 == Prerequisites
 
-To select data from a document or keyspace, your client must have 1 of the following privileges:
+To select data from a document or keyspace, your client must have necessary privileges on the target document or keyspace.
+The required privilege depends on your xref:clusters:cluster-rbac.adoc#cluster-access-credential-types[cluster access credential type]. 
 
-* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`] privilege on the document or keyspace.
-* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Read`] privilege on the document or keyspace.
+[cols="1a,1a", options="header"]
+|===
+| Credential Type | Privilege 
+| Basic
+| xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`]
+| Advanced
+| xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Read`]
+|===
 
 [#section_Syntax]
 == Syntax

--- a/modules/n1ql/pages/n1ql-language-reference/selectintro.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/selectintro.adoc
@@ -15,7 +15,7 @@ include::partial$n1ql-language-reference/collapsible-style.adoc[]
 [abstract]
 {description}
 
-The `SELECT` statement takes a set of JSON documents from keyspaces as its input, manipulates it and returns a set of JSON documents in the result array.
+The SELECT statement takes a set of JSON documents from keyspaces as its input, manipulates it and returns a set of JSON documents in the result array.
 Since the schema for JSON documents is flexible, JSON documents in the result set have flexible schema as well.
 
 A simple query in {sqlpp} consists of three parts:
@@ -31,8 +31,8 @@ include::ROOT:partial$query-context.adoc[tag=statement]
 
 == Prerequisites
 
-To execute the `SELECT` statement, the client must have the `Read` privilege on all keyspaces referred in the query. 
-The `SELECT` statement can refer to one keyspace, multiple keyspaces, or no keyspaces at all.
+To execute the SELECT statement, your client must have the `Read` privilege on all keyspaces referenced in the query. 
+The SELECT statement can reference one keyspace, multiple keyspaces, or no keyspaces at all.
 For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 
 .RBAC Examples
@@ -144,12 +144,12 @@ In clusters running Couchbase Server 7.6 or later, the projection is returned in
 In prior versions, the projection was sorted alphabetically.
 To revert to this behavior, use the xref:n1ql:n1ql-manage/query-settings.adoc#sort_projection[sort_projection] request-level parameter.
 
-The `SELECT` statement provides a variety of data processing capabilities such as <<filtering,filtering>>, <<query-across-relationships,querying across relationships>> using JOINs or subqueries, <<deep-traversal-nested-docs,deep traversal of nested documents>>, <<aggregation,aggregation>>, <<combine-resultsets,combining result sets>> using operators, <<group-sort-limit,grouping>>, <<group-sort-limit,sorting>>, and more.
+The SELECT statement provides a variety of data processing capabilities such as <<filtering,filtering>>, <<query-across-relationships,querying across relationships>> using JOINs or subqueries, <<deep-traversal-nested-docs,deep traversal of nested documents>>, <<aggregation,aggregation>>, <<combine-resultsets,combining result sets>> using operators, <<group-sort-limit,grouping>>, <<group-sort-limit,sorting>>, and more.
 Follow the links for examples that demonstrate each capability.
 
 == SELECT Statement Processing
 
-The `SELECT` statement queries a keyspace and returns a JSON array that contains zero or more objects.
+The SELECT statement queries a keyspace and returns a JSON array that contains zero or more objects.
 
 The following diagram shows the query execution workflow at a high level and illustrates the interaction with the query, index, and data services.
 
@@ -159,7 +159,7 @@ The following diagram shows the query execution workflow at a high level and ill
 include::indexes:partial$diagrams/query-execution.puml[]
 ....
 
-The `SELECT` statement is executed as a sequence of steps.
+The SELECT statement is executed as a sequence of steps.
 Each step in the process produces result objects that are then used as inputs in the next step until all steps in the process are complete.
 While the workflow diagram shows all the possible phases a query goes through before returning a result, the clauses and predicates in a query decide the phases and the number of times that the query goes through.
 For example, sort phase can be skipped when there is no ORDER BY clause in the query; scan-fetch-join phase will execute multiple times for correlated subqueries.
@@ -293,7 +293,7 @@ WHERE  tz = "America/Anchorage"
 
 [#query-across-relationships]
 === Querying Across Relationships
-You can use the `SELECT` statement to query across relationships using the JOIN clause or subqueries.
+You can use the SELECT statement to query across relationships using the JOIN clause or subqueries.
 
 ==== JOIN Clause
 Before delving into examples, take a look at a simplified representation of the data model of the `inventory` scope in the `travel-sample` bucket, which is used in the following examples.
@@ -441,7 +441,7 @@ WHERE airline.iata = "AA";
 ====
 
 ==== Subqueries
-A subquery is an expression that is evaluated by executing an inner `SELECT` query.
+A subquery is an expression that is evaluated by executing an inner SELECT query.
 Subqueries can be used in most places where you can use an expression such as projections, FROM clauses, and WHERE clauses.
 
 A subquery is executed once for every input document to the outer statement and it returns an array every time it is evaluated.
@@ -474,7 +474,7 @@ FROM   (SELECT t.airportname
 
 [#deep-traversal-nested-docs]
 === Deep Traversal for Nested Documents
-When querying a keyspace with nested documents, `SELECT` provides an easy way to traverse deep nested documents using the dot notation and NEST and UNNEST clauses.
+When querying a keyspace with nested documents, SELECT provides an easy way to traverse deep nested documents using the dot notation and NEST and UNNEST clauses.
 
 ==== Dot Notation
 The following query looks for the schedule, and accesses the flight id for the destination airport "ALG".
@@ -586,7 +586,7 @@ LIMIT 4;
 
 [#aggregation]
 === Aggregation
-As part of a single `SELECT` statement, you can also perform aggregation using the SUM, COUNT, AVG, MIN, MAX, or ARRAY_AVG functions.
+As part of a single SELECT statement, you can also perform aggregation using the SUM, COUNT, AVG, MIN, MAX, or ARRAY_AVG functions.
 
 The following example counts the total number of flights to SFO:
 

--- a/modules/n1ql/pages/n1ql-language-reference/selectintro.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/selectintro.adoc
@@ -34,7 +34,7 @@ include::ROOT:partial$query-context.adoc[tag=statement]
 To execute the SELECT statement, your client must have 1 of the following privileges:
 
 * If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`] privilege on all keyspaces referenced in the query.
-* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Read`] privilege on all keyspaces referenced in the query. 
+* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Read`] privilege on all keyspaces referenced in the query. 
 
 The SELECT statement can reference one keyspace, multiple keyspaces, or no keyspaces at all.
 

--- a/modules/n1ql/pages/n1ql-language-reference/selectintro.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/selectintro.adoc
@@ -31,6 +31,12 @@ include::ROOT:partial$query-context.adoc[tag=statement]
 
 == Prerequisites
 
+ifdef::granular-rbac[]
+The client executing the SELECT statement must have {query-select}[read] access to all keyspaces referred in the query.
+Note that the SELECT statement may refer to one keyspace, multiple keyspaces, or no keyspaces at all.
+For more details about cluster access privileges, see xref:clusters:manage-database-users.adoc[].
+endif::granular-rbac[]
+
 To execute the SELECT statement, your client must have the `Read` privilege on all keyspaces referenced in the query. 
 The SELECT statement can reference one keyspace, multiple keyspaces, or no keyspaces at all.
 For more information about access privileges, see xref:clusters:manage-database-users.adoc[].

--- a/modules/n1ql/pages/n1ql-language-reference/selectintro.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/selectintro.adoc
@@ -31,10 +31,17 @@ include::ROOT:partial$query-context.adoc[tag=statement]
 
 == Prerequisites
 
-To execute the SELECT statement, your client must have 1 of the following privileges:
+To execute this statement, your client must have necessary privileges on the keyspaces referenced in it.
+The required privilege depends on your xref:clusters:cluster-rbac.adoc#cluster-access-credential-types[cluster access credential type]. 
 
-* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`] privilege on all keyspaces referenced in the query.
-* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Read`] privilege on all keyspaces referenced in the query. 
+[cols="1a,1a", options="header"]
+|===
+| Credential Type | Privilege 
+| Basic
+| xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`]
+| Advanced
+| xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Read`]
+|===
 
 The SELECT statement can reference one keyspace, multiple keyspaces, or no keyspaces at all.
 

--- a/modules/n1ql/pages/n1ql-language-reference/selectintro.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/selectintro.adoc
@@ -32,6 +32,8 @@ include::ROOT:partial$query-context.adoc[tag=statement]
 == Prerequisites
 
 To execute this statement, your client must have necessary privileges on the keyspaces referenced in it.
+The statement can reference one keyspace, multiple keyspaces, or no keyspaces at all.
+
 The required privilege depends on your xref:clusters:cluster-rbac.adoc#cluster-access-credential-types[cluster access credential type]. 
 
 [cols="1a,1a", options="header"]
@@ -42,8 +44,6 @@ The required privilege depends on your xref:clusters:cluster-rbac.adoc#cluster-a
 | Advanced
 | xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Read`]
 |===
-
-The SELECT statement can reference one keyspace, multiple keyspaces, or no keyspaces at all.
 
 .RBAC Examples
 [%collapsible]

--- a/modules/n1ql/pages/n1ql-language-reference/selectintro.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/selectintro.adoc
@@ -31,15 +31,12 @@ include::ROOT:partial$query-context.adoc[tag=statement]
 
 == Prerequisites
 
-ifdef::granular-rbac[]
-The client executing the SELECT statement must have {query-select}[read] access to all keyspaces referred in the query.
-Note that the SELECT statement may refer to one keyspace, multiple keyspaces, or no keyspaces at all.
-For more details about cluster access privileges, see xref:clusters:manage-database-users.adoc[].
-endif::granular-rbac[]
+To execute the SELECT statement, your client must have 1 of the following privileges:
 
-To execute the SELECT statement, your client must have the `Read` privilege on all keyspaces referenced in the query. 
+* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`] privilege on all keyspaces referenced in the query.
+* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Read`] privilege on all keyspaces referenced in the query. 
+
 The SELECT statement can reference one keyspace, multiple keyspaces, or no keyspaces at all.
-For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 
 .RBAC Examples
 [%collapsible]

--- a/modules/n1ql/pages/n1ql-language-reference/selectintro.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/selectintro.adoc
@@ -15,7 +15,7 @@ include::partial$n1ql-language-reference/collapsible-style.adoc[]
 [abstract]
 {description}
 
-The SELECT statement takes a set of JSON documents from keyspaces as its input, manipulates it and returns a set of JSON documents in the result array.
+The `SELECT` statement takes a set of JSON documents from keyspaces as its input, manipulates it and returns a set of JSON documents in the result array.
 Since the schema for JSON documents is flexible, JSON documents in the result set have flexible schema as well.
 
 A simple query in {sqlpp} consists of three parts:
@@ -31,9 +31,9 @@ include::ROOT:partial$query-context.adoc[tag=statement]
 
 == Prerequisites
 
-The client executing the SELECT statement must have {query-select}[read] access to all keyspaces referred in the query.
-Note that the SELECT statement may refer to one keyspace, multiple keyspaces, or no keyspaces at all.
-For more details about cluster access privileges, see xref:clusters:manage-database-users.adoc[].
+To execute the `SELECT` statement, the client must have the `Read` privilege on all keyspaces referred in the query. 
+The `SELECT` statement can refer to one keyspace, multiple keyspaces, or no keyspaces at all.
+For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 
 .RBAC Examples
 [%collapsible]
@@ -144,12 +144,12 @@ In clusters running Couchbase Server 7.6 or later, the projection is returned in
 In prior versions, the projection was sorted alphabetically.
 To revert to this behavior, use the xref:n1ql:n1ql-manage/query-settings.adoc#sort_projection[sort_projection] request-level parameter.
 
-The SELECT statement provides a variety of data processing capabilities such as <<filtering,filtering>>, <<query-across-relationships,querying across relationships>> using JOINs or subqueries, <<deep-traversal-nested-docs,deep traversal of nested documents>>, <<aggregation,aggregation>>, <<combine-resultsets,combining result sets>> using operators, <<group-sort-limit,grouping>>, <<group-sort-limit,sorting>>, and more.
+The `SELECT` statement provides a variety of data processing capabilities such as <<filtering,filtering>>, <<query-across-relationships,querying across relationships>> using JOINs or subqueries, <<deep-traversal-nested-docs,deep traversal of nested documents>>, <<aggregation,aggregation>>, <<combine-resultsets,combining result sets>> using operators, <<group-sort-limit,grouping>>, <<group-sort-limit,sorting>>, and more.
 Follow the links for examples that demonstrate each capability.
 
 == SELECT Statement Processing
 
-The SELECT statement queries a keyspace and returns a JSON array that contains zero or more objects.
+The `SELECT` statement queries a keyspace and returns a JSON array that contains zero or more objects.
 
 The following diagram shows the query execution workflow at a high level and illustrates the interaction with the query, index, and data services.
 
@@ -159,7 +159,7 @@ The following diagram shows the query execution workflow at a high level and ill
 include::indexes:partial$diagrams/query-execution.puml[]
 ....
 
-The SELECT statement is executed as a sequence of steps.
+The `SELECT` statement is executed as a sequence of steps.
 Each step in the process produces result objects that are then used as inputs in the next step until all steps in the process are complete.
 While the workflow diagram shows all the possible phases a query goes through before returning a result, the clauses and predicates in a query decide the phases and the number of times that the query goes through.
 For example, sort phase can be skipped when there is no ORDER BY clause in the query; scan-fetch-join phase will execute multiple times for correlated subqueries.
@@ -293,7 +293,7 @@ WHERE  tz = "America/Anchorage"
 
 [#query-across-relationships]
 === Querying Across Relationships
-You can use the SELECT statement to query across relationships using the JOIN clause or subqueries.
+You can use the `SELECT` statement to query across relationships using the JOIN clause or subqueries.
 
 ==== JOIN Clause
 Before delving into examples, take a look at a simplified representation of the data model of the `inventory` scope in the `travel-sample` bucket, which is used in the following examples.
@@ -441,7 +441,7 @@ WHERE airline.iata = "AA";
 ====
 
 ==== Subqueries
-A subquery is an expression that is evaluated by executing an inner SELECT query.
+A subquery is an expression that is evaluated by executing an inner `SELECT` query.
 Subqueries can be used in most places where you can use an expression such as projections, FROM clauses, and WHERE clauses.
 
 A subquery is executed once for every input document to the outer statement and it returns an array every time it is evaluated.
@@ -474,7 +474,7 @@ FROM   (SELECT t.airportname
 
 [#deep-traversal-nested-docs]
 === Deep Traversal for Nested Documents
-When querying a keyspace with nested documents, SELECT provides an easy way to traverse deep nested documents using the dot notation and NEST and UNNEST clauses.
+When querying a keyspace with nested documents, `SELECT` provides an easy way to traverse deep nested documents using the dot notation and NEST and UNNEST clauses.
 
 ==== Dot Notation
 The following query looks for the schedule, and accesses the flight id for the destination airport "ALG".
@@ -586,7 +586,7 @@ LIMIT 4;
 
 [#aggregation]
 === Aggregation
-As part of a single SELECT statement, you can also perform aggregation using the SUM, COUNT, AVG, MIN, MAX, or ARRAY_AVG functions.
+As part of a single `SELECT` statement, you can also perform aggregation using the SUM, COUNT, AVG, MIN, MAX, or ARRAY_AVG functions.
 
 The following example counts the total number of flights to SFO:
 

--- a/modules/n1ql/pages/n1ql-language-reference/update.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/update.adoc
@@ -37,10 +37,10 @@ The required privileges depend on your xref:clusters:cluster-rbac.adoc#cluster-a
 | Credential Type | Privilege for UPDATE | Privilege for SELECT / RETURNING
 | Basic
 | xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`]
-| xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`] on all keyspaces referred in the clause
+| xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`] on all keyspaces referenced in the clause
 | Advanced
 | xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Update`]
-| xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Read`] on all keyspaces referred in the clause
+| xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Read`] on all keyspaces referenced in the clause
 |===
 
 NOTE: A user with the `Data Manage` privilege may set documents to expire.
@@ -52,7 +52,7 @@ When the document expires, the Data Service deletes the document, even though th
 ======
 include::ROOT:partial$query-context.adoc[tag=example]
 
-The following privileges apply if you're using basic cluster access credentials. 
+The following privileges apply if you use the basic cluster access credentials. 
 
 To execute the following statement, your client must have the `Write` privilege on `airport`.
 

--- a/modules/n1ql/pages/n1ql-language-reference/update.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/update.adoc
@@ -30,7 +30,7 @@ Refer to xref:clusters:data-service/import-data-documents.adoc#import-sample-dat
 == Prerequisites
 
 To execute the UPDATE statement, your client must have the `Write` privilege on the target keyspace.
-If the statement includes any clauses that reads data, such as a SELECT clause or a RETURNING clause, the client must also have `Read` privileges on the keyspaces referenced in those clauses.
+If the statement includes any clauses that read data, such as a SELECT clause or a RETURNING clause, the client must also have `Read` privileges on the keyspaces referenced in those clauses.
 For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 
 NOTE: A user with the xref:projects:project-roles.adoc#project-cluster-data-reader-writer[Data Writer] privilege can set documents to expire.

--- a/modules/n1ql/pages/n1ql-language-reference/update.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/update.adoc
@@ -29,22 +29,30 @@ Refer to xref:clusters:data-service/import-data-documents.adoc#import-sample-dat
 
 == Prerequisites
 
-To execute the UPDATE statement, your client must have 1 of the following privileges:
+To execute this statement, your client must have necessary privileges on the keyspace.
+The required privileges depend on your xref:clusters:cluster-rbac.adoc#cluster-access-credential-types[cluster access credential type] and whether the statement includes a `SELECT` or `RETURNING` clause.
 
-* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`] privilege on the target keyspace.
-If the statement includes any clauses that read data, such as a SELECT clause or a RETURNING clause, the client must also have `Read` privileges on the keyspaces referenced in those clauses.
-* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Update`] privilege on the keyspace.
-If the statement includes any clauses that read data, such as a SELECT clause or a RETURNING clause, the client must also have `Query Read` privileges on the keyspaces referenced in those clauses.
-+
+[cols="1a,1a,1a", options="header"]
+|===
+| Credential Type | Privilege for UPDATE | Privilege for SELECT / RETURNING
+| Basic
+| xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`]
+| xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`] on all keyspaces referred in the clause
+| Advanced
+| xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Update`]
+| xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Read`] on all keyspaces referred in the clause
+|===
+
 NOTE: A user with the `Data Manage` privilege may set documents to expire.
-When the document expires, the data service deletes the document, even though the user may not have the `Query Delete` privilege.
+When the document expires, the Data Service deletes the document, even though the user may not have the `Query Delete` privilege.
 
 .RBAC Examples
 [%collapsible]
 ====
 ======
 include::ROOT:partial$query-context.adoc[tag=example]
-In addition, the following examples assume that you're using basic cluster access credentials. 
+
+The following privileges apply if you're using basic cluster access credentials. 
 
 To execute the following statement, your client must have the `Write` privilege on `airport`.
 

--- a/modules/n1ql/pages/n1ql-language-reference/update.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/update.adoc
@@ -52,23 +52,21 @@ When the document expires, the Data Service deletes the document, even though th
 ======
 include::ROOT:partial$query-context.adoc[tag=example]
 
-The following privileges apply if you use the basic cluster access credentials. 
-
-To execute the following statement, your client must have the `Write` privilege on `airport`.
+To execute the following statement, your client must have the `Write` / `Query Update` privilege on `airport`.
 
 [source,sqlpp]
 ----
 include::example$dml/update-rbac.n1ql[]
 ----
 
-To execute the following statement, your client must have the `Write` privilege on `airport` and `Read` privilege on `pass:c[`beer-sample`]`.
+To execute the following statement, your client must have the `Write` / `Query Update` privilege on `airport` and `Read` / `Query Read` privilege on `pass:c[`beer-sample`]`.
 
 [source,sqlpp]
 ----
 include::example$dml/update-rbac-sub.n1ql[]
 ----
 
-To execute the following statement, your client must have both `Write` and `Read` privileges on `airport`.
+To execute the following statement, your client must have `Write` / `Query Update` and `Read` / `Query Read` privileges on `airport`.
 
 [source,sqlpp]
 ----

--- a/modules/n1ql/pages/n1ql-language-reference/update.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/update.adoc
@@ -30,10 +30,10 @@ Refer to xref:clusters:data-service/import-data-documents.adoc#import-sample-dat
 == Prerequisites
 
 To execute the UPDATE statement, your client must have the `Write` privilege on the target keyspace.
-If the statement includes any clauses that needs data read, such as SELECT clause, or RETURNING clause, the client also requires the `Read` privilege on the keyspaces referenced in those clauses.
+If the statement includes any clauses that reads data, such as a SELECT clause or a RETURNING clause, the client must also have `Read` privileges on the keyspaces referenced in those clauses.
 For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 
-NOTE: A user with the xref:projects:project-roles.adoc#project-cluster-data-reader-writer[Data Writer] privilege may set documents to expire.
+NOTE: A user with the xref:projects:project-roles.adoc#project-cluster-data-reader-writer[Data Writer] privilege can set documents to expire.
 When the document expires, the data service deletes the document, even though the user may not have the xref:clusters:manage-database-users.adoc#database-role-write[Write] privilege.
 
 .RBAC Examples

--- a/modules/n1ql/pages/n1ql-language-reference/update.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/update.adoc
@@ -29,13 +29,12 @@ Refer to xref:clusters:data-service/import-data-documents.adoc#import-sample-dat
 
 == Prerequisites
 
-To execute the `UPDATE` statement, you must have the `Write` privilege on the target keyspace.
-If the statement has any clauses that needs data read, such as `SELECT` clause, or `RETURNING` clause, then the `Read` privilege is also required on the keyspaces referred in the respective clauses.
+To execute the UPDATE statement, your client must have the `Write` privilege on the target keyspace.
+If the statement includes any clauses that needs data read, such as SELECT clause, or RETURNING clause, the client also requires the `Read` privilege on the keyspaces referenced in those clauses.
 For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 
-[NOTE]
-A user with the _Data Writer_ privilege may set documents to expire.
-When the document expires, the data service deletes the document, even though the user may not have the _Query Delete_ privilege.
+NOTE: A user with the xref:projects:project-roles.adoc#project-cluster-data-reader-writer[Data Writer] privilege may set documents to expire.
+When the document expires, the data service deletes the document, even though the user may not have the xref:clusters:manage-database-users.adoc#database-role-write[Write] privilege.
 
 .RBAC Examples
 [%collapsible]

--- a/modules/n1ql/pages/n1ql-language-reference/update.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/update.adoc
@@ -29,11 +29,9 @@ Refer to xref:clusters:data-service/import-data-documents.adoc#import-sample-dat
 
 == Prerequisites
 
-=== RBAC Privileges
-
-The client executing the UPDATE statement must have the _Query Update_ privilege on the target keyspace.
-If the statement has any clauses that needs data read, such as SELECT clause, or RETURNING clause, then _Query Select_ privilege is also required on the keyspaces referred in the respective clauses.
-For more details about cluster access privileges, see {authorization-overview}[].
+To execute the `UPDATE` statement, you must have the `Write` privilege on the target keyspace.
+If the statement has any clauses that needs data read, such as `SELECT` clause, or `RETURNING` clause, then the `Read` privilege is also required on the keyspaces referred in the respective clauses.
+For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 
 [NOTE]
 A user with the _Data Writer_ privilege may set documents to expire.
@@ -45,21 +43,21 @@ When the document expires, the data service deletes the document, even though th
 ======
 include::ROOT:partial$query-context.adoc[tag=example]
 
-To execute the following statement, your client must have the _Query Update_ privilege on `airport`.
+To execute the following statement, your client must have the `Write` privilege on `airport`.
 
 [source,sqlpp]
 ----
 include::example$dml/update-rbac.n1ql[]
 ----
 
-To execute the following statement, your client must have the _Query Update_ privilege on `airport` and _Query Select_ privilege on `pass:c[`beer-sample`]`.
+To execute the following statement, your client must have the `Write` privilege on `airport` and `Read` privilege on `pass:c[`beer-sample`]`.
 
 [source,sqlpp]
 ----
 include::example$dml/update-rbac-sub.n1ql[]
 ----
 
-To execute the following statement, your client must have the _Query Update_ and _Query Select_ privileges on `airport`.
+To execute the following statement, your client must have both `Write` and `Read` privileges on `airport`.
 
 [source,sqlpp]
 ----

--- a/modules/n1ql/pages/n1ql-language-reference/update.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/update.adoc
@@ -33,7 +33,7 @@ To execute the UPDATE statement, your client must have 1 of the following privil
 
 * If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`] privilege on the target keyspace.
 If the statement includes any clauses that read data, such as a SELECT clause or a RETURNING clause, the client must also have `Read` privileges on the keyspaces referenced in those clauses.
-* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Update`] privilege on the keyspace.
+* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Update`] privilege on the keyspace.
 If the statement includes any clauses that read data, such as a SELECT clause or a RETURNING clause, the client must also have `Query Read` privileges on the keyspaces referenced in those clauses.
 +
 NOTE: A user with the `Data Manage` privilege may set documents to expire.

--- a/modules/n1ql/pages/n1ql-language-reference/update.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/update.adoc
@@ -29,18 +29,31 @@ Refer to xref:clusters:data-service/import-data-documents.adoc#import-sample-dat
 
 == Prerequisites
 
+ifdef::granular-rbac[]
+The client executing the UPDATE statement must have the _Query Update_ privilege on the target keyspace.
+If the statement has any clauses that needs data read, such as SELECT clause, or RETURNING clause, then _Query Select_ privilege is also required on the keyspaces referred in the respective clauses.
+For more details about cluster access privileges, see {authorization-overview}[].
+endif::granular-rbac[]
+
 To execute the UPDATE statement, your client must have the `Write` privilege on the target keyspace.
 If the statement includes any clauses that read data, such as a SELECT clause or a RETURNING clause, the client must also have `Read` privileges on the keyspaces referenced in those clauses.
 For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 
-NOTE: A user with the xref:projects:project-roles.adoc#project-cluster-data-reader-writer[Data Writer] privilege can set documents to expire.
-When the document expires, the data service deletes the document, even though the user may not have the xref:clusters:manage-database-users.adoc#database-role-write[Write] privilege.
+ifdef::granular-rbac[]
+[NOTE]
+A user with the _Data Writer_ privilege may set documents to expire.
+When the document expires, the data service deletes the document, even though the user may not have the _Query Delete_ privilege.
+endif::granular-rbac[]
 
 .RBAC Examples
 [%collapsible]
 ====
 ======
 include::ROOT:partial$query-context.adoc[tag=example]
+
+ifdef::granular-rbac[]
+To execute the following statement, your client must have the _Query Update_ privilege on `airport`.
+endif::granular-rbac[]
 
 To execute the following statement, your client must have the `Write` privilege on `airport`.
 
@@ -49,12 +62,20 @@ To execute the following statement, your client must have the `Write` privilege 
 include::example$dml/update-rbac.n1ql[]
 ----
 
+ifdef::granular-rbac[]
+To execute the following statement, your client must have the _Query Update_ privilege on `airport` and _Query Select_ privilege on `pass:c[`beer-sample`]`.
+endif::granular-rbac[]
+
 To execute the following statement, your client must have the `Write` privilege on `airport` and `Read` privilege on `pass:c[`beer-sample`]`.
 
 [source,sqlpp]
 ----
 include::example$dml/update-rbac-sub.n1ql[]
 ----
+
+ifdef::granular-rbac[]
+To execute the following statement, your client must have the _Query Update_ and _Query Select_ privileges on `airport`.
+endif::granular-rbac[]
 
 To execute the following statement, your client must have both `Write` and `Read` privileges on `airport`.
 

--- a/modules/n1ql/pages/n1ql-language-reference/update.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/update.adoc
@@ -29,31 +29,22 @@ Refer to xref:clusters:data-service/import-data-documents.adoc#import-sample-dat
 
 == Prerequisites
 
-ifdef::granular-rbac[]
-The client executing the UPDATE statement must have the _Query Update_ privilege on the target keyspace.
-If the statement has any clauses that needs data read, such as SELECT clause, or RETURNING clause, then _Query Select_ privilege is also required on the keyspaces referred in the respective clauses.
-For more details about cluster access privileges, see {authorization-overview}[].
-endif::granular-rbac[]
+To execute the UPDATE statement, your client must have 1 of the following privileges:
 
-To execute the UPDATE statement, your client must have the `Write` privilege on the target keyspace.
+* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`] privilege on the target keyspace.
 If the statement includes any clauses that read data, such as a SELECT clause or a RETURNING clause, the client must also have `Read` privileges on the keyspaces referenced in those clauses.
-For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
-
-ifdef::granular-rbac[]
-[NOTE]
-A user with the _Data Writer_ privilege may set documents to expire.
-When the document expires, the data service deletes the document, even though the user may not have the _Query Delete_ privilege.
-endif::granular-rbac[]
+* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Update`] privilege on the keyspace.
+If the statement includes any clauses that read data, such as a SELECT clause or a RETURNING clause, the client must also have `Query Read` privileges on the keyspaces referenced in those clauses.
++
+NOTE: A user with the `Data Manage` privilege may set documents to expire.
+When the document expires, the data service deletes the document, even though the user may not have the `Query Delete` privilege.
 
 .RBAC Examples
 [%collapsible]
 ====
 ======
 include::ROOT:partial$query-context.adoc[tag=example]
-
-ifdef::granular-rbac[]
-To execute the following statement, your client must have the _Query Update_ privilege on `airport`.
-endif::granular-rbac[]
+In addition, the following examples assume that you're using basic cluster access credentials. 
 
 To execute the following statement, your client must have the `Write` privilege on `airport`.
 
@@ -62,20 +53,12 @@ To execute the following statement, your client must have the `Write` privilege 
 include::example$dml/update-rbac.n1ql[]
 ----
 
-ifdef::granular-rbac[]
-To execute the following statement, your client must have the _Query Update_ privilege on `airport` and _Query Select_ privilege on `pass:c[`beer-sample`]`.
-endif::granular-rbac[]
-
 To execute the following statement, your client must have the `Write` privilege on `airport` and `Read` privilege on `pass:c[`beer-sample`]`.
 
 [source,sqlpp]
 ----
 include::example$dml/update-rbac-sub.n1ql[]
 ----
-
-ifdef::granular-rbac[]
-To execute the following statement, your client must have the _Query Update_ and _Query Select_ privileges on `airport`.
-endif::granular-rbac[]
 
 To execute the following statement, your client must have both `Write` and `Read` privileges on `airport`.
 

--- a/modules/n1ql/pages/n1ql-language-reference/upsert.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/upsert.adoc
@@ -60,7 +60,7 @@ When the document expires, the Data Service deletes the document, even though th
 ======
 include::ROOT:partial$query-context.adoc[tag=example]
 
-To execute the following statement, your client must have the `Write` or `Query Update` and `Query Insert` privileges on `hotel`.
+To execute the following statement, your client must have either the `Write` or both the `Query Update` and `Query Insert` privileges on `hotel`.
 
 [source,sqlpp]
 ----
@@ -69,7 +69,7 @@ include::example$dml/upsert-rbac.n1ql[]
 
 To execute the following statement, your client must have:
 
-* `Write` or `Query Update` and `Query Insert` privileges on `hotel`
+* `Write` or both `Query Update` and `Query Insert` privileges on `hotel`
 * `Read` or `Query Read` privilege on `hotel`
 
 [source,sqlpp]
@@ -85,7 +85,7 @@ include::example$dml/upsert-rbac-return.jsonc[]
 
 To execute the following statement, your client must have:
 
-*  `Write` or `Query Update` and `Query Insert` privileges on `landmark`
+* `Write` or both `Query Update` and `Query Insert` privileges on `landmark`
 * `Read` or `Query Read` privilege on `beer-sample`
 
 [source,sqlpp]

--- a/modules/n1ql/pages/n1ql-language-reference/upsert.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/upsert.adoc
@@ -36,22 +36,15 @@ Refer to xref:clusters:data-service/import-data-documents.adoc#import-sample-dat
 
 == Prerequisites
 
-ifdef::granular-rbac[]
-The client executing the UPSERT statement must have the _Query Update_ and _Query Insert_ privileges on the target keyspace.
-If the statement has any RETURNING clauses, then the _Query Select_ privilege is also required on the keyspaces referred in the respective clauses.
-For more details about cluster access privileges, see
-{authorization-overview}[].
-endif::granular-rbac[]
+To execute the UPSERT statement, your client must have 1 of the following privileges:
 
-To execute the UPSERT statement, your client must have the `Write` privilege on the target keyspace.
+* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`] privilege on the target keyspace.
 If the statement includes any RETURNING clauses, the client must also have `Read` privileges on the keyspaces referenced in those clauses.
-For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
-
-ifdef::granular-rbac[]
-[NOTE]
-A user with the _Data Writer_ privilege may set documents to expire.
-When the document expires, the data service deletes the document, even though the user may not have the _Query Delete_ privilege.
-endif::granular-rbac[]
+* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Update`] and  xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Insert`] privileges on the target keyspace.
+If the statement includes any RETURNING clauses, the client must also have `Query Read` privileges on the keyspaces referenced in those clauses.
++
+NOTE: A user with the `Data Manage` privilege may set documents to expire.
+When the document expires, the data service deletes the document, even though the user may not have the `Query Delete` privilege.
 
 .RBAC Examples
 [%collapsible]

--- a/modules/n1ql/pages/n1ql-language-reference/upsert.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/upsert.adoc
@@ -36,15 +36,22 @@ Refer to xref:clusters:data-service/import-data-documents.adoc#import-sample-dat
 
 == Prerequisites
 
-To execute the UPSERT statement, your client must have 1 of the following privileges:
+o execute this statement, your client must have necessary privileges on the keyspace.
+The required privileges depend on your xref:clusters:cluster-rbac.adoc#cluster-access-credential-types[cluster access credential type] and whether the statement includes a `SELECT` or `RETURNING` clause.
 
-* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`] privilege on the target keyspace.
-If the statement includes any RETURNING clauses, the client must also have `Read` privileges on the keyspaces referenced in those clauses.
-* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Update`] and xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Insert`] privileges on the target keyspace.
-If the statement includes any RETURNING clauses, the client must also have `Query Read` privileges on the keyspaces referenced in those clauses.
-+
+[cols="1a,1a,1a", options="header"]
+|===
+| Credential Type | Privilege for UPDATE | Privilege for SELECT / RETURNING
+| Basic
+| xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`]
+| xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`] on all keyspaces referred in the clause
+| Advanced
+| xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Update`]
+| xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Read`] on all keyspaces referred in the clause
+|===
+
 NOTE: A user with the `Data Manage` privilege may set documents to expire.
-When the document expires, the data service deletes the document, even though the user may not have the `Query Delete` privilege.
+When the document expires, the Data Service deletes the document, even though the user may not have the `Query Delete` privilege.
 
 .RBAC Examples
 [%collapsible]
@@ -52,9 +59,7 @@ When the document expires, the data service deletes the document, even though th
 ======
 include::ROOT:partial$query-context.adoc[tag=example]
 
-ifdef::granular-rbac[]
-To execute the following statement, your client must have the _Query Update_ and _Query Insert_ privileges on `hotel`.
-endif::granular-rbac[]
+The following privileges apply if you use the basic cluster access credentials.
 
 To execute the following statement, your client must have the `Write` privilege on `hotel`.
 
@@ -62,10 +67,6 @@ To execute the following statement, your client must have the `Write` privilege 
 ----
 include::example$dml/upsert-rbac.n1ql[]
 ----
-
-ifdef::granular-rbac[]
-To execute the following statement, your client must have the _Query Update_ and _Query Insert_ privileges on `hotel` and the _Query Select_ privilege on `hotel` also (for RETURNING clause).
-endif::granular-rbac[]
 
 To execute the following statement, your client must have both the `Write` privilege and the `Read` privilege (for the RETURNING clause) on `hotel`.
 
@@ -79,10 +80,6 @@ include::example$dml/upsert-rbac-return.n1ql[]
 ----
 include::example$dml/upsert-rbac-return.jsonc[]
 ----
-
-ifdef::granular-rbac[]
-To execute the following statement, your client must have the _Query Update_ and _Query Insert_ privileges on `landmark` and _Query Select_ privilege on `pass:c[`beer-sample`]`.
-endif::granular-rbac[]
 
 To execute the following statement, your client must have the `Write` privilege on `landmark` and the `Read` privilege on `beer-sample`.
 

--- a/modules/n1ql/pages/n1ql-language-reference/upsert.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/upsert.adoc
@@ -36,12 +36,22 @@ Refer to xref:clusters:data-service/import-data-documents.adoc#import-sample-dat
 
 == Prerequisites
 
+ifdef::granular-rbac[]
+The client executing the UPSERT statement must have the _Query Update_ and _Query Insert_ privileges on the target keyspace.
+If the statement has any RETURNING clauses, then the _Query Select_ privilege is also required on the keyspaces referred in the respective clauses.
+For more details about cluster access privileges, see
+{authorization-overview}[].
+endif::granular-rbac[]
+
 To execute the UPSERT statement, your client must have the `Write` privilege on the target keyspace.
 If the statement includes any RETURNING clauses, the client must also have `Read` privileges on the keyspaces referenced in those clauses.
 For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 
-NOTE: A user with the xref:projects:project-roles.adoc#project-cluster-data-reader-writer[Data Writer] privilege can set documents to expire.
-When the document expires, the data service deletes the document, even though the user may not have the xref:clusters:manage-database-users.adoc#database-role-write[Write] privilege.
+ifdef::granular-rbac[]
+[NOTE]
+A user with the _Data Writer_ privilege may set documents to expire.
+When the document expires, the data service deletes the document, even though the user may not have the _Query Delete_ privilege.
+endif::granular-rbac[]
 
 .RBAC Examples
 [%collapsible]
@@ -49,12 +59,20 @@ When the document expires, the data service deletes the document, even though th
 ======
 include::ROOT:partial$query-context.adoc[tag=example]
 
+ifdef::granular-rbac[]
+To execute the following statement, your client must have the _Query Update_ and _Query Insert_ privileges on `hotel`.
+endif::granular-rbac[]
+
 To execute the following statement, your client must have the `Write` privilege on `hotel`.
 
 [source,sqlpp]
 ----
 include::example$dml/upsert-rbac.n1ql[]
 ----
+
+ifdef::granular-rbac[]
+To execute the following statement, your client must have the _Query Update_ and _Query Insert_ privileges on `hotel` and the _Query Select_ privilege on `hotel` also (for RETURNING clause).
+endif::granular-rbac[]
 
 To execute the following statement, your client must have both the `Write` privilege and the `Read` privilege (for the RETURNING clause) on `hotel`.
 
@@ -68,6 +86,10 @@ include::example$dml/upsert-rbac-return.n1ql[]
 ----
 include::example$dml/upsert-rbac-return.jsonc[]
 ----
+
+ifdef::granular-rbac[]
+To execute the following statement, your client must have the _Query Update_ and _Query Insert_ privileges on `landmark` and _Query Select_ privilege on `pass:c[`beer-sample`]`.
+endif::granular-rbac[]
 
 To execute the following statement, your client must have the `Write` privilege on `landmark` and the `Read` privilege on `beer-sample`.
 

--- a/modules/n1ql/pages/n1ql-language-reference/upsert.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/upsert.adoc
@@ -36,12 +36,9 @@ Refer to xref:clusters:data-service/import-data-documents.adoc#import-sample-dat
 
 == Prerequisites
 
-=== RBAC Privileges
-
-The client executing the UPSERT statement must have the _Query Update_ and _Query Insert_ privileges on the target keyspace.
-If the statement has any RETURNING clauses, then the _Query Select_ privilege is also required on the keyspaces referred in the respective clauses.
-For more details about cluster access privileges, see
-{authorization-overview}[].
+To execute the `UPSERT` statement, your client must have the `Write` privilege on the target keyspace.
+If the statement has any RETURNING clauses, then the `Read` privilege is also required on the keyspaces referred in the respective clauses.
+For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 
 [NOTE]
 A user with the _Data Writer_ privilege may set documents to expire.

--- a/modules/n1ql/pages/n1ql-language-reference/upsert.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/upsert.adoc
@@ -37,10 +37,10 @@ Refer to xref:clusters:data-service/import-data-documents.adoc#import-sample-dat
 == Prerequisites
 
 To execute the UPSERT statement, your client must have the `Write` privilege on the target keyspace.
-If the statement includes any RETURNING clauses, the client also requires the `Read` privilege on the keyspaces referenced in those clauses.
+If the statement includes any RETURNING clauses, the client must also have `Read` privileges on the keyspaces referenced in those clauses.
 For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 
-NOTE: A user with the xref:projects:project-roles.adoc#project-cluster-data-reader-writer[Data Writer] privilege may set documents to expire.
+NOTE: A user with the xref:projects:project-roles.adoc#project-cluster-data-reader-writer[Data Writer] privilege can set documents to expire.
 When the document expires, the data service deletes the document, even though the user may not have the xref:clusters:manage-database-users.adoc#database-role-write[Write] privilege.
 
 .RBAC Examples

--- a/modules/n1ql/pages/n1ql-language-reference/upsert.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/upsert.adoc
@@ -41,12 +41,13 @@ The required privileges depend on your xref:clusters:cluster-rbac.adoc#cluster-a
 
 [cols="1a,1a,1a", options="header"]
 |===
-| Credential Type | Privilege for UPDATE | Privilege for SELECT / RETURNING
+| Credential Type | Privilege for UPSERT | Privilege for SELECT / RETURNING
 | Basic
 | xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`]
 | xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`] on all keyspaces referenced in the clause
 | Advanced
-| xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Update`]
+| xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Update`] and +
+xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Insert`]
 | xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Read`] on all keyspaces referenced in the clause
 |===
 
@@ -59,16 +60,17 @@ When the document expires, the Data Service deletes the document, even though th
 ======
 include::ROOT:partial$query-context.adoc[tag=example]
 
-The following privileges apply if you use the basic cluster access credentials. 
-
-To execute the following statement, your client must have the `Write` privilege on `hotel`.
+To execute the following statement, your client must have the `Write` or `Query Update` and `Query Insert` privileges on `hotel`.
 
 [source,sqlpp]
 ----
 include::example$dml/upsert-rbac.n1ql[]
 ----
 
-To execute the following statement, your client must have both the `Write` privilege and the `Read` privilege (for the RETURNING clause) on `hotel`.
+To execute the following statement, your client must have:
+
+* `Write` or `Query Update` and `Query Insert` privileges on `hotel`
+* `Read` or `Query Read` privilege on `hotel`
 
 [source,sqlpp]
 ----
@@ -81,7 +83,10 @@ include::example$dml/upsert-rbac-return.n1ql[]
 include::example$dml/upsert-rbac-return.jsonc[]
 ----
 
-To execute the following statement, your client must have the `Write` privilege on `landmark` and the `Read` privilege on `beer-sample`.
+To execute the following statement, your client must have:
+
+*  `Write` or `Query Update` and `Query Insert` privileges on `landmark`
+* `Read` or `Query Read` privilege on `beer-sample`
 
 [source,sqlpp]
 ----

--- a/modules/n1ql/pages/n1ql-language-reference/upsert.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/upsert.adoc
@@ -44,10 +44,10 @@ The required privileges depend on your xref:clusters:cluster-rbac.adoc#cluster-a
 | Credential Type | Privilege for UPDATE | Privilege for SELECT / RETURNING
 | Basic
 | xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`]
-| xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`] on all keyspaces referred in the clause
+| xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`] on all keyspaces referenced in the clause
 | Advanced
 | xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Update`]
-| xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Read`] on all keyspaces referred in the clause
+| xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Read`] on all keyspaces referenced in the clause
 |===
 
 NOTE: A user with the `Data Manage` privilege may set documents to expire.
@@ -59,7 +59,7 @@ When the document expires, the Data Service deletes the document, even though th
 ======
 include::ROOT:partial$query-context.adoc[tag=example]
 
-The following privileges apply if you use the basic cluster access credentials.
+The following privileges apply if you use the basic cluster access credentials. 
 
 To execute the following statement, your client must have the `Write` privilege on `hotel`.
 

--- a/modules/n1ql/pages/n1ql-language-reference/upsert.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/upsert.adoc
@@ -40,7 +40,7 @@ To execute the UPSERT statement, your client must have 1 of the following privil
 
 * If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`] privilege on the target keyspace.
 If the statement includes any RETURNING clauses, the client must also have `Read` privileges on the keyspaces referenced in those clauses.
-* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Update`] and  xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Insert`] privileges on the target keyspace.
+* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Update`] and xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Insert`] privileges on the target keyspace.
 If the statement includes any RETURNING clauses, the client must also have `Query Read` privileges on the keyspaces referenced in those clauses.
 +
 NOTE: A user with the `Data Manage` privilege may set documents to expire.

--- a/modules/n1ql/pages/n1ql-language-reference/upsert.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/upsert.adoc
@@ -36,13 +36,12 @@ Refer to xref:clusters:data-service/import-data-documents.adoc#import-sample-dat
 
 == Prerequisites
 
-To execute the `UPSERT` statement, your client must have the `Write` privilege on the target keyspace.
-If the statement has any RETURNING clauses, then the `Read` privilege is also required on the keyspaces referred in the respective clauses.
+To execute the UPSERT statement, your client must have the `Write` privilege on the target keyspace.
+If the statement includes any RETURNING clauses, the client also requires the `Read` privilege on the keyspaces referenced in those clauses.
 For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 
-[NOTE]
-A user with the _Data Writer_ privilege may set documents to expire.
-When the document expires, the data service deletes the document, even though the user may not have the _Query Delete_ privilege.
+NOTE: A user with the xref:projects:project-roles.adoc#project-cluster-data-reader-writer[Data Writer] privilege may set documents to expire.
+When the document expires, the data service deletes the document, even though the user may not have the xref:clusters:manage-database-users.adoc#database-role-write[Write] privilege.
 
 .RBAC Examples
 [%collapsible]
@@ -50,14 +49,14 @@ When the document expires, the data service deletes the document, even though th
 ======
 include::ROOT:partial$query-context.adoc[tag=example]
 
-To execute the following statement, your client must have the _Query Update_ and _Query Insert_ privileges on `hotel`.
+To execute the following statement, your client must have the `Write` privilege on `hotel`.
 
 [source,sqlpp]
 ----
 include::example$dml/upsert-rbac.n1ql[]
 ----
 
-To execute the following statement, your client must have the _Query Update_ and _Query Insert_ privileges on `hotel` and the _Query Select_ privilege on `hotel` also (for RETURNING clause).
+To execute the following statement, your client must have both the `Write` privilege and the `Read` privilege (for the RETURNING clause) on `hotel`.
 
 [source,sqlpp]
 ----
@@ -70,7 +69,7 @@ include::example$dml/upsert-rbac-return.n1ql[]
 include::example$dml/upsert-rbac-return.jsonc[]
 ----
 
-To execute the following statement, your client must have the _Query Update_ and _Query Insert_ privileges on `landmark` and _Query Select_ privilege on `pass:c[`beer-sample`]`.
+To execute the following statement, your client must have the `Write` privilege on `landmark` and the `Read` privilege on `beer-sample`.
 
 [source,sqlpp]
 ----

--- a/modules/n1ql/pages/n1ql-language-reference/userfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/userfun.adoc
@@ -30,7 +30,21 @@ When you do this, an error is generated.
 
 == Prerequisites
 
-* To manage user-defined functions on your operational cluster, you must have the xref:projects:project-roles.adoc#project-owner-role[`Project Owner`] or the xref:projects:project-roles.adoc#project-cluster-data-reader-writer[`Cluster Data Reader/Writer`] role.
+To manage user-defined functions, your client must have specific privileges depending on your xref:clusters:cluster-rbac.adoc#cluster-access-credential-types[cluster access credential type] and whether the function is global or scoped.
+
+[cols="1a,1,1a", options="header"]
+|===
+| Credential Type | Function Type | Privilege 
+| Basic
+| Global or scoped
+| xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Write`]
+| Advanced
+| Global
+| xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Global Function Manage`] 
+| Advanced
+| Scoped
+| xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Manage`]
+|===
 
 == Arguments
 

--- a/modules/n1ql/pages/n1ql-language-reference/with.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/with.adoc
@@ -13,7 +13,7 @@ Common table expressions or CTEs can be used to simplify complex queries.
 They can also be particularly useful when a value needs to be used several times in a query.
 
 The WITH clause has comparable functionality to the xref:n1ql-language-reference/let.adoc[LET] clause.
-The major difference between the WITH clause and the LET clause is that the WITH clause can come before the `SELECT` clause, enabling an earlier definition of expressions; whereas the LET clause must come after the xref:n1ql-language-reference/from.adoc[FROM] clause.
+The major difference between the WITH clause and the LET clause is that the WITH clause can come before the SELECT clause, enabling an earlier definition of expressions; whereas the LET clause must come after the xref:n1ql-language-reference/from.adoc[FROM] clause.
 
 The WITH clause is evaluated once per query block, and LET is evaluated for every object produced by the FROM or JOIN clause.
 
@@ -22,7 +22,7 @@ A CTE that you create in one WITH clause may be referenced in a later WITH claus
 
 == Prerequisites
 
-The WITH clause can only be used preceding a `SELECT` statement.
+Use the WITH clause only before a SELECT statement.
 To select data from a document or keyspace, your client must have the `Read` privilege on the document or keyspace.
 For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 

--- a/modules/n1ql/pages/n1ql-language-reference/with.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/with.adoc
@@ -22,15 +22,10 @@ A CTE that you create in one WITH clause may be referenced in a later WITH claus
 
 == Prerequisites
 
-ifdef::granular-rbac[]
-The WITH clause can only be used preceding a SELECT statement, and to select data from a document or keyspace, your client must have the [.param]`query_select` privilege on the document or keyspace.
-For more details about cluster access privileges, see
-xref:clusters:manage-database-users.adoc[].
-endif::granular-rbac[]
+To select data from a document or keyspace, your client must have 1 of the following privileges:
 
-Use the WITH clause only before a SELECT statement.
-To select data from a document or keyspace, your client must have the `Read` privilege on the document or keyspace.
-For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
+* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`] privilege on the document or keyspace.
+* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Read`] privilege on the document or keyspace.
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/with.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/with.adoc
@@ -13,7 +13,7 @@ Common table expressions or CTEs can be used to simplify complex queries.
 They can also be particularly useful when a value needs to be used several times in a query.
 
 The WITH clause has comparable functionality to the xref:n1ql-language-reference/let.adoc[LET] clause.
-The major difference between the WITH clause and the LET clause is that the WITH clause can come before the SELECT clause, enabling an earlier definition of expressions; whereas the LET clause must come after the xref:n1ql-language-reference/from.adoc[FROM] clause.
+The major difference between the WITH clause and the LET clause is that the WITH clause can come before the `SELECT` clause, enabling an earlier definition of expressions; whereas the LET clause must come after the xref:n1ql-language-reference/from.adoc[FROM] clause.
 
 The WITH clause is evaluated once per query block, and LET is evaluated for every object produced by the FROM or JOIN clause.
 
@@ -22,9 +22,9 @@ A CTE that you create in one WITH clause may be referenced in a later WITH claus
 
 == Prerequisites
 
-The WITH clause can only be used preceding a SELECT statement, and to select data from a document or keyspace, your client must have the [.param]`query_select` privilege on the document or keyspace.
-For more details about cluster access privileges, see
-xref:clusters:manage-database-users.adoc[].
+The WITH clause can only be used preceding a `SELECT` statement.
+To select data from a document or keyspace, your client must have the `Read` privilege on the document or keyspace.
+For more information about access privileges, see xref:clusters:manage-database-users.adoc[].
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/with.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/with.adoc
@@ -22,6 +22,12 @@ A CTE that you create in one WITH clause may be referenced in a later WITH claus
 
 == Prerequisites
 
+ifdef::granular-rbac[]
+The WITH clause can only be used preceding a SELECT statement, and to select data from a document or keyspace, your client must have the [.param]`query_select` privilege on the document or keyspace.
+For more details about cluster access privileges, see
+xref:clusters:manage-database-users.adoc[].
+endif::granular-rbac[]
+
 Use the WITH clause only before a SELECT statement.
 To select data from a document or keyspace, your client must have the `Read` privilege on the document or keyspace.
 For more information about access privileges, see xref:clusters:manage-database-users.adoc[].

--- a/modules/n1ql/pages/n1ql-language-reference/with.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/with.adoc
@@ -22,10 +22,17 @@ A CTE that you create in one WITH clause may be referenced in a later WITH claus
 
 == Prerequisites
 
-To select data from a document or keyspace, your client must have 1 of the following privileges:
+To select data from a document or keyspace, your client must have necessary privileges on the document or keyspace.
+The required privilege depends on your xref:clusters:cluster-rbac.adoc#cluster-access-credential-types[cluster access credential type]. 
 
-* If you're using basic cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`] privilege on the document or keyspace.
-* If you're using advanced cluster access credentials, your client must have the xref:clusters:cluster-rbac.adoc#advanced-access-credentials[`Query Read`] privilege on the document or keyspace.
+[cols="1a,1a", options="header"]
+|===
+| Credential Type | Privilege 
+| Basic
+| xref:clusters:cluster-rbac.adoc#basic-access-credentials[`Read`]
+| Advanced
+| xref:clusters:cluster-rbac.adoc#privileges-for-advanced-access-credentials[`Query Read`]
+|===
 
 == Syntax
 


### PR DESCRIPTION
~~PR to simplify and fix RBAC content for SQL++ statements (for Capella).~~

Updating the scope to add fine-grained RBAC. 

Key changes include:
- ~~Replacing privileges like `query_select`, `query_manage_index`, etc., with more high-level privileges like `Read` and `Write`.~~
- Adding fine-grained RBAC.
- Matching terminologies on the Capella UI.
- Removing server-specific terms.

Preview site:

- Link: [SQL++ Statements](https://preview.docs-test.couchbase.com/docs-devex-DOC-13661-sqlpp-rbac/cloud/n1ql/n1ql-language-reference/statements.html)
   - Open the document for each SQL++ statement.
   - Check the **Prerequisites** section on that page for the RBAC details.
- Preview credentials:  [Credentials for internal review](https://couchbasecloud.atlassian.net/wiki/x/dYF_dQ#Preview-docs-for-internal-review)

