### PR TITLE
[DOC-13208] Remove Integer type support from INFER

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/infer.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/infer.adoc
@@ -151,7 +151,7 @@ When the schema inferencing process sees more than [.var]`dictionary_threshold` 
 == Schema Output
 
 The statement returns the output in the http://json-schema.org/documentation.html[JSON Schema draft^] format as specified by http://json-schema.org/[json-schema.org^].
-It supports the following data types: array, boolean, integer, null, number, and object.
+It supports the following data types: array, boolean, null, number, and object.
 
 At the top level, the output contains an array of schemas.
 Each schema recursively describes the structure of a flavor of document.


### PR DESCRIPTION
Jira: DOC-13208

A tiny change to remove "Integer" from the list of data types supported by INFER.