### PR TITLE
DOC-10581: Explain how the LSS file storage works in relation to compaction

### DIFF
--- a/modules/indexes/pages/storage-modes.adoc
+++ b/modules/indexes/pages/storage-modes.adoc
@@ -112,7 +112,8 @@ If the cluster is multi-node, and only some of the nodes host the Index Service,
 
 . Identify the nodes running the Index Service.
 . Remove each of the nodes running the Index Service.
-As Index Service nodes are removed, so are the indexes they contain, and in consequence, any ongoing queries fail.
+As Index Service nodes are removed, so are the indexes they contain.
+In consequence, any ongoing queries fail.
 . Perform a rebalance.
 . Change the Index Storage Settings for the cluster.
 . Add new Index Service nodes, and confirm the revised storage mode.
@@ -168,4 +169,4 @@ In consequence, items most likely to be accessed remain uncompressed in memory, 
 Items less likely to be accessed are retained in memory in compressed form, until their ejection.
 After ejection, they must be accessed through disk reads.
 
-This new model of memory usage leads to higher residence ratios, and greater access efficiency -- at the cost of some additional CPU utilization, due to the more frequent performance of compression and decompression routines.
+This new model of memory usage leads to higher residence ratios and greater access efficiency, at the cost of some additional CPU utilization, due to the more frequent performance of compression and decompression routines.

--- a/modules/indexes/pages/storage-modes.adoc
+++ b/modules/indexes/pages/storage-modes.adoc
@@ -15,7 +15,7 @@ Both standard and memory-optimized indexes implement multi-version concurrency c
 [.labels]
 [.edition]#{enterprise}#
 
-Memory-optimized index-storage is supported by the Nitro storage engine, and is only available in Couchbase Server Enterprise Edition.
+Memory-optimized index storage is supported by the Nitro storage engine, and is only available in Couchbase Server Enterprise Edition.
 
 A memory-optimized index uses a lock-free skiplist to maintain the index and keeps all the index data in memory.
 A memory-optimized index has better latency for index scans and processes the mutations of the data much faster.
@@ -23,26 +23,31 @@ A memory-optimized index has better latency for index scans and processes the mu
 Memory-optimized indexes can be created for both Couchbase and Ephemeral buckets.
 See xref:learn:buckets-memory-and-storage/buckets.adoc[Buckets].
 
-Memory-optimized index-storage allows high-speed maintenance and scanning; since the index is kept fully in memory at all times.
-A snapshot of the index is maintained on disk, to permit rapid recovery if node-failures are experienced.
-To be consistently beneficial, memory-optimized index-storage requires that all nodes running the Index Service have a memory quota sufficient for the number and size of their resident indexes, and for the frequency with which the indexes will be updated and scanned.
+Memory-optimized index storage allows high-speed maintenance and scanning, since the index is kept fully in memory at all times.
+A snapshot of the index is maintained on disk, to permit rapid recovery if node failures are experienced.
+To be consistently beneficial, memory-optimized index storage requires that all nodes running the Index Service have a memory quota sufficient for the number and size of their resident indexes, and for the frequency with which the indexes will be updated and scanned.
 
-Memory-optimized index-storage may be less suitable for nodes where memory is constrained; since whenever the Index Service memory-quota is exceeded, indexes on the node can neither be updated nor scanned.
+Memory-optimized index storage may be less suitable for nodes where memory is constrained, since whenever the Index Service memory quota is exceeded, indexes on the node can neither be updated nor scanned.
 
-If indexer RAM usage goes above 75% of the Index Service memory-quota, an xref:manage:manage-settings/configure-alerts.adoc[error notification] is provided.
-If indexer RAM usage then goes above 95% of the Index Service memory-quota, the indexer goes into the Paused mode on that node; and although the indexes remain in `Active` state, traffic is routed away from the node.
+If indexer RAM usage goes above 75% of the Index Service memory quota, an xref:manage:manage-settings/configure-alerts.adoc[error notification] is provided.
+If indexer RAM usage then goes above 95% of the Index Service memory quota, the indexer goes into the Paused mode on that node.
+Although the indexes remain in `Active` state, traffic is routed away from the node.
 
