### PR TITLE
DOC-12450: Modify the SQL++ used in the transaction documentation

### DIFF
--- a/modules/guides/pages/transactions.adoc
+++ b/modules/guides/pages/transactions.adoc
@@ -65,11 +65,10 @@ When the new named parameter appears, enter the name in the *name* box and a val
 
 image::transactions-preferences.png['The Run-Time Preferences dialog, with Scan Consistency set to "not_bounded", Transaction Timeout set to "120", and named parameter "durability_level" set to "none"']
 
-① Set *Scan Consistency* to `not_bounded`.
-
-② In the *Named Parameters* section, add a named parameter with *name* set to `durability_level` and *value* set to `"none"` (with double quotes).
-
-③ Set *Transaction Timeout* to `120`.
+[calloutlist]
+. Set *Scan Consistency* to `not_bounded`.
+. In the *Named Parameters* section, add a named parameter with *name* set to `durability_level` and *value* set to `"none"` (with double quotes).
+. Set *Transaction Timeout* to `120`.
 --
 
 CBQ Shell::

--- a/modules/guides/pages/transactions.adoc
+++ b/modules/guides/pages/transactions.adoc
@@ -180,13 +180,6 @@ Second, use the *context* controls at the top right of the Query Editor to selec
 
 image::transactions-context.png["The query context drop-down menu, with the tenant_agent_00 scope selected"]
 
-Third, create a primary index on the `bookings` collection so that you can query this keyspace.
-
-[source,sqlpp]
-----
-include::n1ql:example$transactions/multiple.n1ql[tag=index]
-----
-
 .Transaction
 Now copy the entire sequence below and paste it into the Query Workbench.
 
@@ -225,13 +218,6 @@ Second, set the query context to the `tenant_agent_00` scope in the travel sampl
 [source,sqlpp]
 ----
 include::n1ql:example$transactions/multiple.n1ql[tag=context]
-----
-
-Third, create a primary index on the `bookings` collection so that you can query this keyspace.
-
-[source,sqlpp]
-----
-include::n1ql:example$transactions/multiple.n1ql[tag=index]
 ----
 
 .Transaction

--- a/modules/n1ql/examples/transactions/multiple.n1ql
+++ b/modules/n1ql/examples/transactions/multiple.n1ql
@@ -16,7 +16,7 @@
 -- pass:[<mark>Start the transaction</mark>]
 /* end::begin-mark[] */
 /* tag::begin[] */
-BEGIN WORK;
+BEGIN TRANSACTION;
 /* end::begin[] */
 
 /* tag::set-plain[] */
@@ -100,7 +100,7 @@ ON KEYS b.`user`;
 -- pass:[<mark>Roll back the transaction to the second savepoint</mark>]
 /* end::rollback-mark[] */
 /* tag::rollback[] */
-ROLLBACK TRAN TO SAVEPOINT s2;
+ROLLBACK TRANSACTION TO SAVEPOINT s2;
 /* end::rollback[] */
 
 -- Check the content of the booking and user again
@@ -119,6 +119,6 @@ ON KEYS b.`user`;
 -- pass:[<mark>Commit the transaction</mark>]
 /* end::commit-mark[] */
 /* tag::commit[] */
-COMMIT WORK;
+COMMIT TRANSACTION;
 /* end::commit[] */
 /* end::transaction[] */

--- a/modules/n1ql/examples/transactions/multiple.n1ql
+++ b/modules/n1ql/examples/transactions/multiple.n1ql
@@ -8,10 +8,6 @@
 \SET -query_context travel-sample.tenant_agent_00;
 /* end::context[] */
 
-/* tag::index[] */
-CREATE PRIMARY INDEX ON bookings;
-/* end::index[] */
-
 /* tag::transaction[] */
 /* tag::begin-plain[] */
 -- Start the transaction
@@ -58,17 +54,17 @@ SAVEPOINT s1;
 -- Update the booking document to include a user
 /* tag::update-1[] */
 UPDATE bookings AS b
-SET b.`user` = "0"
-WHERE META(b).id = "bf7ad6fa-bdb9-4099-a840-196e47179f03";
+USE KEYS "bf7ad6fa-bdb9-4099-a840-196e47179f03"
+SET b.`user` = "0";
 /* end::update-1[] */
 
 -- Check the content of the booking and user
 /* tag::check-1[] */
 SELECT b.*, u.name
 FROM bookings b
+USE KEYS "bf7ad6fa-bdb9-4099-a840-196e47179f03"
 JOIN users u
-ON b.`user` = META(u).id
-WHERE META(b).id = "bf7ad6fa-bdb9-4099-a840-196e47179f03";
+ON KEYS b.`user`;
 /* end::check-1[] */
 
 /* tag::savepoint-plain[] */
@@ -84,17 +80,17 @@ SAVEPOINT s2;
 -- Update the booking documents to change the user
 /* tag::update-2[] */
 UPDATE bookings AS b
-SET b.`user` = "1"
-WHERE META(b).id = "bf7ad6fa-bdb9-4099-a840-196e47179f03";
+USE KEYS "bf7ad6fa-bdb9-4099-a840-196e47179f03"
+SET b.`user` = "1";
 /* end::update-2[] */
 
 -- Check the content of the booking and user
 /* tag::check-2[] */
 SELECT b.*, u.name
 FROM bookings b
+USE KEYS "bf7ad6fa-bdb9-4099-a840-196e47179f03"
 JOIN users u
-ON b.`user` = META(u).id
-WHERE META(b).id = "bf7ad6fa-bdb9-4099-a840-196e47179f03";
+ON KEYS b.`user`;
 /* end::check-2[] */
 
 /* tag::rollback-plain[] */
@@ -111,9 +107,9 @@ ROLLBACK TRAN TO SAVEPOINT s2;
 /* tag::check-3[] */
 SELECT b.*, u.name
 FROM bookings b
