### PR TITLE
DOC-8634: numatrs should not be a request level parameter

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/transactions.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/transactions.adoc
@@ -121,8 +121,7 @@ Refer to the documentation for each parameter for more information and examples.
 {queryCleanupWindow}[queryCleanupWindow] cluster-level setting
 | Specify how frequently active transaction records are checked for cleanup.
 
-| {numatrs_req}[numatrs] request-level parameter +
-{numatrs-srv}[numatrs] node-level setting +
+| {{numatrs-srv}[numatrs] node-level setting +
 {queryNumAtrs}[queryNumAtrs] cluster-level setting
 | Specify the total number of active transaction records.
 |===

--- a/modules/n1ql/pages/n1ql-language-reference/transactions.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/transactions.adoc
@@ -121,7 +121,7 @@ Refer to the documentation for each parameter for more information and examples.
 {queryCleanupWindow}[queryCleanupWindow] cluster-level setting
 | Specify how frequently active transaction records are checked for cleanup.
 
-| {{numatrs-srv}[numatrs] node-level setting +
+| {numatrs-srv}[numatrs] node-level setting +
 {queryNumAtrs}[queryNumAtrs] cluster-level setting
 | Specify the total number of active transaction records.
 |===


### PR DESCRIPTION
Jira issue: DOC-8634

This PR removes the `numatrs` request-level parameter from the Transactions page.

Docs preview: [SQL++ Support for Couchbase Transactions](https://preview.docs-test.couchbase.com/docs-server-DOC-8634-numatrs-req/server/current/n1ql/n1ql-language-reference/transactions.html#settings-and-parameters)
You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.

This PR must be merged at the same time as the following:

- https://github.com/couchbaselabs/cb-swagger/pull/203
- https://github.com/couchbase/docs-server/pull/4030

Merge to the following branches:

- [x] `release/7.6`
- [x] `release/8.0`
- [x] `capella`