### PR TITLE
[DOC-13757] Revamp the Comparison Functions page

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/comparisonfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/comparisonfun.adoc
@@ -11,41 +11,45 @@
 
 Determines the largest non-NULL, non-MISSING value from a list of expressions.
 
-* Requires at least two expressions.
-* All expressions must be of the same type; otherwise, the function returns `NULL`.
-* Ignores `NULL` and `MISSING` values when evaluating the greatest value.
+The function requires at least two expressions and ignores `NULL` and `MISSING` values when evaluating the greatest value.
 
 === Syntax
 
 [subs=normal]
 ....
-GREATEST (expression1, expression2, ..., expressionN)
+GREATEST (expression1, expression2, ...)
 ....
 
 ==== Arguments
 
-expression1, expression2, ..., expressionN::
-
-Any valid expression. 
+expression1, expression2, ...::
+The expressions to compare.
 You must specify at least two expressions.
-The expressions must be of the same type (for example, all numbers or all strings).
 
-=== Return Values
+=== Return Value
 
 The function returns:
 
-* The largest value among the provided expressions, if all expressions are of the same type.  
-* `NULL` if the expressions are of different types or if all expressions are `NULL` or `MISSING`.
+* The largest value among the provided expressions. 
+* `NULL` if all expressions are `NULL` or `MISSING`.
 
 === Example
 
-.Find the greatest value among three numbers
+.Find the highest rating across all review categories for a hotel
 ====
 
 .Query
 [source,sqlpp]
 ----
-SELECT GREATEST(10, 20, 15) AS greatest_value;
+SELECT GREATEST(
+    reviews[0].ratings.Service,
+    reviews[0].ratings.Cleanliness,
+    reviews[0].ratings.Overall,
+    reviews[0].ratings.Location,
+    reviews[0].ratings.Rooms
+) AS highest_rating
+FROM `travel-sample`.`inventory`.hotel
+WHERE id = 10025;
 ----
 
 .Result
@@ -53,7 +57,7 @@ SELECT GREATEST(10, 20, 15) AS greatest_value;
 ----
 [
   {
-    "greatest_value": 20
+    "highest_rating": 5
   }
 ]
 ----
@@ -65,43 +69,53 @@ SELECT GREATEST(10, 20, 15) AS greatest_value;
 
 Determines the smallest non-NULL, non-MISSING value from a list of expressions.
 
-* Requires at least two expressions.
-* All expressions must be of the same type; otherwise, the function returns `NULL`.
-* Ignores `NULL` and `MISSING` values when evaluating the least value.
-* Returns `NULL` if all expressions are `NULL` or `MISSING`.
+The function requires at least two expressions and ignores `NULL` and `MISSING` values when evaluating the least value.
 
 === Syntax
 
 [subs=normal]
 ....
-LEAST (expr1, expr2, ..., exprN)
+LEAST (expression1, expression2, ...)
 ....
 
 ==== Arguments
 
-expr1, expr2, ..., exprN::
-Any valid expression.
-You can specify two or more expressions.
+expression1, expression2, ...::
+The expressions to compare.
+You must specify at least two expressions.
 
-=== Return Values
-If all expressions are of the same type, the function returns the smallest non-NULL, non-MISSING value.
-If the expressions are of different types, the function returns NULL.
+=== Return Value
+
+The function returns:
+
+* The smallest value among the provided expressions.
+* `NULL` if all expressions are `NULL` or `MISSING`.
 
 === Example
 
-.Find the least value among three numbers
+.Find the least rating across all review categories for a hotel
 ====
+
 .Query
 [source,sqlpp]
 ----
-SELECT LEAST(10, 20, 15) AS least_value;
+SELECT LEAST(
+    reviews[0].ratings.Service,
+    reviews[0].ratings.Cleanliness,
+    reviews[0].ratings.Overall,
+    reviews[0].ratings.Location,
+    reviews[0].ratings.Rooms
+) AS highest_rating
+FROM `travel-sample`.`inventory`.hotel
+WHERE id = 10025;
 ----
+
 .Result
 [source,json]
 ----
 [
   {
-    "least_value": 10
+    "lowest_rating": 3
   }
 ]
 ----

--- a/modules/n1ql/pages/n1ql-language-reference/comparisonfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/comparisonfun.adoc
@@ -63,6 +63,27 @@ WHERE id = 10025;
 ----
 ====
 
+.Find the greatest value among different types
+====
+
+.Query
+[source,sqlpp]
+----
+SELECT GREATEST(42, "Hotel", "2025-12-01T00:00:00Z") AS greatest_value;
+----
+
+.Result
+[source,json]
+----
+[
+  {
+    "greatest_value": "Hotel"
+  }
+]
+----
+The function returns `"Hotel"` because strings have a higher precedence than numbers and dates.
+====
+
 == LEAST
 
 === Description
