### PR TITLE
DOC-10577-Adding section about Eventing Retry policy

### DIFF
--- a/modules/eventing/pages/eventing-faq.adoc
+++ b/modules/eventing/pages/eventing-faq.adoc
@@ -155,7 +155,7 @@ Note that if you edit Eventing Functions (code or settings) in two browser windo
 * How does retrying work in Eventing?
 +
 Eventing retries transient and recoverable errors every 200 ms (5 times per second) until the function reaches its script timeout (60 seconds by default). 
-When you configure the `lcb_retry_count` in xref:eventing-rest-api:index.adoc[Eventing Service API],  with a non-zero value, Eventing limits retries to the specified count. 
+When you configure the `lcb_retry_count` in xref:eventing-rest-api:index.adoc[Eventing Service API], with a non-zero value, Eventing limits retries to the specified count. 
 After Eventing exhausts the configured retries, it throws an exception for that operation.
 
 == Eventing Function Code

--- a/modules/eventing/pages/eventing-faq.adoc
+++ b/modules/eventing/pages/eventing-faq.adoc
@@ -152,6 +152,11 @@ No. The Eventing service will properly distribute the Function code or lifecycle
 It is a best practice to only have one (1) Admin UI to a single node in your cluster when developing or modifying your Eventing Functions.
 Note that if you edit Eventing Functions (code or settings) in two browser windows or tabs (to same node or different nodes), you might inadvertently deploy a slightly older or “stale” definition if you switch back and forth between different UI sessions.
 
+* How does retrying work in Eventing?
++
+Eventing retries transient, recoverable errors every 200 ms (5 times per second) until the function reaches its script timeout (60 seconds by default). 
+In severe failure conditions, Eventing attempts about 300 retries in a minute. After the timeout, Eventing stops retrying and terminates the function for that mutation.
+
 == Eventing Function Code
 
 * What languages are supported?

--- a/modules/eventing/pages/eventing-faq.adoc
+++ b/modules/eventing/pages/eventing-faq.adoc
@@ -155,7 +155,7 @@ Note that if you edit Eventing Functions (code or settings) in two browser windo
 * How does retrying work in Eventing?
 +
 Eventing retries transient and recoverable errors every 200 ms (5 times per second) until the function reaches its script timeout (60 seconds by default). 
-When you configure the `lcb_retry_count` in the xref:eventing-rest-api:index.adoc[Eventing function settings], with a non-zero value, Eventing limits retries to the specified count. 
+When you configure the `lcb_retry_count` in the xref:eventing-rest-api:index.adoc#settings_schema[Eventing function settings], with a non-zero value, Eventing limits retries to the specified count. 
 After Eventing exhausts the configured retries, it throws an exception for that operation.
 
 == Eventing Function Code

--- a/modules/eventing/pages/eventing-faq.adoc
+++ b/modules/eventing/pages/eventing-faq.adoc
@@ -155,7 +155,7 @@ Note that if you edit Eventing Functions (code or settings) in two browser windo
 * How does retrying work in Eventing?
 +
 Eventing retries transient and recoverable errors every 200 ms (5 times per second) until the function reaches its script timeout (60 seconds by default). 
-When you configure the `lcb_retry_count` in xref:eventing-rest-api:index.adoc[Eventing Service API], with a non-zero value, Eventing limits retries to the specified count. 
+When you configure the `lcb_retry_count` in the xref:eventing-rest-api:index.adoc[Eventing function settings], with a non-zero value, Eventing limits retries to the specified count. 
 After Eventing exhausts the configured retries, it throws an exception for that operation.
 
 == Eventing Function Code

--- a/modules/eventing/pages/eventing-faq.adoc
+++ b/modules/eventing/pages/eventing-faq.adoc
@@ -154,8 +154,9 @@ Note that if you edit Eventing Functions (code or settings) in two browser windo
 
 * How does retrying work in Eventing?
 +
-Eventing retries transient, recoverable errors every 200 ms (5 times per second) until the function reaches its script timeout (60 seconds by default). 
-In severe failure conditions, Eventing attempts about 300 retries in a minute. After the timeout, Eventing stops retrying and terminates the function for that mutation.
+Eventing retries transient and recoverable errors every 200 ms (5 times per second) until the function reaches its script timeout (60 seconds by default). 
+When you configure the `lcb_retry_count` in xref:eventing-rest-api:index.adoc[Eventing Service API],  with a non-zero value, Eventing limits retries to the specified count. 
+After Eventing exhausts the configured retries, it throws an exception for that operation.
 
 == Eventing Function Code
 


### PR DESCRIPTION
[DOC-10577](https://jira.issues.couchbase.com/browse/DOC-10577)

Added a blurb about Eventing Retry policy under the heading, Functions. 

[Docs preview](https://preview.docs-test.couchbase.com/docs-devex-DOC-10577-Eventing-Retry-Policy/server/current/eventing/eventing-faq.html) 

[Preview credentials](https://couchbasecloud.atlassian.net/wiki/x/dYF_dQ#Preview-docs-for-internal-review)

[DOC-10577]: https://couchbasecloud.atlassian.net/browse/DOC-10577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