-Before index-operations can resume, memory must be freed.
-When the indexer RAM usage drops below 80% of the Index Service memory-quota, the indexer goes into Active mode again on that node.
+Before index operations can resume, memory must be freed.
+When the indexer RAM usage drops below 80% of the Index Service memory quota, the indexer goes into Active mode again on that node.
 
 To resume indexing operations on a node where the Indexer has paused due to low memory, consider taking one or more of the following actions:
 
 * Increase the index memory quota, to give indexes additional memory for request processing.
 * Remove less important indexes from the node, to free up memory.
-* Remove buckets with indexes: removing a bucket automatically removes all the dependent indexes.
-* Flush buckets that have indexes: flushing a bucket deletes all data in a bucket; and even if there are pending updates not yet processed, flushing causes all indexes to drop their own data.
+* Remove buckets with indexes.
+Removing a bucket automatically removes all the dependent indexes.
+* Flush buckets that have indexes.
+Flushing a bucket deletes all data in a bucket.
+Even if there are pending updates not yet processed, flushing causes all indexes to drop their own data.
 +
-Attempting to delete bucket-data selectively during an out-of-memory condition does not succeed in decreasing memory-usage; since without memory, such requested deletions cannot themselves be processed.
+Attempting to delete bucket data selectively during an out-of-memory condition does not succeed in decreasing memory usage.
+Without memory, such requested deletions cannot themselves be processed.
 
 In cases where recovery requires an Index Service node to be restarted, the node's resident memory-optimized indexes are rebuilt from the snapshots retained on disk.
 Following the node's restart, these indexes remain in the `Warmup` state until all information has been read into memory: then, final updates are made with the indexes in `Active` state.