@@ -120,3 +141,25 @@ WHERE id = 10025;
 ]
 ----
 ====
+
+.Find the least value among different types
+====
+
+.Query
+[source,sqlpp]
+----
+SELECT LEAST(42, "Hotel", "2025-12-01T00:00:00Z") AS least_value;
+----
+
+.Result
+[source,json]
+----
+[
+  {
+    "least_value": 42
+  }
+]
+----
+The function returns `42` because numbers have a lower precedence than strings and dates.
+====
+

--- a/modules/n1ql/pages/n1ql-language-reference/comparisonfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/comparisonfun.adoc
@@ -2,12 +2,107 @@
 :description: Comparison functions determine the greatest or least value from a set of values.
 :page-topic-type: reference
 
+[abstract]
 {description}
 
-GREATEST(expression1, expression2, \...)
+== GREATEST 
 
-Largest non-NULL, non-MISSING value if the values are of the same type; otherwise NULL.
+=== Description
 
-LEAST(expression1, expression2, \...)
+Determines the largest non-NULL, non-MISSING value from a list of expressions.
 
-Returns smallest non-NULL, non-MISSING value if the values are of the same type, otherwise returns NULL.
+* Requires at least two expressions.
+* All expressions must be of the same type; otherwise, the function returns `NULL`.
+* Ignores `NULL` and `MISSING` values when evaluating the greatest value.
+
+=== Syntax
+
+[subs=normal]
+....
+GREATEST (expression1, expression2, ..., expressionN)
+....
+
+==== Arguments
+
+expression1, expression2, ..., expressionN::
+
+Any valid expression. 
+You must specify at least two expressions.
+The expressions must be of the same type (for example, all numbers or all strings).
+
+=== Return Values
+
+The function returns:
+
+* The largest value among the provided expressions, if all expressions are of the same type.  
+* `NULL` if the expressions are of different types or if all expressions are `NULL` or `MISSING`.
+
+=== Example
+
+.Find the greatest value among three numbers
+====
+
+.Query
+[source,sqlpp]
+----
+SELECT GREATEST(10, 20, 15) AS greatest_value;
+----
+
+.Result
+[source,json]
+----
+[
+  {
+    "greatest_value": 20
+  }
+]
+----
+====
+
+== LEAST
+
+=== Description
+
+Determines the smallest non-NULL, non-MISSING value from a list of expressions.
+
+* Requires at least two expressions.
+* All expressions must be of the same type; otherwise, the function returns `NULL`.
+* Ignores `NULL` and `MISSING` values when evaluating the least value.
+* Returns `NULL` if all expressions are `NULL` or `MISSING`.
+
+=== Syntax
+
+[subs=normal]
+....
+LEAST (expr1, expr2, ..., exprN)
+....
+
+==== Arguments
+
+expr1, expr2, ..., exprN::
+Any valid expression.
+You can specify two or more expressions.
+
+=== Return Values
+If all expressions are of the same type, the function returns the smallest non-NULL, non-MISSING value.
+If the expressions are of different types, the function returns NULL.
+
+=== Example
+
+.Find the least value among three numbers
+====
+.Query
+[source,sqlpp]
+----
+SELECT LEAST(10, 20, 15) AS least_value;
+----
+.Result
+[source,json]
+----
+[
+  {
+    "least_value": 10
+  }
+]
+----
+====

--- a/modules/n1ql/pages/n1ql-language-reference/comparisonfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/comparisonfun.adoc
@@ -10,9 +10,13 @@
 
 === Description
 
-Determines the largest non-NULL, non-MISSING value from a list of expressions.
+Returns the greatest value from a list of expressions.
 
-The function requires at least 2 expressions and ignores `NULL` and `MISSING` when evaluating the greatest value.
+The function compares values based on the sort order of their data types.
+For example, it compares strings alphabetically and dates chronologically.
+When comparing values of different data types, the function uses xref:n1ql-language-reference/datatypes.adoc#collation[collation rules] to determine precedence.
+
+The function requires at least 2 expressions and ignores `NULL` and `MISSING` when evaluating values.
 
 === Arguments
 
@@ -96,9 +100,13 @@ The function returns `"airline"` because strings have a higher precedence than n
 
 === Description
 
-Determines the smallest non-NULL, non-MISSING value from a list of expressions.
+Returns the smallest value from a list of expressions.
 
-The function requires at least 2 expressions and ignores `NULL` and `MISSING` when evaluating the least value.
+The function compares values based on the sort order of their data types.
+For example, it compares strings alphabetically and dates chronologically.
+When comparing values of different data types, the function uses xref:n1ql-language-reference/datatypes.adoc#collation[collation rules] to determine precedence.
+
+The function requires at least 2 expressions and ignores `NULL` and `MISSING` when evaluating values.
 
 === Arguments
 