+USE KEYS "bf7ad6fa-bdb9-4099-a840-196e47179f03"
 JOIN users u
-ON b.`user` = META(u).id
-WHERE META(b).id = "bf7ad6fa-bdb9-4099-a840-196e47179f03";
+ON KEYS b.`user`;
 /* end::check-3[] */
 
 /* tag::commit-plain[] */

--- a/modules/n1ql/examples/transactions/multiple.sh
+++ b/modules/n1ql/examples/transactions/multiple.sh
@@ -26,7 +26,7 @@ curl http://localhost:8093/query/service \
   "statement": "SET TRANSACTION ISOLATION LEVEL READ COMMITTED;",
   "query_context": "`travel-sample`.tenant_agent_00",
   "txid": '${TXID}'
-}' # <1>
+}'
 # end::set[]
 
 # tag::upsert[]
@@ -37,7 +37,7 @@ curl http://localhost:8093/query/service \
   "statement": "UPSERT INTO bookings VALUES(\"bf7ad6fa-bdb9-4099-a840-196e47179f03\", {\"date\": \"07/24/2021\", \"flight\": \"WN533\", \"flighttime\": 7713, \"price\": 964.13, \"route\": \"63986\"});",
   "query_context": "`travel-sample`.tenant_agent_00",
   "txid": '${TXID}'
-}' # <1>
+}'
 # end::upsert[]
 
 # tag::savepoint-1[]
@@ -48,7 +48,7 @@ curl http://localhost:8093/query/service \
   "statement": "SAVEPOINT s1;",
   "query_context": "`travel-sample`.tenant_agent_00",
   "txid": '${TXID}'
-}' # <1>
+}'
 # end::savepoint-1[]
 
 # tag::update-1[]
@@ -59,7 +59,7 @@ curl http://localhost:8093/query/service \
   "statement": "UPDATE bookings AS b USE KEYS \"bf7ad6fa-bdb9-4099-a840-196e47179f03\" SET b.`user` = \"0\";",
   "query_context": "`travel-sample`.tenant_agent_00",
   "txid": '${TXID}'
-}' # <1>
+}'
 # end::update-1[]
 
 # tag::check-1[]
@@ -70,7 +70,7 @@ curl http://localhost:8093/query/service \
   "statement": "SELECT b.*, u.name FROM bookings b USE KEYS \"bf7ad6fa-bdb9-4099-a840-196e47179f03\" JOIN users u ON KEYS b.`user`;",
   "query_context": "`travel-sample`.tenant_agent_00",
   "txid": '${TXID}'
-}' # <1>
+}'
 # end::check-1[]
 
 # tag::savepoint-2[]
@@ -81,7 +81,7 @@ curl http://localhost:8093/query/service \
   "statement": "SAVEPOINT s2;",
   "query_context": "`travel-sample`.tenant_agent_00",
   "txid": '${TXID}'
-}' # <1>
+}'
 # end::savepoint-2[]
 
 # tag::update-2[]
@@ -92,7 +92,7 @@ curl http://localhost:8093/query/service \
   "statement": "UPDATE bookings AS b USE KEYS \"bf7ad6fa-bdb9-4099-a840-196e47179f03\" SET b.`user` = \"1\";",
   "query_context": "`travel-sample`.tenant_agent_00",
   "txid": '${TXID}'
-}' # <1>
+}'
 # end::update-2[]
 
 # tag::check-2[]
@@ -103,7 +103,7 @@ curl http://localhost:8093/query/service \
   "statement": "SELECT b.*, u.name FROM bookings b USE KEYS \"bf7ad6fa-bdb9-4099-a840-196e47179f03\" JOIN users u ON KEYS b.`user`;",
   "query_context": "`travel-sample`.tenant_agent_00",
   "txid": '${TXID}'
-}' # <1>
+}'
 # end::check-2[]
 
 # tag::rollback[]
@@ -114,7 +114,7 @@ curl http://localhost:8093/query/service \
   "statement": "ROLLBACK TRAN TO SAVEPOINT s2;",
   "query_context": "`travel-sample`.tenant_agent_00",
   "txid": '${TXID}'
-}' # <1>
+}'
 # end::rollback[]
 
 # tag::check-3[]
@@ -125,7 +125,7 @@ curl http://localhost:8093/query/service \
   "statement": "SELECT b.*, u.name FROM bookings b USE KEYS \"bf7ad6fa-bdb9-4099-a840-196e47179f03\" JOIN users u ON KEYS b.`user`;",
   "query_context": "`travel-sample`.tenant_agent_00",
   "txid": '${TXID}'
-}' # <1>
+}'
 # end::check-3[]
 
 # tag::commit[]
@@ -136,6 +136,6 @@ curl http://localhost:8093/query/service \
   "statement": "COMMIT TRANSACTION",
   "query_context": "`travel-sample`.tenant_agent_00",
   "txid": '${TXID}'
-}' # <1>
+}'
 # end::commit[]
 # end::transaction[]

--- a/modules/n1ql/examples/transactions/multiple.sh
+++ b/modules/n1ql/examples/transactions/multiple.sh
@@ -1,16 +1,9 @@
 #!/bin/sh
 
-# tag::index[]
-curl http://localhost:8093/query/service \
--u Administrator:password \
--H 'Content-Type: application/json' \
--d '{
-  "statement": "CREATE PRIMARY INDEX ON bookings;",
-  "query_context": "`travel-sample`.tenant_agent_00",
-}'
-# end::index[]
+set -exuo pipefail
 
 # tag::transaction[]
+TXID=$(
 # tag::begin[]
 curl http://localhost:8093/query/service \
 -u Administrator:password \
@@ -21,8 +14,9 @@ curl http://localhost:8093/query/service \
   "txtimeout": "2m",
   "scan_consistency": "request_plus",
   "durability_level": "none"
-}'
+}' | jq '.results[0].txid'
 # end::begin[]
