### PR TITLE
[DOC-12745] Feedback on UNNEST Clause 

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/metafun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/metafun.adoc
@@ -1890,6 +1890,7 @@ LIMIT  1;
 ]
 ----
 ====
+
 [[unnest-pos,UNNEST_POS()]]
 == UNNEST_POS(`expr`)
 

--- a/modules/n1ql/pages/n1ql-language-reference/metafun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/metafun.adoc
@@ -1890,7 +1890,6 @@ LIMIT  1;
 ]
 ----
 ====
-
 [[unnest-pos,UNNEST_POS()]]
 == UNNEST_POS(`expr`)
 

--- a/modules/n1ql/pages/n1ql-language-reference/unnest.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/unnest.adoc
@@ -17,7 +17,7 @@ If a document or object contains a nested array, UNNEST conceptually performs a 
 Each resulting joined object becomes an output of the query.
 Unnests can be chained.
 
-TIP: To return the position of the elements in an unnested array after you use `UNNEST`, use the xref:n1ql-language-reference/unnestposfun.adoc[UNNEST_POS function].
+TIP: To return the position of the elements in an unnested array after you use `UNNEST`, use the xref:n1ql-language-reference/metafun.adoc#unnest-pos[UNNEST_POS function].
 
 == Syntax
 


### PR DESCRIPTION
Fix a broken link on the UNNEST Clause page that points to the UNNEST_POS function. 

Preview: https://preview.docs-test.couchbase.com/docs-devex-DOC-12745-unnest-clause-feedback/server/current/n1ql/n1ql-language-reference/unnest.html