--- a/modules/n1ql/pages/n1ql-language-reference/comparisonfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/comparisonfun.adoc
@@ -17,7 +17,7 @@ The function requires at least 2 expressions and ignores `NULL` and `MISSING` va
 
 [subs=normal]
 ....
-GREATEST (expression1, expression2, ...)
+GREATEST(expression1, expression2, ...)
 ....
 
 ==== Arguments
@@ -96,7 +96,7 @@ The function requires at least 2 expressions and ignores `NULL` and `MISSING` va
 
 [subs=normal]
 ....
-LEAST (expression1, expression2, ...)
+LEAST(expression1, expression2, ...)
 ....
 
 ==== Arguments

--- a/modules/n1ql/pages/n1ql-language-reference/comparisonfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/comparisonfun.adoc
@@ -12,7 +12,7 @@
 
 Determines the largest non-NULL, non-MISSING value from a list of expressions.
 
-The function requires at least 2 expressions and ignores `NULL` and `MISSING` values when evaluating the greatest value.
+The function requires at least 2 expressions and ignores `NULL` and `MISSING` when evaluating the greatest value.
 
 === Arguments
 
@@ -98,7 +98,7 @@ The function returns `"airline"` because strings have a higher precedence than n
 
 Determines the smallest non-NULL, non-MISSING value from a list of expressions.
 
-The function requires at least 2 expressions and ignores `NULL` and `MISSING` values when evaluating the least value.
+The function requires at least 2 expressions and ignores `NULL` and `MISSING` when evaluating the least value.
 
 === Arguments
 

--- a/modules/n1ql/pages/n1ql-language-reference/comparisonfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/comparisonfun.adoc
@@ -5,7 +5,8 @@
 [abstract]
 {description}
 
-== GREATEST 
+[[comparison-func-greatest]]
+== GREATEST(`expr1` , `expr2`, ...)
 
 === Description
 
@@ -13,16 +14,9 @@ Determines the largest non-NULL, non-MISSING value from a list of expressions.
 
 The function requires at least 2 expressions and ignores `NULL` and `MISSING` values when evaluating the greatest value.
 
-=== Syntax
+=== Arguments
 
-[subs=normal]
-....
-GREATEST(expression1, expression2, ...)
-....
-
-==== Arguments
-
-expression1, expression2, ...::
+expr1, expr2, ...::
 The expressions to compare.
 You must specify at least 2 expressions.
 
@@ -35,21 +29,13 @@ The function returns:
 
 === Examples
 
-.Find the highest rating across all review categories for a hotel
+.Find the greatest value from a list of numbers
 ====
 
 .Query
 [source,sqlpp]
 ----
-SELECT GREATEST(
-    reviews[0].ratings.Service,
-    reviews[0].ratings.Cleanliness,
-    reviews[0].ratings.Overall,
-    reviews[0].ratings.Location,
-    reviews[0].ratings.Rooms
-) AS highest_rating
-FROM `travel-sample`.`inventory`.hotel
-WHERE id = 10025;
+SELECT GREATEST(19.50, 15, 21.50, 18) AS greatest_number;
 ----
 
 .Result
@@ -57,19 +43,20 @@ WHERE id = 10025;
 ----
 [
   {
-    "highest_rating": 5
+    "greatest_number": 21.5
   }
 ]
 ----
 ====
 
-.Find the greatest value among different types
+.Find the greatest value from a list of strings
 ====
 
 .Query
 [source,sqlpp]
 ----
-SELECT GREATEST(42, "Hotel", "2025-12-01T00:00:00Z") AS greatest_value;
+SELECT GREATEST("United", "Delta", "American", "Southwest") 
+AS last_airline_name;
 ----
 
 .Result
@@ -77,14 +64,35 @@ SELECT GREATEST(42, "Hotel", "2025-12-01T00:00:00Z") AS greatest_value;
 ----
 [
   {
-    "greatest_value": "Hotel"
+    "last_airline_name": "United"
   }
 ]
 ----
-The function returns `"Hotel"` because strings have a higher precedence than numbers and dates.
+When comparing string values, the function uses alphabetical order to determine the greatest value.
 ====
 
-== LEAST
+.Find the greatest value from a list with mixed types
+====
+.Query
+[source,sqlpp]
+----
+SELECT GREATEST(42, "airline", "2025-12-01T00:00:00Z", NULL)
+AS greatest_value;
+----
+.Result
+[source,json]
+----
+[
+  {
+    "greatest_value": "airline"
+  }
+]
+----
+The function returns `"airline"` because strings have a higher precedence than numbers and dates.
+====
+
+[[comparison-func-least]]
+== LEAST(`expr1` , `expr2`, ...)
 
 === Description
 
@@ -92,16 +100,9 @@ Determines the smallest non-NULL, non-MISSING value from a list of expressions.
 
 The function requires at least 2 expressions and ignores `NULL` and `MISSING` values when evaluating the least value.
 