+)
 
 # tag::set[]
 curl http://localhost:8093/query/service \
@@ -31,7 +25,7 @@ curl http://localhost:8093/query/service \
 -d '{
   "statement": "SET TRANSACTION ISOLATION LEVEL READ COMMITTED;",
   "query_context": "`travel-sample`.tenant_agent_00",
-  "txid": "d81d9b4a-b758-4f98-b007-87ba262d3a51"
+  "txid": '${TXID}'
 }' # <1>
 # end::set[]
 
@@ -40,15 +34,9 @@ curl http://localhost:8093/query/service \
 -u Administrator:password \
 -H 'Content-Type: application/json' \
 -d '{
-  "statement": "UPSERT INTO bookings VALUES(\"bf7ad6fa-bdb9-4099-a840-196e47179f03\", {
-    \"date\": \"07/24/2021\",
-    \"flight\": \"WN533\",
-    \"flighttime\": 7713,
-    \"price\": 964.13,
-    \"route\": \"63986\"
-});",
+  "statement": "UPSERT INTO bookings VALUES(\"bf7ad6fa-bdb9-4099-a840-196e47179f03\", {\"date\": \"07/24/2021\", \"flight\": \"WN533\", \"flighttime\": 7713, \"price\": 964.13, \"route\": \"63986\"});",
   "query_context": "`travel-sample`.tenant_agent_00",
-  "txid": "d81d9b4a-b758-4f98-b007-87ba262d3a51"
+  "txid": '${TXID}'
 }' # <1>
 # end::upsert[]
 
@@ -59,7 +47,7 @@ curl http://localhost:8093/query/service \
 -d '{
   "statement": "SAVEPOINT s1;",
   "query_context": "`travel-sample`.tenant_agent_00",
-  "txid": "d81d9b4a-b758-4f98-b007-87ba262d3a51"
+  "txid": '${TXID}'
 }' # <1>
 # end::savepoint-1[]
 
@@ -68,11 +56,9 @@ curl http://localhost:8093/query/service \
 -u Administrator:password \
 -H 'Content-Type: application/json' \
 -d '{
-  "statement": "UPDATE bookings AS b
-    SET b.`user` = \"0\"
-    WHERE META(b).id = \"bf7ad6fa-bdb9-4099-a840-196e47179f03\";",
+  "statement": "UPDATE bookings AS b USE KEYS \"bf7ad6fa-bdb9-4099-a840-196e47179f03\" SET b.`user` = \"0\";",
   "query_context": "`travel-sample`.tenant_agent_00",
-  "txid": "d81d9b4a-b758-4f98-b007-87ba262d3a51"
+  "txid": '${TXID}'
 }' # <1>
 # end::update-1[]
 
@@ -81,11 +67,9 @@ curl http://localhost:8093/query/service \
 -u Administrator:password \
 -H 'Content-Type: application/json' \
 -d '{
-  "statement": "SELECT b.*, u.name
-                FROM bookings b JOIN users u ON b.`user` = META(u).id
-                WHERE META(b).id = \"bf7ad6fa-bdb9-4099-a840-196e47179f03\";",
+  "statement": "SELECT b.*, u.name FROM bookings b USE KEYS \"bf7ad6fa-bdb9-4099-a840-196e47179f03\" JOIN users u ON KEYS b.`user`;",
   "query_context": "`travel-sample`.tenant_agent_00",
-  "txid": "d81d9b4a-b758-4f98-b007-87ba262d3a51"
+  "txid": '${TXID}'
 }' # <1>
 # end::check-1[]
 
@@ -96,7 +80,7 @@ curl http://localhost:8093/query/service \
 -d '{
   "statement": "SAVEPOINT s2;",
   "query_context": "`travel-sample`.tenant_agent_00",
-  "txid": "d81d9b4a-b758-4f98-b007-87ba262d3a51"
+  "txid": '${TXID}'
 }' # <1>
 # end::savepoint-2[]
 
@@ -105,11 +89,9 @@ curl http://localhost:8093/query/service \
 -u Administrator:password \
 -H 'Content-Type: application/json' \
 -d '{
-  "statement": "UPDATE bookings AS b
-    SET b.`user` = \"1\"
-    WHERE META(b).id = \"bf7ad6fa-bdb9-4099-a840-196e47179f03\";",
+  "statement": "UPDATE bookings AS b USE KEYS \"bf7ad6fa-bdb9-4099-a840-196e47179f03\" SET b.`user` = \"1\";",
   "query_context": "`travel-sample`.tenant_agent_00",
-  "txid": "d81d9b4a-b758-4f98-b007-87ba262d3a51"
+  "txid": '${TXID}'
 }' # <1>
 # end::update-2[]
 
@@ -118,11 +100,9 @@ curl http://localhost:8093/query/service \
 -u Administrator:password \
 -H 'Content-Type: application/json' \
 -d '{
-  "statement": "SELECT b.*, u.name
-                FROM bookings b JOIN users u ON b.`user` = META(u).id
-                WHERE META(b).id = \"bf7ad6fa-bdb9-4099-a840-196e47179f03\";",
+  "statement": "SELECT b.*, u.name FROM bookings b USE KEYS \"bf7ad6fa-bdb9-4099-a840-196e47179f03\" JOIN users u ON KEYS b.`user`;",
   "query_context": "`travel-sample`.tenant_agent_00",
-  "txid": "d81d9b4a-b758-4f98-b007-87ba262d3a51"
+  "txid": '${TXID}'
 }' # <1>
 # end::check-2[]
 
@@ -133,7 +113,7 @@ curl http://localhost:8093/query/service \
 -d '{
   "statement": "ROLLBACK TRAN TO SAVEPOINT s2;",
   "query_context": "`travel-sample`.tenant_agent_00",
-  "txid": "d81d9b4a-b758-4f98-b007-87ba262d3a51"
+  "txid": '${TXID}'
 }' # <1>
 # end::rollback[]
 