@@ -53,11 +58,10 @@ For information on these settings, see xref:services-and-indexes/indexes/index-r
 [#standard-index-storage]
 == Standard Index Storage
 
-Standard is the default storage-setting for Secondary Indexes: the indexes are saved on disk; in a disk-optimized format that uses both memory and disk for index-update and scanning.
+Standard is the default storage setting for Secondary Indexes: the indexes are saved on disk in a disk-optimized format that uses both memory and disk for index update and scanning.
 The performance of standard index storage depends on overall I/O performance.
 
-In versions of Couchbase Server prior to 7.0.2, standard index storage supports indexes for Couchbase Buckets, but not for Ephemeral Buckets.
-In version 7.0.2 and after, standard index storage supports indexes for both Couchbase buckets and Ephemeral buckets.
+In Couchbase Server version 7.0.2 and later, standard index storage supports indexes for both Couchbase buckets and Ephemeral buckets.
 This applies both to Couchbase Server Enterprise Edition and to Couchbase Server Community Edition.
 See xref:learn:buckets-memory-and-storage/buckets.adoc[Buckets].
 
@@ -71,7 +75,7 @@ In Couchbase Server Enterprise Edition, standard index storage is supported by t
 In this case, compaction is handled automatically.
 
 Each index is represented on disk by up to 4 Log Structured Stores (LSS).
-A single LSS is made up of multiple append-only segment files.
+A single LSS is made up of multiple append only segment files.
 Index compaction and space reclamation are triggered when the LSS segment files reach a maximum file size, which by default is 512{nbsp}MiB on Microsoft Windows and 4{nbsp}GiB on GNU Linux and macOS.
 
 To change the maximum LSS segment file size, use the xref:index-rest-settings:index.adoc[Index Settings REST API] to set the `indexer.plasma.LSSSegmentFileSize` property.
@@ -82,36 +86,36 @@ For installations of Couchbase Server Enterprise Edition running on Linux, hole 
 ****
 [.edition]#{community}#
 
-In Couchbase Server Community Edition, standard index-storage is supported by the Forestdb storage engine.
+In Couchbase Server Community Edition, standard index storage is supported by the Forestdb storage engine.
 In this case, each index saved with the standard option has two write modes:
 
-[[circular-reuse]]Circular Write Mode:: Writes changes to the end of the index-file, until the relative index fragmentation exceeds 65%.
+[[circular-reuse]]Circular Write Mode:: Writes changes to the end of the index file, until the relative index fragmentation exceeds 65%.
 Block reuse is then triggered: new data is written into stale blocks where possible, rather than to the end of the file, so as to optimize I/O throughput.
 Full compaction runs in accordance with the value of the *Circular write mode with day + time interval trigger* setting: see
 xref:manage:manage-settings/configure-compact-settings.adoc#index-fragmentation[Index Fragmentation].
 However, the index fragmentation data size is not significantly changed by compaction.
 
-[[compaction]]Append-only Write Mode:: Writes changes to the end of the index-file, invalidating existing pages within the index file, and requiring frequent, full compaction.
+[[compaction]]Append-only Write Mode:: Writes changes to the end of the index file, invalidating existing pages within the index file, and requiring frequent, full compaction.
 
 By default, Couchbase Server Community Edition uses Circular Write Mode for standard index storage.
 Append-only Write Mode is provided for backwards compatibility with previous versions.
 ****
 
-Other storage-settings are described in detail in xref:manage:manage-settings/configure-compact-settings.adoc[Configuring Auto-Compaction].
+Other storage settings are described in detail in xref:manage:manage-settings/configure-compact-settings.adoc[Configuring Auto-Compaction].
 
 == Changing Index Storage Settings
 
 Settings are established at cluster initialization for all indexes on the cluster, across all buckets.
-Following cluster-initialization, to change from one setting to the other, all nodes running the Index Service must be removed.
+Following cluster initialization, to change from one setting to the other, all nodes running the Index Service must be removed.
 If the cluster is single-node, uninstall and reinstall Couchbase Server.
 If the cluster is multi-node, and only some of the nodes host the Index Service, proceed as follows:
 
 . Identify the nodes running the Index Service.
 . Remove each of the nodes running the Index Service.
-As Index Service nodes are removed, so are the indexes they contain; and in consequence, any ongoing queries fail.
+As Index Service nodes are removed, so are the indexes they contain, and in consequence, any ongoing queries fail.
 . Perform a rebalance.
-. Change the Index-Storage Settings for the cluster.
-. Add new Index-Service nodes, and confirm the revised storage mode.
+. Change the Index Storage Settings for the cluster.
+. Add new Index Service nodes, and confirm the revised storage mode.
 
 For information on adding and removing nodes, and on rebalancing a cluster, see
 xref:manage:manage-nodes/node-management-overview.adoc[Manage
@@ -150,13 +154,18 @@ include::manage:manage-settings/general-settings.adoc[tag=bloom-filter-default]
 [#in-memory-compression]
 === In-Memory Compression
 
-Plasma memory-management routinely performs the compression of a subset of items, in order to free memory; and thereby, due to the additional memory made available, keep a greater number of items in memory overall.
+Plasma memory management routinely performs the compression of a subset of items.
+This frees memory, and due to the additional memory made available, keeps a greater number of items in memory overall.
 By keeping more items in memory, the need for disk reads is reduced, as are corresponding latencies.
 
 The selection of items to be compressed occurs periodically.
-Only items that have already been flushed to disk are compressed: after compression, such items are principal candidates for subsequent ejection.
+Only items that have already been flushed to disk are compressed.
+After compression, such items are principal candidates for subsequent ejection.
 
-Disk-flushing occurs every 10 minutes: items not yet flushed to disk are not compressed; nor is any recently used item.
-In consequence, items most likely to be accessed remain uncompressed in memory, and are therefore accessible with the least latency; while items less likely to be accessed are retained in memory in compressed form, until their ejection; beyond which, they must be accessed through disk reads.
+Disk flushing occurs every 10 minutes.
+Items not yet flushed to disk are not compressed, nor is any recently used item.
+In consequence, items most likely to be accessed remain uncompressed in memory, and are therefore accessible with the least latency.
+Items less likely to be accessed are retained in memory in compressed form, until their ejection.
+After ejection, they must be accessed through disk reads.
 
-This new model of memory usage leads to higher residence ratios, and greater access efficiency; at the cost of some additional CPU utilization, due to the more frequent performance of compression and decompression routines.
+This new model of memory usage leads to higher residence ratios, and greater access efficiency -- at the cost of some additional CPU utilization, due to the more frequent performance of compression and decompression routines.

--- a/modules/indexes/pages/storage-modes.adoc
+++ b/modules/indexes/pages/storage-modes.adoc
@@ -5,7 +5,7 @@
 :page-aliases: learn:services-and-indexes/indexes/storage-modes,understanding-couchbase:services-and-indexes/indexes/storage-modes,architecture:index-storage
 
 [abstract]
-A Secondary Index can be saved in either of two ways: _memory-optimized_ or _standard_.
+{description}
 
 Both standard and memory-optimized indexes implement multi-version concurrency control (MVCC) to provide consistent index scan results and high throughput.
 
@@ -15,7 +15,7 @@ Both standard and memory-optimized indexes implement multi-version concurrency c
 [.labels]
 [.edition]#{enterprise}#
 
-Memory-optimized index-storage is supported by the _Nitro_ storage engine, and is only available in Couchbase Server Enterprise Edition.
+Memory-optimized index-storage is supported by the Nitro storage engine, and is only available in Couchbase Server Enterprise Edition.
 
 A memory-optimized index uses a lock-free skiplist to maintain the index and keeps all the index data in memory.
 A memory-optimized index has better latency for index scans and processes the mutations of the data much faster.
@@ -29,7 +29,7 @@ To be consistently beneficial, memory-optimized index-storage requires that all 
 
 Memory-optimized index-storage may be less suitable for nodes where memory is constrained; since whenever the Index Service memory-quota is exceeded, indexes on the node can neither be updated nor scanned.
 
-If indexer RAM usage goes above 75% of the Index Service memory-quota, an xref:manage:manage-settings/configure-alerts.adoc[error-notification] is provided.
+If indexer RAM usage goes above 75% of the Index Service memory-quota, an xref:manage:manage-settings/configure-alerts.adoc[error notification] is provided.
 If indexer RAM usage then goes above 95% of the Index Service memory-quota, the indexer goes into the Paused mode on that node; and although the indexes remain in `Active` state, traffic is routed away from the node.
 
 Before index-operations can resume, memory must be freed.
@@ -37,28 +37,28 @@ When the indexer RAM usage drops below 80% of the Index Service memory-quota, th
 
 To resume indexing operations on a node where the Indexer has paused due to low memory, consider taking one or more of the following actions:
 
-* Increase the index-memory quota, to give indexes additional memory for request-processing.
+* Increase the index memory quota, to give indexes additional memory for request processing.
 * Remove less important indexes from the node, to free up memory.
 * Remove buckets with indexes: removing a bucket automatically removes all the dependent indexes.
 * Flush buckets that have indexes: flushing a bucket deletes all data in a bucket; and even if there are pending updates not yet processed, flushing causes all indexes to drop their own data.
 +
-Note that attempting to delete bucket-data _selectively_ during an out-of-memory condition does not succeed in decreasing memory-usage; since without memory, such requested deletions cannot themselves be processed.
+Attempting to delete bucket-data selectively during an out-of-memory condition does not succeed in decreasing memory-usage; since without memory, such requested deletions cannot themselves be processed.
 
-In cases where recovery requires an Index-Service node to be restarted, the node's resident memory-optimized indexes are rebuilt from the snapshots retained on disk.
+In cases where recovery requires an Index Service node to be restarted, the node's resident memory-optimized indexes are rebuilt from the snapshots retained on disk.
 Following the node's restart, these indexes remain in the `Warmup` state until all information has been read into memory: then, final updates are made with the indexes in `Active` state.
-Note that once a rebuilt index is thus available, queries with `consistency=request_plus` or `consistency=at_plus` fail, if the specified timestamp exceeds the last timestamp processed by given index. footnote:[In fact, queries in this case wait for a consistent snapshot to be available and time out, rather than fail immediately.]
+Once a rebuilt index is available, queries with `consistency=request_plus` or `consistency=at_plus` fail, if the specified timestamp exceeds the last timestamp processed by given index. footnote:[In fact, queries in this case wait for a consistent snapshot to be available and time out, rather than fail immediately.]
 However, queries with `consistency=unbounded` execute normally.
 For information on these settings, see xref:services-and-indexes/indexes/index-replication.adoc[Index Availability and Performance].
 
 [#standard-index-storage]
 == Standard Index Storage
 
-_Standard_ is the default storage-setting for Secondary Indexes: the indexes are saved on disk; in a disk-optimized format that uses both memory and disk for index-update and scanning.
+Standard is the default storage-setting for Secondary Indexes: the indexes are saved on disk; in a disk-optimized format that uses both memory and disk for index-update and scanning.
 The performance of standard index storage depends on overall I/O performance.
 
 In versions of Couchbase Server prior to 7.0.2, standard index storage supports indexes for Couchbase Buckets, but not for Ephemeral Buckets.
-In version 7.0.2 and after, standard index storage supports indexes for both Couchbase buckets _and_ Ephemeral buckets.
-This applies both to Enterprise and to Community Edition.
+In version 7.0.2 and after, standard index storage supports indexes for both Couchbase buckets and Ephemeral buckets.
+This applies both to Couchbase Server Enterprise Edition and to Couchbase Server Community Edition.
 See xref:learn:buckets-memory-and-storage/buckets.adoc[Buckets].
 
 The standard global secondary index uses a B-Tree index and keeps the optimal working set of data in the buffer.
@@ -67,23 +67,23 @@ This means the total size of the index can be much bigger than the amount of mem
 ****
 [.edition]#{enterprise}#
 
-In Couchbase Server Enterprise Edition, standard index-storage is supported by the _Plasma_ storage engine.
+In Couchbase Server Enterprise Edition, standard index storage is supported by the Plasma storage engine.
 In this case, compaction is handled automatically.
 
-However, for installations of Couchbase Server Enterprise Edition running on Linux, note that hole punching is required to enable auto-compaction of Global Secondary Indexes using standard index-storage.
+However, for installations of Couchbase Server Enterprise Edition running on Linux, hole punching is required to enable auto-compaction of Global Secondary Indexes using standard index-storage.
 ****
 
 ****
 [.edition]#{community}#
 
-In Couchbase Server Community Edition, standard index-storage is supported by the _ForestDB_ storage engine.
-In this case, each index saved with the _standard_ option has two write modes:
+In Couchbase Server Community Edition, standard index-storage is supported by the Forestdb storage engine.
+In this case, each index saved with the standard option has two write modes:
 
 [[circular-reuse]]Circular Write Mode:: Writes changes to the end of the index-file, until the relative index fragmentation exceeds 65%.
-_Block reuse_ is then triggered: new data is written into stale blocks where possible, rather than to the end of the file, so as to optimize I/O throughput.
+Block reuse is then triggered: new data is written into stale blocks where possible, rather than to the end of the file, so as to optimize I/O throughput.
 Full compaction runs in accordance with the value of the *Circular write mode with day + time interval trigger* setting: see
 xref:manage:manage-settings/configure-compact-settings.adoc#index-fragmentation[Index Fragmentation].
-Note, however, that the index-fragmentation data-size is not significantly changed by compaction.
+However, the index fragmentation data size is not significantly changed by compaction.
 
 [[compaction]]Append-only Write Mode:: Writes changes to the end of the index-file, invalidating existing pages within the index file, and requiring frequent, full compaction.
 
@@ -93,16 +93,16 @@ Append-only Write Mode is provided for backwards compatibility with previous ver
 
 Other storage-settings are described in detail in xref:manage:manage-settings/configure-compact-settings.adoc[Configuring Auto-Compaction].
 
-== Changing Index-Storage Settings
+== Changing Index Storage Settings
 
-Settings are established at cluster-initialization for all indexes on the cluster, across all buckets.
+Settings are established at cluster initialization for all indexes on the cluster, across all buckets.
 Following cluster-initialization, to change from one setting to the other, all nodes running the Index Service must be removed.
 If the cluster is single-node, uninstall and reinstall Couchbase Server.
 If the cluster is multi-node, and only some of the nodes host the Index Service, proceed as follows:
 
 . Identify the nodes running the Index Service.
 . Remove each of the nodes running the Index Service.
-Note that as Index-Service nodes are removed, so are the indexes they contain; and in consequence, any ongoing queries fail.
+As Index Service nodes are removed, so are the indexes they contain; and in consequence, any ongoing queries fail.
 . Perform a rebalance.
 . Change the Index-Storage Settings for the cluster.
 . Add new Index-Service nodes, and confirm the revised storage mode.
@@ -115,9 +115,9 @@ Nodes and Clusters].
 
 Couchbase Server provides the following enhancements for Plasma:
 
-* Per page _Bloom Filters_.
+* <<per-page-bloom-filters>>
 
-* In-memory compression.
+* <<in-memory-compression>>
 
 These are described below.
 
@@ -125,14 +125,14 @@ These are described below.
 === Per Page Bloom Filters
 
 A https://en.wikipedia.org/wiki/Bloom_filter[Bloom filter^] gives guidance as to whether a searched-for item resides on disk.
-By indicating that the item is _not_ on disk, the filter prevents unnecessary on-disk searches.
+By indicating that the item is not on disk, the filter prevents unnecessary on-disk searches.
 
-If Bloom filters are enabled (which is the default), when a lookup occurs, and the correct Plasma page is located, the Bloom filter indicates either that the item is _not_ on the page, or that it _may be_ on the page.
+If Bloom filters are enabled (which is the default), when a lookup occurs, and the correct Plasma page is located, the Bloom filter indicates either that the item is not on the page, or that it may be on the page.
 If the filter indicates that:
 
-* The item is _not_ on the page, then the item is not on disk, and no disk read need occur.
+* The item is not on the page, then the item is not on disk, and no disk read need occur.
 
-* The item _may be_ on the page, then the item can continue to be searched for, and a disk read must therefore occur.
+* The item may be on the page, then the item can continue to be searched for, and a disk read must therefore occur.
 
 The consequent reduction in disk reads promotes the efficiency of mutation processing, when the mutations are insert heavy.
 
@@ -141,15 +141,16 @@ See the information provided on establishing xref:manage:manage-settings/general
 
 include::manage:manage-settings/general-settings.adoc[tag=bloom-filter-default]
 
+[#in-memory-compression]
 === In-Memory Compression
 
-Plasma memory-management routinely performs the _compression_ of a subset of items, in order to free memory; and thereby, due to the additional memory made available, keep a greater number of items in memory overall.
+Plasma memory-management routinely performs the compression of a subset of items, in order to free memory; and thereby, due to the additional memory made available, keep a greater number of items in memory overall.
 By keeping more items in memory, the need for disk reads is reduced, as are corresponding latencies.
 
 The selection of items to be compressed occurs periodically.
 Only items that have already been flushed to disk are compressed: after compression, such items are principal candidates for subsequent ejection.
 
-Disk-flushing occurs every ten minutes: items not yet flushed to disk are not compressed; nor is any recently used item.
-In consequence, items most likely to be accessed remain _uncompressed_ in memory, and are therefore accessible with the least latency; while items less likely to be accessed are retained in memory in _compressed_ form, until their ejection; beyond which, they must be accessed through disk reads.
+Disk-flushing occurs every 10 minutes: items not yet flushed to disk are not compressed; nor is any recently used item.
+In consequence, items most likely to be accessed remain uncompressed in memory, and are therefore accessible with the least latency; while items less likely to be accessed are retained in memory in compressed form, until their ejection; beyond which, they must be accessed through disk reads.
 
-This new model of memory usage leads to higher _residence ratios_, and greater _access-efficiency_; at the cost of some additional CPU utilization, due to the more frequent performance of compression and decompression routines.
+This new model of memory usage leads to higher residence ratios, and greater access efficiency; at the cost of some additional CPU utilization, due to the more frequent performance of compression and decompression routines.

--- a/modules/indexes/pages/storage-modes.adoc
+++ b/modules/indexes/pages/storage-modes.adoc
@@ -70,7 +70,13 @@ This means the total size of the index can be much bigger than the amount of mem
 In Couchbase Server Enterprise Edition, standard index storage is supported by the Plasma storage engine.
 In this case, compaction is handled automatically.
 
-However, for installations of Couchbase Server Enterprise Edition running on Linux, hole punching is required to enable auto-compaction of Global Secondary Indexes using standard index-storage.
+Each index is represented on disk by up to 4 Log Structured Stores (LSS).
+A single LSS is made up of multiple append-only segment files.
+Index compaction and space reclamation are triggered when the LSS segment files reach a maximum file size, which by default is 512MB on Microsoft Windows and 4GB on GNU Linux and macOS.
+
+To set the maximum LSS segment file size, use the xref:index-rest-settings:index.adoc[Index Settings REST API] to set the `indexer.plasma.LSSSegmentFileSize` property.
+
+For installations of Couchbase Server Enterprise Edition running on Linux, hole punching is required to enable auto-compaction of Global Secondary Indexes using standard index-storage.
 ****
 
 ****

--- a/modules/indexes/pages/storage-modes.adoc
+++ b/modules/indexes/pages/storage-modes.adoc
@@ -72,11 +72,11 @@ In this case, compaction is handled automatically.
 
 Each index is represented on disk by up to 4 Log Structured Stores (LSS).
 A single LSS is made up of multiple append-only segment files.
-Index compaction and space reclamation are triggered when the LSS segment files reach a maximum file size, which by default is 512MB on Microsoft Windows and 4GB on GNU Linux and macOS.
+Index compaction and space reclamation are triggered when the LSS segment files reach a maximum file size, which by default is 512{nbsp}MiB on Microsoft Windows and 4{nbsp}GiB on GNU Linux and macOS.
 
-To set the maximum LSS segment file size, use the xref:index-rest-settings:index.adoc[Index Settings REST API] to set the `indexer.plasma.LSSSegmentFileSize` property.
+To change the maximum LSS segment file size, use the xref:index-rest-settings:index.adoc[Index Settings REST API] to set the `indexer.plasma.LSSSegmentFileSize` property.
 
-For installations of Couchbase Server Enterprise Edition running on Linux, hole punching is required to enable auto-compaction of Global Secondary Indexes using standard index-storage.
+For installations of Couchbase Server Enterprise Edition running on Linux, hole punching is required to enable auto-compaction of Global Secondary Indexes using standard index storage.
 ****
 
 ****

--- a/preview/DOC-10581-lss-compaction.yml
+++ b/preview/DOC-10581-lss-compaction.yml
@@ -1,0 +1,7 @@
+sources:
+  docs-server:
+    branches: [release/8.0]
+  cb-swagger:
+    branches: [DOC-10413-lss-segment]
+override:
+  startPage: server:introduction:intro.adoc

--- a/preview/DOC-10581-lss-compaction.yml
+++ b/preview/DOC-10581-lss-compaction.yml
@@ -1,7 +1,0 @@
-sources:
-  docs-server:
-    branches: [release/8.0]
-  cb-swagger:
-    branches: [DOC-10413-lss-segment]
-override:
-  startPage: server:introduction:intro.adoc

--- a/preview/DOC-10581.yml
+++ b/preview/DOC-10581.yml
@@ -1,6 +1,4 @@
 sources:
-  docs-server:
-    branches: [release/8.0]
   cb-swagger:
     branches: [DOC-10581-lss-compaction]
 override:

--- a/preview/DOC-10581.yml
+++ b/preview/DOC-10581.yml
@@ -1,5 +1,0 @@
-sources:
-  cb-swagger:
-    branches: [DOC-10413-lss-segment-10581-lss-compaction]
-override:
-  startPage: server:introduction:intro.adoc

--- a/preview/DOC-10581.yml
+++ b/preview/DOC-10581.yml
@@ -2,6 +2,6 @@ sources:
   docs-server:
     branches: [release/8.0]
   cb-swagger:
-    branches: [release/8.0]
+    branches: [DOC-10581-lss-compaction]
 override:
   startPage: server:introduction:intro.adoc

--- a/preview/DOC-10581.yml
+++ b/preview/DOC-10581.yml
@@ -1,5 +1,5 @@
 sources:
   cb-swagger:
-    branches: [DOC-10581-lss-compaction]
+    branches: [DOC-10413-lss-segment-10581-lss-compaction]
 override:
   startPage: server:introduction:intro.adoc


### PR DESCRIPTION
Jira ticket: DOC-10581

Adds brief information about the LSS to the Index Storage Settings page.

Docs preview:
* [Storage Settings](https://preview.docs-test.couchbase.com/docs-devex-DOC-10581-lss-compaction/server/current/indexes/storage-modes.html)
* [Index Settings REST API › Settings](https://preview.docs-test.couchbase.com/docs-devex-DOC-10581-lss-compaction/server/current/index-rest-settings/index.html#Settings)

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.

This must be merged at the same time as the following:

* https://github.com/couchbaselabs/cb-swagger/pull/200