-=== Syntax
+=== Arguments
 
-[subs=normal]
-....
-LEAST(expression1, expression2, ...)
-....
-
-==== Arguments
-
-expression1, expression2, ...::
+expr1, expr2, ...::
 The expressions to compare.
 You must specify at least 2 expressions.
 
@@ -114,21 +115,13 @@ The function returns:
 
 === Examples
 
-.Find the least rating across all review categories for a hotel
+.Find the least value from a list of numbers
 ====
 
 .Query
 [source,sqlpp]
 ----
-SELECT LEAST(
-    reviews[0].ratings.Service,
-    reviews[0].ratings.Cleanliness,
-    reviews[0].ratings.Overall,
-    reviews[0].ratings.Location,
-    reviews[0].ratings.Rooms
-) AS highest_rating
-FROM `travel-sample`.`inventory`.hotel
-WHERE id = 10025;
+SELECT LEAST(19.50, 15, 21.50, 18) AS lowest_number;
 ----
 
 .Result
@@ -136,21 +129,43 @@ WHERE id = 10025;
 ----
 [
   {
-    "lowest_rating": 3
+    "lowest_number": 15
   }
 ]
 ----
 ====
 
-.Find the least value among different types
+.Find the least value from a list of strings
 ====
 
 .Query
 [source,sqlpp]
 ----
-SELECT LEAST(42, "Hotel", "2025-12-01T00:00:00Z") AS least_value;
+SELECT LEAST("United", "Delta", "American", "Southwest") 
+AS first_airline_name; 
 ----
 
+.Result
+[source,json]
+----
+[
+  {
+    "first_airline_name": "American"
+  }
+]
+----
+When comparing string values, the function uses alphabetical order to determine the least value.
+====
+
+.Find the least value from a list with mixed types
+====
+
+.Query
+[source,sqlpp]
+----
+SELECT LEAST(42, "airline", "2025-12-01T00:00:00Z", NULL)
+AS least_value;
+----
 .Result
 [source,json]
 ----
@@ -162,4 +177,3 @@ SELECT LEAST(42, "Hotel", "2025-12-01T00:00:00Z") AS least_value;
 ----
 The function returns `42` because numbers have a lower precedence than strings and dates.
 ====
-

--- a/modules/n1ql/pages/n1ql-language-reference/comparisonfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/comparisonfun.adoc
@@ -11,7 +11,7 @@
 
 Determines the largest non-NULL, non-MISSING value from a list of expressions.
 
-The function requires at least two expressions and ignores `NULL` and `MISSING` values when evaluating the greatest value.
+The function requires at least 2 expressions and ignores `NULL` and `MISSING` values when evaluating the greatest value.
 
 === Syntax
 
@@ -24,7 +24,7 @@ GREATEST (expression1, expression2, ...)
 
 expression1, expression2, ...::
 The expressions to compare.
-You must specify at least two expressions.
+You must specify at least 2 expressions.
 
 === Return Value
 
@@ -33,7 +33,7 @@ The function returns:
 * The largest value among the provided expressions. 
 * `NULL` if all expressions are `NULL` or `MISSING`.
 
-=== Example
+=== Examples
 
 .Find the highest rating across all review categories for a hotel
 ====
@@ -90,7 +90,7 @@ The function returns `"Hotel"` because strings have a higher precedence than num
 
 Determines the smallest non-NULL, non-MISSING value from a list of expressions.
 
-The function requires at least two expressions and ignores `NULL` and `MISSING` values when evaluating the least value.
+The function requires at least 2 expressions and ignores `NULL` and `MISSING` values when evaluating the least value.
 
 === Syntax
 
@@ -103,7 +103,7 @@ LEAST (expression1, expression2, ...)
 
 expression1, expression2, ...::
 The expressions to compare.
-You must specify at least two expressions.
+You must specify at least 2 expressions.
 
 === Return Value
 
@@ -112,7 +112,7 @@ The function returns:
 * The smallest value among the provided expressions.
 * `NULL` if all expressions are `NULL` or `MISSING`.
 
-=== Example
+=== Examples
 
 .Find the least rating across all review categories for a hotel
 ====


### PR DESCRIPTION
Update the Comparison Functions page to comply with the [function template](https://github.com/couchbaselabs/docs-tooling/blob/main/templates/reference/function.adoc).
Also, addresses the feedback from DOC-13326. 

Preview: [Comparison Function](https://preview.docs-test.couchbase.com/docs-devex-DOC-13757-comparison-function/server/current/n1ql/n1ql-language-reference/comparisonfun.html)
Preview credentials:  [Credentials for internal review](https://couchbasecloud.atlassian.net/wiki/x/dYF_dQ#Preview-docs-for-internal-review)