@@ -142,11 +122,9 @@ curl http://localhost:8093/query/service \
 -u Administrator:password \
 -H 'Content-Type: application/json' \
 -d '{
-  "statement": "SELECT b.*, u.name
-                FROM bookings b JOIN users u ON b.`user` = META(u).id
-                WHERE META(b).id = \"bf7ad6fa-bdb9-4099-a840-196e47179f03\";",
+  "statement": "SELECT b.*, u.name FROM bookings b USE KEYS \"bf7ad6fa-bdb9-4099-a840-196e47179f03\" JOIN users u ON KEYS b.`user`;",
   "query_context": "`travel-sample`.tenant_agent_00",
-  "txid": "d81d9b4a-b758-4f98-b007-87ba262d3a51"
+  "txid": '${TXID}'
 }' # <1>
 # end::check-3[]
 
@@ -157,7 +135,7 @@ curl http://localhost:8093/query/service \
 -d '{
   "statement": "COMMIT TRANSACTION",
   "query_context": "`travel-sample`.tenant_agent_00",
-  "txid": "d81d9b4a-b758-4f98-b007-87ba262d3a51"
+  "txid": '${TXID}'
 }' # <1>
 # end::commit[]
 # end::transaction[]

--- a/modules/n1ql/examples/transactions/multiple.sh
+++ b/modules/n1ql/examples/transactions/multiple.sh
@@ -9,7 +9,7 @@ curl http://localhost:8093/query/service \
 -u Administrator:password \
 -H 'Content-Type: application/json' \
 -d '{
-  "statement": "BEGIN WORK",
+  "statement": "BEGIN TRANSACTION",
   "query_context": "`travel-sample`.tenant_agent_00",
   "txtimeout": "2m",
   "scan_consistency": "request_plus",
@@ -111,7 +111,7 @@ curl http://localhost:8093/query/service \
 -u Administrator:password \
 -H 'Content-Type: application/json' \
 -d '{
-  "statement": "ROLLBACK TRAN TO SAVEPOINT s2;",
+  "statement": "ROLLBACK TRANSACTION TO SAVEPOINT s2;",
   "query_context": "`travel-sample`.tenant_agent_00",
   "txid": '${TXID}'
 }'

--- a/modules/n1ql/examples/transactions/results.jsonc
+++ b/modules/n1ql/examples/transactions/results.jsonc
@@ -42,7 +42,7 @@
   },
   {
     "_sequence_num": 5,
-    "_sequence_query": "\n\n-- Update the booking document to include a user\nUPDATE `travel-sample`.tenant_agent_00.bookings AS b\nSET b.`user` = \"0\"\nWHERE META(b).id = \"bf7ad6fa-bdb9-4099-a840-196e47179f03\";",
+    "_sequence_query": "\n\n-- Update the booking document to include a user\nUPDATE bookings AS b\nUSE KEYS \"bf7ad6fa-bdb9-4099-a840-196e47179f03\"\nSET b.`user` = \"0\";",
     "_sequence_query_status": "success",
     "_sequence_result": {
       "results": []
@@ -50,17 +50,17 @@
   },
   {
     "_sequence_num": 6,
-    "_sequence_query": "\n\n-- Check the content of the booking and user\nSELECT b.*, u.name\nFROM `travel-sample`.tenant_agent_00.bookings b\nJOIN `travel-sample`.tenant_agent_00.users u\nON b.`user` = META(u).id\nWHERE META(b).id = \"bf7ad6fa-bdb9-4099-a840-196e47179f03\";",
+    "_sequence_query": "\n\n-- Check the content of the booking and user\nSELECT b.*, u.name\nFROM bookings b\nUSE KEYS \"bf7ad6fa-bdb9-4099-a840-196e47179f03\"\nJOIN users u\nON KEYS b.`user`;",
     "_sequence_query_status": "success",
     "_sequence_result": [
       {
         "date": "07/24/2021",
         "flight": "WN533",
         "flighttime": 7713,
-        "name": "Keon Hoppe",
         "price": 964.13,
         "route": "63986",
-        "user": "0" // <.>
+        "user": "0", // <.>
+        "name": "Keon Hoppe"
       }
     ]
   },
@@ -74,7 +74,7 @@
   },
   {
     "_sequence_num": 8,
-    "_sequence_query": "\n\n-- Update the booking documents to change the user\nUPDATE `travel-sample`.tenant_agent_00.bookings AS b\nSET b.`user` = \"1\"\nWHERE META(b).id = \"bf7ad6fa-bdb9-4099-a840-196e47179f03\";",
+    "_sequence_query": "\n\n-- Update the booking documents to change the user\nUPDATE bookings AS b\nUSE KEYS \"bf7ad6fa-bdb9-4099-a840-196e47179f03\"\nSET b.`user` = \"1\";",
     "_sequence_query_status": "success",
     "_sequence_result": {
       "results": []
@@ -82,17 +82,17 @@
   },
   {
     "_sequence_num": 9,
-    "_sequence_query": "\n\n-- Check the content of the booking and user\nSELECT b.*, u.name\nFROM `travel-sample`.tenant_agent_00.bookings b\nJOIN `travel-sample`.tenant_agent_00.users u\nON b.`user` = META(u).id\nWHERE META(b).id = \"bf7ad6fa-bdb9-4099-a840-196e47179f03\";",
+    "_sequence_query": "\n\n-- Check the content of the booking and user\nSELECT b.*, u.name\nFROM bookings b\nUSE KEYS \"bf7ad6fa-bdb9-4099-a840-196e47179f03\"\nJOIN users u\nON KEYS b.`user`;",
     "_sequence_query_status": "success",
     "_sequence_result": [
       {
         "date": "07/24/2021",
         "flight": "WN533",
         "flighttime": 7713,
-        "name": "Rigoberto Bernier",
         "price": 964.13,
         "route": "63986",
-        "user": "1" // <.>
+        "user": "1", // <.>
+        "name": "Rigoberto Bernier"
       }
     ]
   },
@@ -106,7 +106,7 @@
   },
   {
     "_sequence_num": 11,
-    "_sequence_query": "\n\n-- Check the content of the booking and user again\nSELECT b.*, u.name\nFROM `travel-sample`.tenant_agent_00.bookings b\nJOIN `travel-sample`.tenant_agent_00.users u\nON b.`user` = META(u).id\nWHERE META(b).id = \"bf7ad6fa-bdb9-4099-a840-196e47179f03\";",
+    "_sequence_query": "\n\n-- Check the content of the booking and user again\nSELECT b.*, u.name\nFROM bookings b\nUSE KEYS \"bf7ad6fa-bdb9-4099-a840-196e47179f03\"\nJOIN users u\nON KEYS b.`user`;",
     "_sequence_query_status": "success",
     "_sequence_result": [
 // tag::check-3[]
@@ -114,10 +114,10 @@
         "date": "07/24/2021",
         "flight": "WN533",
         "flighttime": 7713,
-        "name": "Keon Hoppe",
         "price": 964.13,
         "route": "63986",
-        "user": "0" // <.>
+        "user": "0", // <.>
+        "name": "Keon Hoppe"
       }
 // end::check-3[]
     ]

--- a/modules/n1ql/examples/transactions/results.jsonc
+++ b/modules/n1ql/examples/transactions/results.jsonc
@@ -22,7 +22,7 @@
   },
   {
     "_sequence_num": 3,
-    "_sequence_query": "\n\n-- Create a booking document\nUPSERT INTO `travel-sample`.tenant_agent_00.bookings\nVALUES(\"bf7ad6fa-bdb9-4099-a840-196e47179f03\", {\n  \"date\": \"07/24/2021\",\n  \"flight\": \"WN533\",\n  \"flighttime\": 7713,\n  \"price\": 964.13,\n  \"route\": \"63986\"\n});",
+    "_sequence_query": "\n\n-- Create a booking document\nUPSERT INTO bookings\nVALUES(\"bf7ad6fa-bdb9-4099-a840-196e47179f03\", {\n  \"date\": \"07/24/2021\",\n  \"flight\": \"WN533\",\n  \"flighttime\": 7713,\n  \"price\": 964.13,\n  \"route\": \"63986\"\n});",
     "_sequence_query_status": "success",
     "_sequence_result": {
       "results": []

--- a/modules/n1ql/examples/transactions/results.jsonc
+++ b/modules/n1ql/examples/transactions/results.jsonc
@@ -2,7 +2,7 @@
 [
   {
     "_sequence_num": 1,
-    "_sequence_query": "-- Start the transaction\nBEGIN WORK;",
+    "_sequence_query": "-- Start the transaction\nBEGIN TRANSACTION;",
     "_sequence_query_status": "success",
     "_sequence_result": [
 // tag::begin[]
@@ -98,7 +98,7 @@
   },
   {
     "_sequence_num": 10,
-    "_sequence_query": "\n\n-- Roll back the transaction to the second savepoint\nROLLBACK TRAN TO SAVEPOINT s2;",
+    "_sequence_query": "\n\n-- Roll back the transaction to the second savepoint\nROLLBACK TRANSACTION TO SAVEPOINT s2;",
     "_sequence_query_status": "success",
     "_sequence_result": {
       "results": []
@@ -124,7 +124,7 @@
   },
   {
     "_sequence_num": 12,
-    "_sequence_query": "\n\n-- Commit the transaction\nCOMMIT WORK;",
+    "_sequence_query": "\n\n-- Commit the transaction\nCOMMIT TRANSACTION;",
     "_sequence_query_status": "success",
     "_sequence_result": {
       "results": []

--- a/modules/n1ql/examples/transactions/single.sh
+++ b/modules/n1ql/examples/transactions/single.sh
@@ -5,9 +5,8 @@ curl http://localhost:8093/query/service \
 -u Administrator:password \
 -H 'Content-Type: application/json' \
 -d '{
-  "statement": "UPDATE `travel-sample`.inventory.hotel
-                SET price = \"from £89\"
-                WHERE name = \"Glasgow Grand Central\";",
+  "statement": "UPDATE hotel SET price = \"from £89\" WHERE name = \"Glasgow Grand Central\";",
+  "query_context": "`travel-sample`.inventory",
   "tximplicit": true
 }'
 # end::query[]

--- a/modules/n1ql/pages/n1ql-language-reference/rollback-transaction.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/rollback-transaction.adoc
@@ -112,7 +112,7 @@ USE KEYS "42641d7a-cde3-4a4d-bfd5-fec321510f70"
 JOIN users u
 ON KEYS b.`user`;
 
--- Roll back the transaction to the second savepoint
+-- pass:[<mark>Roll back the transaction to the second savepoint</mark>]
 ROLLBACK TRANSACTION TO SAVEPOINT s2;
 
 -- Check the content of the booking and user again

--- a/modules/n1ql/pages/n1ql-language-reference/rollback-transaction.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/rollback-transaction.adoc
@@ -67,13 +67,13 @@ If you want to try these examples, first refer to {preparation}[Preparation] to 
 [source,sqlpp,subs=macros]
 ----
 -- Start the transaction
-BEGIN WORK;
+BEGIN TRANSACTION;
 
 -- Specify transaction settings
 SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
 
 -- Create a booking document
-UPSERT INTO `travel-sample`.tenant_agent_00.bookings
+UPSERT INTO bookings
 VALUES("42641d7a-cde3-4a4d-bfd5-fec321510f70", {
   "date": "07/24/2021",
   "flight": "WN533",
@@ -86,44 +86,44 @@ VALUES("42641d7a-cde3-4a4d-bfd5-fec321510f70", {
 SAVEPOINT s1;
 
 -- Update the booking document to include a user
-UPDATE `travel-sample`.tenant_agent_00.bookings AS b
-SET b.`user` = "0"
-WHERE META(b).id = "42641d7a-cde3-4a4d-bfd5-fec321510f70";
+UPDATE bookings AS b
+USE KEYS "42641d7a-cde3-4a4d-bfd5-fec321510f70"
+SET b.`user` = "0";
 
 -- Check the content of the booking and user
 SELECT b.*, u.name
-FROM `travel-sample`.tenant_agent_00.bookings b
-JOIN `travel-sample`.tenant_agent_00.users u
-ON b.`user` = META(u).id
-WHERE META(b).id = "42641d7a-cde3-4a4d-bfd5-fec321510f70";
+FROM bookings b
+USE KEYS "42641d7a-cde3-4a4d-bfd5-fec321510f70"
+JOIN users u
+ON KEYS b.`user`;
 
 -- Set a second savepoint
 SAVEPOINT s2;
 
 -- Update the booking documents to change the user
-UPDATE `travel-sample`.tenant_agent_00.bookings AS b
-SET b.`user` = "1"
-WHERE META(b).id = "42641d7a-cde3-4a4d-bfd5-fec321510f70";
+UPDATE bookings AS b
+USE KEYS "42641d7a-cde3-4a4d-bfd5-fec321510f70"
+SET b.`user` = "1";
 
 -- Check the content of the booking and user
 SELECT b.*, u.name
-FROM `travel-sample`.tenant_agent_00.bookings b
-JOIN `travel-sample`.tenant_agent_00.users u
-ON b.`user` = META(u).id
-WHERE META(b).id = "42641d7a-cde3-4a4d-bfd5-fec321510f70";
+FROM bookings b
+USE KEYS "42641d7a-cde3-4a4d-bfd5-fec321510f70"
+JOIN users u
+ON KEYS b.`user`;
 
--- pass:[<mark>Roll back the transaction to the second savepoint</mark>]
-ROLLBACK TRAN TO SAVEPOINT s2;
+-- Roll back the transaction to the second savepoint
+ROLLBACK TRANSACTION TO SAVEPOINT s2;
 
 -- Check the content of the booking and user again
 SELECT b.*, u.name
-FROM `travel-sample`.tenant_agent_00.bookings b
-JOIN `travel-sample`.tenant_agent_00.users u
-ON b.`user` = META(u).id
-WHERE META(b).id = "42641d7a-cde3-4a4d-bfd5-fec321510f70";
+FROM bookings b
+USE KEYS "42641d7a-cde3-4a4d-bfd5-fec321510f70"
+JOIN users u
+ON KEYS b.`user`;
 
 -- pass:[<mark>Roll back the entire transaction</mark>]
-ROLLBACK WORK;
+ROLLBACK TRANSACTION;
 ----
 
 .Results
@@ -132,7 +132,7 @@ ROLLBACK WORK;
 [
   {
     "_sequence_num": 1,
-    "_sequence_query": "-- Start the transaction\nBEGIN WORK;",
+    "_sequence_query": "-- Start the transaction\nBEGIN TRANSACTION;",
     "_sequence_query_status": "success",
     "_sequence_result": [
       {
@@ -150,7 +150,7 @@ ROLLBACK WORK;
   },
   {
     "_sequence_num": 3,
-    "_sequence_query": "\n\n-- Create a booking document\nUPSERT INTO `travel-sample`.tenant_agent_00.bookings\nVALUES(\"42641d7a-cde3-4a4d-bfd5-fec321510f70\", {\n  \"date\": \"07/24/2021\",\n  \"flight\": \"WN533\",\n  \"flighttime\": 7713,\n  \"price\": 964.13,\n  \"route\": \"63986\"\n});",
+    "_sequence_query": "\n\n-- Create a booking document\nUPSERT INTO bookings\nVALUES(\"42641d7a-cde3-4a4d-bfd5-fec321510f70\", {\n  \"date\": \"07/24/2021\",\n  \"flight\": \"WN533\",\n  \"flighttime\": 7713,\n  \"price\": 964.13,\n  \"route\": \"63986\"\n});",
     "_sequence_query_status": "success",
     "_sequence_result": {
       "results": []
@@ -166,7 +166,7 @@ ROLLBACK WORK;
   },
   {
     "_sequence_num": 5,
-    "_sequence_query": "\n\n-- Update the booking document to include a user\nUPDATE `travel-sample`.tenant_agent_00.bookings AS b\nSET b.`user` = \"0\"\nWHERE META(b).id = \"42641d7a-cde3-4a4d-bfd5-fec321510f70\";",
+    "_sequence_query": "\n\n-- Update the booking document to include a user\nUPDATE bookings AS b\nUSE KEYS \"42641d7a-cde3-4a4d-bfd5-fec321510f70\"\nSET b.`user` = \"0\";",
     "_sequence_query_status": "success",
     "_sequence_result": {
       "results": []
@@ -174,17 +174,17 @@ ROLLBACK WORK;
   },
   {
     "_sequence_num": 6,
-    "_sequence_query": "\n\n-- Check the content of the booking and user\nSELECT b.*, u.name\nFROM `travel-sample`.tenant_agent_00.bookings b\nJOIN `travel-sample`.tenant_agent_00.users u\nON b.`user` = META(u).id\nWHERE META(b).id = \"42641d7a-cde3-4a4d-bfd5-fec321510f70\";",
+    "_sequence_query": "\n\n-- Check the content of the booking and user\nSELECT b.*, u.name\nFROM bookings b\nUSE KEYS \"42641d7a-cde3-4a4d-bfd5-fec321510f70\"\nJOIN users u\nON KEYS b.`user`;",
     "_sequence_query_status": "success",
     "_sequence_result": [
       {
         "date": "07/24/2021",
         "flight": "WN533",
         "flighttime": 7713,
-        "name": "Keon Hoppe",
         "price": 964.13,
         "route": "63986",
-        "user": "0" // <.>
+        "user": "0", // <.>
+        "name": "Keon Hoppe"
       }
     ]
   },
@@ -198,7 +198,7 @@ ROLLBACK WORK;
   },
   {
     "_sequence_num": 8,
-    "_sequence_query": "\n\n-- Update the booking documents to change the user\nUPDATE `travel-sample`.tenant_agent_00.bookings AS b\nSET b.`user` = \"1\"\nWHERE META(b).id = \"42641d7a-cde3-4a4d-bfd5-fec321510f70\";",
+    "_sequence_query": "\n\n-- Update the booking documents to change the user\nUPDATE bookings AS b\nUSE KEYS \"42641d7a-cde3-4a4d-bfd5-fec321510f70\"\nSET b.`user` = \"1\";",
     "_sequence_query_status": "success",
     "_sequence_result": {
       "results": []
@@ -206,23 +206,23 @@ ROLLBACK WORK;
   },
   {
     "_sequence_num": 9,
-    "_sequence_query": "\n\n-- Check the content of the booking and user\nSELECT b.*, u.name\nFROM `travel-sample`.tenant_agent_00.bookings b\nJOIN `travel-sample`.tenant_agent_00.users u\nON b.`user` = META(u).id\nWHERE META(b).id = \"42641d7a-cde3-4a4d-bfd5-fec321510f70\";",
+    "_sequence_query": "\n\n-- Check the content of the booking and user\nSELECT b.*, u.name\nFROM bookings b\nUSE KEYS \"42641d7a-cde3-4a4d-bfd5-fec321510f70\"\nJOIN users u\nON KEYS b.`user`;",
     "_sequence_query_status": "success",
     "_sequence_result": [
       {
         "date": "07/24/2021",
         "flight": "WN533",
         "flighttime": 7713,
-        "name": "Rigoberto Bernier",
         "price": 964.13,
         "route": "63986",
-        "user": "1" // <.>
+        "user": "1", // <.>
+        "name": "Rigoberto Bernier"
       }
     ]
   },
   {
     "_sequence_num": 10,
-    "_sequence_query": "\n\n-- Roll back the transaction to the second savepoint\nROLLBACK TRAN TO SAVEPOINT s2;",
+    "_sequence_query": "\n\n-- Roll back the transaction to the second savepoint\nROLLBACK TRANSACTION TO SAVEPOINT s2;",
     "_sequence_query_status": "success",
     "_sequence_result": {
       "results": []
@@ -230,23 +230,23 @@ ROLLBACK WORK;
   },
   {
     "_sequence_num": 11,
-    "_sequence_query": "\n\n-- Check the content of the booking and user again\nSELECT b.*, u.name\nFROM `travel-sample`.tenant_agent_00.bookings b\nJOIN `travel-sample`.tenant_agent_00.users u\nON b.`user` = META(u).id\nWHERE META(b).id = \"42641d7a-cde3-4a4d-bfd5-fec321510f70\";",
+    "_sequence_query": "\n\n-- Check the content of the booking and user again\nSELECT b.*, u.name\nFROM bookings b\nUSE KEYS \"42641d7a-cde3-4a4d-bfd5-fec321510f70\"\nJOIN users u\nON KEYS b.`user`;",
     "_sequence_query_status": "success",
     "_sequence_result": [
       {
         "date": "07/24/2021",
         "flight": "WN533",
         "flighttime": 7713,
-        "name": "Keon Hoppe",
         "price": 964.13,
         "route": "63986",
-        "user": "0" // <.>
+        "user": "0", // <.>
+        "name": "Keon Hoppe"
       }
     ]
   },
   {
     "_sequence_num": 12,
-    "_sequence_query": "\n\n-- Roll back the entire transaction\nROLLBACK WORK;",
+    "_sequence_query": "\n\n-- Roll back the entire transaction\nROLLBACK TRANSACTION;",
     "_sequence_query_status": "success",
     "_sequence_result": {
       "results": []
@@ -269,10 +269,10 @@ Check the result of rolling back the transaction.
 [source,sqlpp]
 ----
 SELECT b.*, u.name
-FROM `travel-sample`.tenant_agent_00.bookings b
-JOIN `travel-sample`.tenant_agent_00.users u
-ON b.`user` = META(u).id
-WHERE META(b).id = "42641d7a-cde3-4a4d-bfd5-fec321510f70";
+FROM bookings b
+USE KEYS "42641d7a-cde3-4a4d-bfd5-fec321510f70"
+JOIN users u
+ON KEYS b.`user`;
 ----
 
 .Results

--- a/modules/n1ql/pages/n1ql-language-reference/transactions.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/transactions.adoc
@@ -286,78 +286,78 @@ include::example$transactions/results.jsonc[tag=check-3]
 For reference, this example shows the equivalent of <<ex-1>> using the Query REST API.
 
 .Begin transaction and set parameters
-[source,console]
+[source,sh]
 ----
 include::example$transactions/multiple.sh[tag=begin]
 ----
 
-This example uses https://jqlang.org[jq] to get the transaction ID returned by the query.
+This statement uses https://jqlang.org[jq] to get the transaction ID.
+After beginning the transaction, each subsequent statement in the transaction must specify the transaction ID that was generated when the transaction began.
 
 .Specify transaction settings
-[source,console]
+[source,sh]
 ----
 include::example$transactions/multiple.sh[tag=set]
 ----
 
-
-<.> After beginning the transaction, each subsequent statement in the transaction must specify the transaction ID that was generated when the transaction began.
+In this and the following statements, `+${TXID}+` is the transaction ID.
 
 .Create a booking document
-[source,console]
+[source,sh]
 ----
 include::example$transactions/multiple.sh[tag=upsert]
 ----
 
 .Set a savepoint
-[source,console]
+[source,sh]
 ----
 include::example$transactions/multiple.sh[tag=savepoint-1]
 ----
 
 .Update the booking document to include a user
-[source,console]
+[source,sh]
 ----
 include::example$transactions/multiple.sh[tag=update-1]
 ----
 
 .Check the content of the booking and user
-[source,console]
+[source,sh]
 ----
 include::example$transactions/multiple.sh[tag=check-1]
 ----
 
 .Set a second savepoint
-[source,console]
+[source,sh]
 ----
 include::example$transactions/multiple.sh[tag=savepoint-2]
 ----
 
 .Update the booking documents to change the user
-[source,console]
+[source,sh]
 ----
 include::example$transactions/multiple.sh[tag=update-2]
 ----
 
 .Check the content of the booking and user
-[source,console]
+[source,sh]
 ----
 include::example$transactions/multiple.sh[tag=check-2]
 ----
 
 .Roll back the transaction to the second savepoint
-[source,console]
+[source,sh]
 ----
 include::example$transactions/multiple.sh[tag=rollback]
 ----
 
 .Check the content of the booking and user again
-[source,console]
+[source,sh]
 ----
 include::example$transactions/multiple.sh[tag=check-3]
 ----
 
 .Commit the transaction
-[source,console]
+[source,sh]
 ----
 include::example$transactions/multiple.sh[tag=commit]
 ----

--- a/modules/n1ql/pages/n1ql-language-reference/transactions.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/transactions.adoc
@@ -193,18 +193,6 @@ This worked example guides you through a complete Couchbase transaction session 
 The worked example assumes that the supplied `travel-sample` bucket is installed.
 Refer to {install-sample-buckets}[Sample Buckets] for installation details.
 
-.Index
-For the purposes of this worked example, you must create a primary index in the keyspace you will be using.
-
-====
-Create a primary index on `{backtick}travel-sample{backtick}.tenant_agent_00.bookings`, so that you can query and update the documents in this keyspace.
-
-[source,sqlpp]
-----
-include::example$transactions/multiple.n1ql[tag=index]
-----
-====
-
 .Parameters
 If necessary, set the transaction parameters for this worked example.
 In particular, you will turn off durability for the purposes of this example, in order to make sure that there are no problems meeting the transaction durability requirements.
@@ -303,11 +291,16 @@ For reference, this example shows the equivalent of <<ex-1>> using the Query RES
 include::example$transactions/multiple.sh[tag=begin]
 ----
 
+This example uses https://jqlang.org[jq] to get the transaction ID returned by the query.
+
 .Specify transaction settings
 [source,console]
 ----
 include::example$transactions/multiple.sh[tag=set]
 ----
+
+
+<.> After beginning the transaction, each subsequent statement in the transaction must specify the transaction ID that was generated when the transaction began.
 
 .Create a booking document
 [source,console]
@@ -368,8 +361,6 @@ include::example$transactions/multiple.sh[tag=check-3]
 ----
 include::example$transactions/multiple.sh[tag=commit]
 ----
-
-<.> After beginning the transaction, each subsequent statement in the transaction must specify the transaction ID that was generated when the transaction began.
 ====
 
 == Related Links

--- a/modules/n1ql/pages/n1ql-language-reference/transactions.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/transactions.adoc
@@ -193,6 +193,10 @@ This worked example guides you through a complete Couchbase transaction session 
 The worked example assumes that the supplied `travel-sample` bucket is installed.
 Refer to {install-sample-buckets}[Sample Buckets] for installation details.
 
+.Context
+For this worked example, set the query context to the `tenant_agent_00` scope in the travel sample dataset.
+For more information, see xref:n1ql:n1ql-intro/queriesandresults.adoc#query-context[Query Context].
+
 .Parameters
 If necessary, set the transaction parameters for this worked example.
 In particular, you will turn off durability for the purposes of this example, in order to make sure that there are no problems meeting the transaction durability requirements.

--- a/modules/n1ql/pages/n1ql-language-reference/transactions.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/transactions.adoc
@@ -291,7 +291,7 @@ For reference, this example shows the equivalent of <<ex-1>> using the Query RES
 include::example$transactions/multiple.sh[tag=begin]
 ----
 
-This statement uses https://jqlang.org[jq] to get the transaction ID.
+This statement uses https://jqlang.org[jq] to get the transaction ID from the query results.
 After beginning the transaction, each subsequent statement in the transaction must specify the transaction ID that was generated when the transaction began.
 
 .Specify transaction settings
@@ -300,7 +300,7 @@ After beginning the transaction, each subsequent statement in the transaction mu
 include::example$transactions/multiple.sh[tag=set]
 ----
 
-In this and the following statements, `+${TXID}+` is the transaction ID.
+In this and the following statements, replace `+'${TXID}'+` with the transaction ID, wrapped in double quotes `""`.
 
 .Create a booking document
 [source,sh]

--- a/modules/n1ql/pages/n1ql-language-reference/window.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/window.adoc
@@ -41,13 +41,11 @@ include::partial$n1ql-language-reference/window-intro.adoc[tag=windows]
 .Window partitions and the window frame
 image::window-example.png[Table of query result set with numbered callouts]
 
-// workaround for callout list with no callout references
-
-[%hardbreaks]
-➀ The query result set.
-➁ Window partitions -- partitioned by `name`, ordered by `time`.
-➂ The current object.
-➃ The window frame -- between unbounded preceding and current object.
+[calloutlist]
+. The query result set.
+. Window partitions -- partitioned by `name`, ordered by `time`.
+. The current object.
+. The window frame -- between unbounded preceding and current object.
 
 include::partial$n1ql-language-reference/window-intro.adoc[tag=functions]
 


### PR DESCRIPTION
Jira issue: DOC-12450

- Updates transaction examples to use keys instead of `META().id`, speeding up the transactions and making the primary index unnecessary.
- Fixes shell script examples so that they actually run.
- Tested locally.
