### PR TITLE
[DOC-11109] Fix SQL++ examples

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/arrayfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/arrayfun.adoc
@@ -21,11 +21,11 @@ If the input [.var]`expression` is `MISSING` or if one of the elements in the ar
 
 === Example
 ====
-Use `ARRAY_AGG` to group a list of three items into an array.
+Group a list of three items into an array.
 
 [source,sqlpp]
 ----
-SELECT ARRAY_AGG(["abc",1,NULL]) AS array_aggregate;
+SELECT ARRAY_AGG( [ "abc", 1, NULL ] ) AS array_aggregate;
 ----
 
 .Results
@@ -56,7 +56,7 @@ It requires a minimum of two arguments and returns an error if there are fewer.
 === Arguments
 expr:: [Required] The array to be appended to.
 
-val1, val2, …:: [At least 1 is required] The text string(s) to be appended.
+val1, val2, …:: [At least 1 is required] The values to be appended.
 
 === Return Values
 A new array with the specified [.var]`val` argument(s) appended.
@@ -71,15 +71,11 @@ If the [.var]`expr` is in the `WHERE` clause of a partial index, this function l
 
 === Example
 ====
-include::ROOT:partial$query-context.adoc[tag=example]
-
-Use `ARRAY_APPEND` to add a user to the Public Likes array:
+Add a couple of numbers to an existing array.
 
 [source,sqlpp]
 ----
-SELECT ARRAY_APPEND(t.public_likes, "Valerie Smith") AS add_user_likes
-FROM hotel t
-LIMIT 1;
+SELECT ARRAY_APPEND( [ 1 , 2 ] , 3 , 4) AS numbers;
 ----
 
 .Results
@@ -87,16 +83,11 @@ LIMIT 1;
 ----
 [
   {
-    "add_user_likes": [
-      "Julius Tromp I",
-      "Corrine Hilll",
-      "Jaeden McKenzie",
-      "Vallie Ryan",
-      "Brian Kilback",
-      "Lilian McLaughlin",
-      "Ms. Moses Feeney",
-      "Elnora Trantow",
-      "Valerie Smith"
+    "numbers": [
+      1,
+      2,
+      3,
+      4
     ]
   }
 ]
@@ -124,12 +115,13 @@ If the array size of [.var]`expr` is 0 (no elements), then it returns `NULL`.
 Any non-number elements in the array [.var]`expr` are ignored.
 
 === Example
+
 ====
-Use `ARRAY_AVG` with a set of numbers.
+Find the average from an array of numbers.
 
 [source,sqlpp]
 ----
-SELECT ARRAY_AVG([0,1,1,2,3,5]) AS array_average;
+SELECT ARRAY_AVG( [ 0 , 1 , 1 , 2 , 3 , 5 ] ) AS array_average;
 ----
 
 .Results
@@ -174,16 +166,12 @@ If the input [.var]`expr` is not an array, it returns `NULL`.
 === Example
 
 ====
-include::ROOT:partial$query-context.adoc[tag=example]
-
-Find which position "Brian Kilback" is in the sorted `public_likes` array:
+Find the position of a number in a sorted array.
 
 [source,sqlpp]
 ----
-SELECT ARRAY_BINARY_SEARCH(ARRAY_SORT(t.public_likes), "Brian Kilback")
-AS sorted_position
-FROM hotel t
-LIMIT 1;
+SELECT ARRAY_BINARY_SEARCH( [ 1 , 3 , 5 , 7 , 9 ] , 5) 
+AS position;
 ----
 
 .Results
@@ -191,7 +179,7 @@ LIMIT 1;
 ----
 [
   {
-    "sorted_position": 0
+    "position": 2
   }
 ]
 ----
@@ -219,15 +207,12 @@ If any of the input [.var]`expr` arguments is not an array, then it returns `NUL
 
 === Example
 ====
-include::ROOT:partial$query-context.adoc[tag=example]
-
-Use `ARRAY_CONCAT` to add two people to the Public Likes array:
+Combine two arrays into one.
 
 [source,sqlpp]
 ----
-SELECT ARRAY_CONCAT(t.public_likes, ["John McHill", "Dave Smith"]) AS add_user_likes
-FROM hotel t
-LIMIT 1;
+SELECT ARRAY_CONCAT( [ 1 , 2 , 3 ], [ 4 , 5 , 6 ] ) 
+AS combined_array;
 ----
 
 .Results
@@ -235,17 +220,13 @@ LIMIT 1;
 ----
 [
   {
-    "add_user_likes": [
-      "Julius Tromp I",
-      "Corrine Hilll",
-      "Jaeden McKenzie",
-      "Vallie Ryan",
-      "Brian Kilback",
-      "Lilian McLaughlin",
-      "Ms. Moses Feeney",
-      "Elnora Trantow",
-      "John McHill",
-      "Dave Smith"
+    "combined_array": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6
     ]
   }
 ]
@@ -273,16 +254,14 @@ If the [.var]`expr` argument is not an array, then it returns `NULL`.
 If the array [.var]`expr` contains [.var]`val`, then it returns `TRUE`; otherwise, it returns `FALSE`.
 
 === Example
-====
-include::ROOT:partial$query-context.adoc[tag=example]
 
-Use `ARRAY_CONTAINS` with a Boolean function:
+====
+Check if a value exists in an array.
 
 [source,sqlpp]
 ----
-SELECT ARRAY_CONTAINS(t.public_likes, "Vallie Ryan") AS array_contains_value
-FROM hotel t
-LIMIT 1;
+SELECT ARRAY_CONTAINS( [ 1 , 2 , 3 , 4 , 5 ] , 3 ) 
+AS contains_value;
 ----
 
 .Results
@@ -290,7 +269,7 @@ LIMIT 1;
 ----
 [
   {
-    "array_contains_value": true
+    "contains_value": true
   }
 ]
 ----
@@ -315,16 +294,14 @@ If the [.var]`expr` argument is `NULL`, then it returns `NULL`.
 If the [.var]`expr` argument is not an array, then it returns `NULL`.
 
 === Example
-====
-include::ROOT:partial$query-context.adoc[tag=example]
 
-Use `ARRAY_COUNT` to count the total hotel reviews:
+====
+Count the number of elements in an array.
 
 [source,sqlpp]
 ----
-SELECT ARRAY_COUNT(t.reviews) AS total_reviews
-FROM hotel t
-LIMIT 1;
+SELECT ARRAY_COUNT( [ 1 , 2 , 3 , 4 , 5 ] )
+AS total_count;
 ----
 
 .Results
@@ -332,7 +309,7 @@ LIMIT 1;
 ----
 [
   {
-    "total_reviews": 2
+    "total_count": 5
   }
 ]
 ----
@@ -355,13 +332,14 @@ If the input [.var]`expr` is `MISSING`, it returns `MISSING`.
 If the input [.var]`expr` is a non-array value, it returns `NULL`.
 
 === Example
+
 ====
-Use `ARRAY_DISTINCT` with a group of items.
+Remove duplicate elements from an array.
 
 [source,sqlpp]
 ----
-SELECT ARRAY_DISTINCT(["apples","bananas","grapes","oranges","apples","mangoes","bananas"])
-AS distinct_fruits;
+SELECT ARRAY_DISTINCT( [ 1 , 2 , 2 , 3 , 4 , 4 , 5 ] )
+AS distinct_numbers;
 ----
 
 .Results
@@ -369,12 +347,12 @@ AS distinct_fruits;
 ----
 [
   {
-    "distinct_fruits": [
-      "oranges",
-      "grapes",
-      "bananas",
-      "mangoes",
-      "apples"
+    "distinct_numbers": [
+      1,
+      2,
+      3,
+      4,
+      5
     ]
   }
 ]
@@ -400,14 +378,14 @@ If any of the arguments is `MISSING`, it returns `MISSING`.
 If any of the arguments is a non-array, it returns `NULL`.
 
 === Examples
+
 ====
-Return an array of even numbers by excluding odd numbers.
+Exclude elements of one array from another.
 
 [source,sqlpp]
 ----
-WITH Numbers AS ([1, 2, 3, 4, 5, 6]),
-Odd AS ([1, 3, 5])
-SELECT ARRAY_EXCEPT(Numbers, Odd) AS Even;
+SELECT ARRAY_EXCEPT( [ 1 , 2 , 3 , 4 , 5 ] , [ 2 , 4 ] )
+AS result_array;
 ----
 
 .Results
@@ -415,10 +393,10 @@ SELECT ARRAY_EXCEPT(Numbers, Odd) AS Even;
 ----
 [
   {
-    "Even": [
-      2,
-      4,
-      6
+    "result_array": [
+      1,
+      3,
+      5
     ]
   }
 ]
@@ -444,15 +422,19 @@ If one of the arguments is `MISSING`, it returns `MISSING`.
 If the input [.var]`expr` is a non-array, or if the input [.var]`depth` argument is not an integer, it returns `NULL`.
 
 === Examples
+
 ====
-Create a 3-level array of numbers to flatten by 1 level.
+Flatten a nested array by 1 and 2 levels.
 
 [source,sqlpp]
 ----
-INSERT INTO default (KEY, value)
-             VALUES ("na", {"a":2, "b":[1,2,[31,32,33],4,[[511, 512], 52]]});
-
-SELECT ARRAY_FLATTEN(b,1) AS flatten_by_1 FROM default USE KEYS ["na"];
+SELECT 
+  ARRAY_FLATTEN(
+    [ [ 1, 2 ], [ 3, [ 4, 5 ] ] ], 1
+  ) AS flatten_by_1,
+  ARRAY_FLATTEN(
+    [ [ 1, 2 ], [ 3, [ 4, 5 ] ] ], 2
+  ) AS flatten_by_2;
 ----
 
 .Results
@@ -463,44 +445,18 @@ SELECT ARRAY_FLATTEN(b,1) AS flatten_by_1 FROM default USE KEYS ["na"];
     "flatten_by_1": [
       1,
       2,
-      31,
-      32,
-      33,
-      4,
+      3,
       [
-        511,
-        512
-      ],
-      52
-    ]
-  }
-]
-----
-====
-
-====
-Flatten the above example by 2 levels.
-
-[source,sqlpp]
-----
-SELECT ARRAY_FLATTEN(b,2) AS flatten_by_2 FROM default USE KEYS ["na"];
-----
-
-.Results
-[source,json]
-----
-[
-  {
+        4,
+        5
+      ]
+    ],
     "flatten_by_2": [
       1,
       2,
-      31,
-      32,
-      33,
+      3,
       4,
-      511,
-      512,
-      52
+      5
     ]
   }
 ]
@@ -525,11 +481,12 @@ If the input [.var]`expr` is a non-array, then it returns `NULL`.
 
 === Examples
 ====
-Find the first non-`NULL` value in an array of items.
+Find the first non-NULL value in an array.
 
 [source,sqlpp]
 ----
-SELECT ARRAY_IFNULL( ["","apples","","bananas","grapes","oranges"]) AS check_null;
+SELECT ARRAY_IFNULL( [ NULL , NULL , 1 , 2 , 3 ] )
+AS first_non_null;
 ----
 
 .Results
@@ -537,33 +494,7 @@ SELECT ARRAY_IFNULL( ["","apples","","bananas","grapes","oranges"]) AS check_nul
 ----
 [
   {
-    "check_null": ""
-  }
-]
-----
-====
-
-====
-include::ROOT:partial$query-context.adoc[tag=example]
-
-Find the first non-`null` hotel reviewers:
-
-[source,sqlpp]
-----
-SELECT ARRAY_IFNULL(t.public_likes) AS if_null
-FROM hotel t
-LIMIT 2;
-----
-
-.Results
-[source,json]
-----
-[
-  {
-    "if_null": "Julius Tromp I"
-  },
-  {
-    "if_null": null
+    "first_non_null": 1
   }
 ]
 ----
@@ -590,16 +521,14 @@ If any of the three arguments are `MISSING`, then it returns `MISSING`.
 If the [.var]`expr` argument is a non-array or if the [.var]`position` argument is not an integer, then it returns `NULL`.
 
 === Example
-====
-include::ROOT:partial$query-context.adoc[tag=example]
 
-Insert "jsmith" into the 2nd position of the `public_likes` array:
+====
+Insert `55` into the 2nd position of an array. 
 
 [source,sqlpp]
 ----
-SELECT ARRAY_INSERT(public_likes, 2, "jsmith") AS insert_val
-FROM hotel
-LIMIT 1;
+SELECT ARRAY_INSERT( [ 1 , 2 , 3 , 4 ] , 2 , 55 ) 
+AS updated_array;
 ----
 
 .Results
@@ -607,16 +536,12 @@ LIMIT 1;
 ----
 [
   {
-    "insert_val": [
-      "Julius Tromp I",
-      "Corrine Hilll",
-      "jsmith",
-      "Jaeden McKenzie",
-      "Vallie Ryan",
-      "Brian Kilback",
-      "Lilian McLaughlin",
-      "Ms. Moses Feeney",
-      "Elnora Trantow"
+    "updated_array": [
+      1,
+      2,
+      55,
+      3,
+      4
     ]
   }
 ]
@@ -643,11 +568,14 @@ If any of the input arguments are non-array values, then it returns `NULL`.
 
 === Examples
 ====
-Compare three arrays of fruit for common elements.
+Compare three arrays to find common elements.
 
 [source,sqlpp]
 ----
-SELECT ARRAY_INTERSECT( ["apples","bananas","grapes","orange"], ["apples","orange"], ["apples","grapes"])
+SELECT ARRAY_INTERSECT( 
+  [ 1 , 2 , 3 , 4 ] , 
+  [ 2 , 4 , 6 ] , 
+  [ 4 , 8 ] )
 AS array_intersection;
 ----
 
@@ -657,7 +585,7 @@ AS array_intersection;
 [
   {
     "array_intersection": [
-      "apples"
+      4
     ]
   }
 ]
@@ -665,11 +593,14 @@ AS array_intersection;
 ====
 
 ====
-Compare three arrays of fruit with no common elements.
+Compare three arrays with no common elements.
 
 [source,sqlpp]
 ----
-SELECT ARRAY_INTERSECT( ["apples","grapes","oranges"], ["apples"],["oranges"],["bananas", "grapes"])
+SELECT ARRAY_INTERSECT( 
+  [ 1 , 2 , 3 ] , 
+  [ 3 , 4 , 5 , 6 ] , 
+  [ 6 , 7 , 8 , 9 ] ) 
 AS array_intersection;
 ----
 
@@ -704,15 +635,12 @@ If the input argument is a non-array value, then it returns `NULL`.
 
 === Example
 ====
-include::ROOT:partial$query-context.adoc[tag=example]
-
-Find how many total `public_likes` there are in the `travel-sample` keyspace:
+Find the number of elements in an array.
 
 [source,sqlpp]
 ----
-SELECT ARRAY_LENGTH(t.public_likes) AS total_likes
-FROM hotel t
-LIMIT 1;
+SELECT ARRAY_LENGTH( [ 1 , 2 , 3 , 4 , 5 ] ) 
+AS total_elements;
 ----
 
 .Results
@@ -720,7 +648,7 @@ LIMIT 1;
 ----
 [
   {
-    "total_likes": 8
+    "total_elements": 5
   }
 ]
 ----
@@ -744,15 +672,13 @@ If the input [.var]`expr` is a non-array value, then it returns `NULL`.
 
 === Example
 ====
-include::ROOT:partial$query-context.adoc[tag=example]
-
-Find the maximum (last) value of the `public_likes` array:
+Find the largest value in an array.
 
 [source,sqlpp]
 ----
-SELECT ARRAY_MAX(t.public_likes) AS max_val
-FROM hotel t
-LIMIT 1;
+SELECT
+  ARRAY_MAX( [ 1 , 3 , 9 , 5 ] ) AS max_num,
+  ARRAY_MAX( [ "delta" , "united" , "southwest" ] ) max_string;
 ----
 
 .Results
@@ -760,7 +686,8 @@ LIMIT 1;
 ----
 [
   {
-    "max_val": "Vallie Ryan"
+    "max_num": 9,
+    "max_string": "united"
   }
 ]
 ----
@@ -784,15 +711,13 @@ If the input [.var]`expr` is a non-array value, then it returns `NULL`.
 
 === Example
 ====
-include::ROOT:partial$query-context.adoc[tag=example]
 
-Find the minimum (first) value of the `public_likes` array:
 
 [source,sqlpp]
 ----
-SELECT ARRAY_MIN(t.public_likes) AS min_val
-FROM hotel t
-LIMIT 1;
+SELECT
+  ARRAY_MIN( [ 1 , 3 , 9 , 5 ] ) AS min_num,
+  ARRAY_MIN( [ "delta" , "united" , "southwest" ] ) min_string;
 ----
 
 .Results
@@ -800,7 +725,8 @@ LIMIT 1;
 ----
 [
   {
-    "min_val": "Brian Kilback"
+    "min_num": 1,
+    "min_string": "delta"
   }
 ]
 ----
@@ -833,12 +759,12 @@ If the [.var]`expr` argument is a non-array, or if either of the [.var]`val` arg
 
 === Examples
 ====
-Move the first element in the array to the second position in the array.
+Move the 1st element in an array to the 3rd position in the array.
 
 [source,sqlpp]
 ----
-WITH Letters AS (["a", "b", "c", "d", "e", "f"])
-SELECT ARRAY_MOVE(Letters, 0, 1) AS Second;
+SELECT ARRAY_MOVE(["a", "b", "c", "d", "e"], 0, 3) 
+AS updated_array;
 ----
 
 .Results
@@ -846,13 +772,12 @@ SELECT ARRAY_MOVE(Letters, 0, 1) AS Second;
 ----
 [
   {
-    "Second": [
+    "updated_array": [
       "b",
-      "a",
       "c",
       "d",
-      "e",
-      "f"
+      "a",
+      "e"
     ]
   }
 ]
@@ -860,12 +785,12 @@ SELECT ARRAY_MOVE(Letters, 0, 1) AS Second;
 ====
 
 ====
-Move the first element in an array to the penultimate position in the array.
+Move the 1st element in an array to the penultimate position in the array.
 
 [source,sqlpp]
 ----
-WITH Letters AS (["a", "b", "c", "d", "e", "f"])
-SELECT ARRAY_MOVE(Letters, 0, -2) AS Penultimate;
+SELECT ARRAY_MOVE( [ "a" , "b" , "c" , "d" , "e" ] , 0 , -2) 
+AS penultimate;
 ----
 
 .Results
@@ -873,13 +798,12 @@ SELECT ARRAY_MOVE(Letters, 0, -2) AS Penultimate;
 ----
 [
   {
-    "Penultimate": [
+    "penultimate": [
       "b",
       "c",
       "d",
-      "e",
       "a",
-      "f"
+      "e"
     ]
   }
 ]
@@ -913,15 +837,12 @@ If either of the arguments are non-array values, it returns `NULL`.
 
 === Example
 ====
-include::ROOT:partial$query-context.adoc[tag=example]
-
-Find which position "Brian Kilback" is in the `public_likes` array:
+Find the position of a number in an array.
 
 [source,sqlpp]
 ----
-SELECT ARRAY_POSITION(t.public_likes, "Brian Kilback") AS array_position
-FROM hotel t
-LIMIT 1;
+SELECT ARRAY_POSITION( [ 10 , 20 , 30 , 40 , 50 ] , 30 )
+AS position;
 ----
 
 .Results
@@ -929,7 +850,7 @@ LIMIT 1;
 ----
 [
   {
-    "array_position": 4
+    "position": 2
   }
 ]
 ----
@@ -957,15 +878,12 @@ If the last argument is a non-array, it returns `NULL`.
 
 === Example
 ====
-include::ROOT:partial$query-context.adoc[tag=example]
-
-Prepend "Dave Smith" to the front of the `public_likes` array:
+Add an element to the beginning of an array.
 
 [source,sqlpp]
 ----
-SELECT ARRAY_PREPEND("Dave Smith",t.public_likes) AS prepend_val
-FROM hotel t
-LIMIT 1;
+SELECT ARRAY_PREPEND( 0 , [ 1 , 2 , 3 , 4 , 5 ] )
+AS updated_array;
 ----
 
 .Results
@@ -973,16 +891,13 @@ LIMIT 1;
 ----
 [
   {
-    "prepend_val": [
-      "Dave Smith",
-      "Julius Tromp I",
-      "Corrine Hilll",
-      "Jaeden McKenzie",
-      "Vallie Ryan",
-      "Brian Kilback",
-      "Lilian McLaughlin",
-      "Ms. Moses Feeney",
-      "Elnora Trantow"
+    "updated_array": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5
     ]
   }
 ]
@@ -1013,15 +928,11 @@ If the first argument is a non-array, then it returns `NULL`.
 
 === Example
 ====
-include::ROOT:partial$query-context.adoc[tag=example]
-
-Append "Dave Smith" to the end of the `public_likes` array:
+Append a value to an array of numbers. 
 
 [source,sqlpp]
 ----
-SELECT ARRAY_PUT(t.public_likes, "Dave Smith") AS array_put
-FROM hotel t
-LIMIT 1;
+SELECT ARRAY_PUT([1, 2, 3, 4], 5) AS updated_array;
 ----
 
 .Results
@@ -1029,16 +940,12 @@ LIMIT 1;
 ----
 [
   {
-    "array_put": [
-      "Julius Tromp I",
-      "Corrine Hilll",
-      "Jaeden McKenzie",
-      "Vallie Ryan",
-      "Brian Kilback",
-      "Lilian McLaughlin",
-      "Ms. Moses Feeney",
-      "Elnora Trantow",
-      "Dave Smith"
+    "updated_array": [
+      1,
+      2,
+      3,
+      4,
+      5
     ]
   }
 ]
@@ -1078,7 +985,7 @@ Make an array from 0 to 20 by stepping every 5th number.
 
 [source,sqlpp]
 ----
-SELECT ARRAY_RANGE(0, 25, 5) AS gen_array_range_5;
+SELECT ARRAY_RANGE( 0 , 25 , 5 ) AS gen_array_range_5;
 ----
 
 .Results
@@ -1103,7 +1010,7 @@ Make an array from 0.1 to 1.1 by stepping every 2nd number.
 
 [source,sqlpp]
 ----
-SELECT ARRAY_RANGE(0.1, 2) AS gen_array_range_2;
+SELECT ARRAY_RANGE( 0.1 , 2 ) AS gen_array_range_2;
 ----
 
 .Results
@@ -1125,7 +1032,7 @@ Make an array from 10 to 3 by stepping down every 3rd number.
 
 [source,sqlpp]
 ----
-SELECT ARRAY_RANGE(10, 3, -3) AS gen_array_range_minus3;
+SELECT ARRAY_RANGE( 10 , 3 , -3 ) AS gen_array_range_minus3;
 ----
 
 .Results
@@ -1180,15 +1087,12 @@ END AS filtered_names;
 
 === Example
 ====
-include::ROOT:partial$query-context.adoc[tag=example]
-
-Remove "Vallie Ryan" from the `public_likes` array:
+Remove `3` and `5` from an array of numbers.
 
 [source,sqlpp]
 ----
-SELECT ARRAY_REMOVE(t.public_likes, "Vallie Ryan") AS remove_val
-FROM hotel t
-LIMIT 1;
+SELECT ARRAY_REMOVE( [ 1 , 2 , 3 , 4 , 5 ] , 3, 5 ) 
+AS updated_array;
 ----
 
 .Results
@@ -1196,14 +1100,10 @@ LIMIT 1;
 ----
 [
   {
-    "remove_val": [
-      "Julius Tromp I",
-      "Corrine Hilll",
-      "Jaeden McKenzie",
-      "Brian Kilback",
-      "Lilian McLaughlin",
-      "Ms. Moses Feeney",
-      "Elnora Trantow"
+    "updated_array": [
+      1,
+      2,
+      4
     ]
   }
 ]
@@ -1230,11 +1130,11 @@ If the [.var]`rep_int` argument is not an integer, then it returns `NULL`.
 
 === Example
 ====
-Make an array with "Vallie Ryan" three times.
+Create an array with the value `"hello"` repeated 3 times.
 
 [source,sqlpp]
 ----
-SELECT ARRAY_REPEAT("Vallie Ryan", 3) AS repeat_val;
+SELECT ARRAY_REPEAT("hello", 3) AS repeated_array;
 ----
 
 .Results
@@ -1242,10 +1142,10 @@ SELECT ARRAY_REPEAT("Vallie Ryan", 3) AS repeat_val;
 ----
 [
   {
-    "repeat_val": [
-      "Vallie Ryan",
-      "Vallie Ryan",
-      "Vallie Ryan"
+    "repeated_array": [
+      "hello",
+      "hello",
+      "hello"
     ]
   }
 ]
@@ -1279,15 +1179,11 @@ If the first argument is not an array or if the second argument is `NULL`, then 
 
 === Example
 ====
-include::ROOT:partial$query-context.adoc[tag=example]
-
-Replace all occurrences of "Vallie Ryan" with "Valerie Ryan":
+Replace all occurrences of `2` with `99` in an array.
 
 [source,sqlpp]
 ----
-SELECT ARRAY_REPLACE(t.public_likes, "Vallie Ryan", "Valerie Ryan") AS replace_val
-FROM hotel t
-LIMIT 1;
+SELECT ARRAY_REPLACE( [ 1 , 2 , 3 , 2 , 4 ] , 2 , 99) AS updated_array;
 ----
 
 .Results
@@ -1295,15 +1191,12 @@ LIMIT 1;
 ----
 [
   {
-    "replace_val": [
-      "Julius Tromp I",
-      "Corrine Hilll",
-      "Jaeden McKenzie",
-      "Valerie Ryan",
-      "Brian Kilback",
-      "Lilian McLaughlin",
-      "Ms. Moses Feeney",
-      "Elnora Trantow"
+    "updated_array": [
+      1,
+      99,
+      3,
+      99,
+      4
     ]
   }
 ]
@@ -1347,14 +1240,10 @@ The following example shows how the ARRAY_REPLACE_EQUIVALENT function can replac
 [source,sqlpp]
 ----
 SELECT 
-ARRAY_REPLACE([{"name":"Brian"},{"name":null}], 
-          {"name":null}, 
-          {"name":"Unknown User"}) 
-          AS replace_result,
-ARRAY_REPLACE_EQUIVALENT([{"name":"Brian"},{"name":null}], 
-          {"name":null}, 
-          {"name":"Unknown User"}) 
-          AS replace_equiv_result;
+ARRAY_REPLACE( [ 1 , 2 , null , 4 ] , null , 99 ) 
+  AS replace_result,
+ARRAY_REPLACE_EQUIVALENT( [ 1 , 2 , null , 4 ] , null , 99 ) 
+  AS replace_equiv_result;
 ----
 
 .Results
@@ -1362,21 +1251,12 @@ ARRAY_REPLACE_EQUIVALENT([{"name":"Brian"},{"name":null}],
 ----
 [
   {
-    "replace_result": [
-      {
-        "name": "Brian"
-      },
-      {
-        "name": null
-      }
-    ],
+    "replace_result": null,
     "replace_equiv_result": [
-      {
-        "name": "Brian"
-      },
-      {
-        "name": "Unknown User"
-      }
+      1,
+      2,
+      99,
+      4
     ]
   }
 ]
@@ -1401,15 +1281,12 @@ If the argument is a non-array value, then it returns `NULL`.
 
 === Example
 ====
-include::ROOT:partial$query-context.adoc[tag=example]
-
-Reverse the values in the `public_likes` array:
+Reverse the order of elements in an array.
 
 [source,sqlpp]
 ----
-SELECT ARRAY_REVERSE(t.public_likes) AS reverse_val
-FROM hotel t
-LIMIT 1;
+SELECT ARRAY_REVERSE( [ 1 , 2 , 3 , 4 , 5 ] ) 
+AS reversed_array;
 ----
 
 .Results
@@ -1417,15 +1294,12 @@ LIMIT 1;
 ----
 [
   {
-    "reverse_val": [
-      "Elnora Trantow",
-      "Ms. Moses Feeney",
-      "Lilian McLaughlin",
-      "Brian Kilback",
-      "Vallie Ryan",
-      "Jaeden McKenzie",
-      "Corrine Hilll",
-      "Julius Tromp I"
+    "reversed_array": [
+      5,
+      4,
+      3,
+      2,
+      1
     ]
   }
 ]
@@ -1450,15 +1324,12 @@ If the argument is a non-array value, then it returns `NULL`.
 
 === Example
 ====
-include::ROOT:partial$query-context.adoc[tag=example]
-
-Sort the `public_likes` array:
+Sort the elements of the array in ascending order.
 
 [source,sqlpp]
 ----
-SELECT ARRAY_SORT(t.public_likes) AS sorted_array
-FROM hotel t
-LIMIT 1;
+SELECT ARRAY_SORT( [ 5 , 3 , 1 , 4 , 2 ] ) 
+AS sorted_array;
 ----
 
 .Results
@@ -1467,14 +1338,11 @@ LIMIT 1;
 [
   {
     "sorted_array": [
-      "Brian Kilback",
-      "Corrine Hilll",
-      "Elnora Trantow",
-      "Jaeden McKenzie",
-      "Julius Tromp I",
-      "Lilian McLaughlin",
-      "Ms. Moses Feeney",
-      "Vallie Ryan"
+      1,
+      2,
+      3,
+      4,
+      5
     ]
   }
 ]
@@ -1499,25 +1367,14 @@ If the argument is a non-array value, then it returns `NULL`.
 
 === Example
 ====
-Convert a given array of two documents each with five items into an object of five arrays each with two documents.
+Convert a given array of two objects, each with three fields, into an object of three arrays.
 
 [source,sqlpp]
 ----
-SELECT ARRAY_STAR( [
-   {
-    "address": "Capstone Road, ME7 3JE",
-    "city": "Medway",
-    "country": "United Kingdom",
-    "name": "Medway Youth Hostel",
-    "url": "http://www.yha.org.uk"
-  },
-  {
-    "address": "6 rue aux Juifs",
-    "city": "Giverny",
-    "country": "France",
-    "name": "The Robins",
-    "url": "http://givernyguesthouse.com/robin.htm"
-  }]) AS array_star;
+SELECT ARRAY_STAR([
+  { "id": 10226, "airline": "Atifly", "code": "A1F" },
+  { "id": 10123, "airline": "Texas Wings", "code": "TXW" }
+]) AS object_of_arrays;
 ----
 
 .Results
@@ -1525,27 +1382,10 @@ SELECT ARRAY_STAR( [
 ----
 [
   {
-    "array_star": {
-      "address": [
-        "Capstone Road, ME7 3JE",
-        "6 rue aux Juifs"
-      ],
-      "city": [
-        "Medway",
-        "Giverny"
-      ],
-      "country": [
-        "United Kingdom",
-        "France"
-      ],
-      "name": [
-        "Medway Youth Hostel",
-        "The Robins"
-      ],
-      "url": [
-        "http://www.yha.org.uk",
-        "http://givernyguesthouse.com/robin.htm"
-      ]
+    "object_of_arrays": {
+      "airline": [ "Atifly", "Texas Wings"],
+      "code": [ "A1F", "TXW" ],
+      "id": [ 10226, 10123]
     }
   }
 ]
@@ -1553,20 +1393,64 @@ SELECT ARRAY_STAR( [
 ====
 
 === Array References
+
 You can use an asterisk (*) as an array subscript which converts the array to an object of arrays.
-The following example returns an array of the ages of the given contact’s children:
+
+The following example returns an array of airline names from an array of flight objects:
+
 ====
+.Query
 [source,sqlpp]
 ----
-SELECT children[*].age FROM contacts WHERE fname = "Dave"
+WITH sample AS (
+  SELECT [
+    { "airline": "Atifly", "code": "AF" },
+    { "airline": "Texas Wings", "code": "TXW" }
+  ] AS flights
+)
+SELECT flights[*].airline
+FROM sample;
+----
+.Results
+[source,json]
+----
+[
+  {
+    "airline": [
+      "Atifly",
+      "Texas Wings"
+    ]
+  }
+]
 ----
 ====
 
-An equivalent query can be written using the [.api]`array_star()` function:
+You can write an equivalent query using the [.api]`array_star()` function:
 ====
+.Query
 [source,sqlpp]
 ----
-SELECT array_star(children).age FROM contacts WHERE fname = "Dave"
+WITH sample AS (
+  SELECT [
+    { "airline": "Atifly", "code": "AF" },
+    { "airline": "Texas Wings", "code": "TXW" }
+  ] AS flights
+)
+SELECT array_star(flights).airline
+FROM sample;
+----
+
+.Results
+[source,json]
+----
+[
+  {
+    "airline": [
+      "Atifly",
+      "Texas Wings"
+    ]
+  }
+]
 ----
 ====
 
@@ -1707,7 +1591,7 @@ Find the total of a given array of numbers.
 
 [source,sqlpp]
 ----
-SELECT ARRAY_SUM([0,1,1,2,3,5]) as sum;
+SELECT ARRAY_SUM( [ 0 , 1 , 1 , 2 , 3 , 5 ] ) as sum;
 ----
 
 .Results
@@ -1753,7 +1637,8 @@ Find the elements that appear in exactly one of these three input arrays.
 
 [source,sqlpp]
 ----
-SELECT ARRAY_SYMDIFF([1, 2], [1, 2, 4], [1, 3]) AS symm_diff1;
+SELECT ARRAY_SYMDIFF( [ 1 , 2 ] , [ 1 , 2 , 4 ] , [ 1 , 3 ] ) 
+AS symm_diff1;
 ----
 
 .Results
@@ -1805,7 +1690,8 @@ Find the elements that appear in an odd number of these three input arrays.
 
 [source,sqlpp]
 ----
-SELECT ARRAY_SYMDIFFN([1, 2], [1, 2, 4], [1, 3]) AS symm_diffn;
+SELECT ARRAY_SYMDIFFN( [ 1 , 2 ] , [ 1 , 2 , 4 ] , [ 1 , 3 ] ) 
+AS symm_diffn;
 ----
 
 .Results
@@ -1845,7 +1731,8 @@ List the union of three given arrays.
 
 [source,sqlpp]
 ----
-SELECT ARRAY_UNION([1, 2], [1, 2, 4], [1, 3]) AS array_union;
+SELECT ARRAY_UNION( [ 1 , 2 ] , [ 1 , 2 , 4 ] , [ 1 , 3 ] )
+AS array_union;
 ----
 
 .Results
@@ -1869,7 +1756,8 @@ List the union of two given arrays with a string.
 
 [source,sqlpp]
 ----
-SELECT ARRAY_UNION([1, 2], [1, 2, 4], "abc") AS array_union;
+SELECT ARRAY_UNION( [ 1 , 2 ] , [ 1 , 2 , 4 ] , "abc") 
+AS array_union;
 ----
 
 .Results

--- a/modules/n1ql/pages/n1ql-language-reference/arrayfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/arrayfun.adoc
@@ -1645,7 +1645,7 @@ This function has a synonym <<fn-array-symdiff1>>.
 
 === Description
 This function returns a new array based on the set symmetric difference, or disjunctive union, of the input [.var]`expression` arrays.
-The new array contains only those elements that appear in _exactly one_ of the input arrays, and it requires a minimum of two arguments.
+The new array contains only those elements that appear in exactly one of the input arrays, and it requires a minimum of two arguments.
 
 === Arguments
 expr1, expr2, …:: [At least 2 are required] The input arrays to compare.
@@ -1699,7 +1699,7 @@ Synonym of <<fn-array-symdiff>>.
 
 === Description
 This function returns a new array based on the set symmetric difference, or disjunctive union, of the input arrays.
-The new array contains only those elements that appear in _an odd number_ of input arrays, and it requires a minimum of two arguments.
+The new array contains only those elements that appear in an odd number of input arrays, and it requires a minimum of two arguments.
 
 === Arguments
 expr1, expr2, …:: [At least 2 are required] The input arrays to compare.

--- a/modules/n1ql/pages/n1ql-language-reference/arrayfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/arrayfun.adoc
@@ -72,7 +72,7 @@ If the [.var]`expr` is in the `WHERE` clause of a partial index, this function l
 
 === Example
 ====
-Add a couple of numbers to an existing array.
+Append two numbers to the end of a given array.
 
 .Query
 [source,sqlpp]

--- a/modules/n1ql/pages/n1ql-language-reference/arrayfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/arrayfun.adoc
@@ -23,6 +23,7 @@ If the input [.var]`expression` is `MISSING` or if one of the elements in the ar
 ====
 Group a list of three items into an array.
 
+.Query
 [source,sqlpp]
 ----
 SELECT ARRAY_AGG( [ "abc", 1, NULL ] ) AS array_aggregate;
@@ -73,6 +74,7 @@ If the [.var]`expr` is in the `WHERE` clause of a partial index, this function l
 ====
 Add a couple of numbers to an existing array.
 
+.Query
 [source,sqlpp]
 ----
 SELECT ARRAY_APPEND( [ 1 , 2 ] , 3 , 4) AS numbers;
@@ -119,6 +121,7 @@ Any non-number elements in the array [.var]`expr` are ignored.
 ====
 Find the average from an array of numbers.
 
+.Query
 [source,sqlpp]
 ----
 SELECT ARRAY_AVG( [ 0 , 1 , 1 , 2 , 3 , 5 ] ) AS array_average;
@@ -168,6 +171,7 @@ If the input [.var]`expr` is not an array, it returns `NULL`.
 ====
 Find the position of a number in a sorted array.
 
+.Query
 [source,sqlpp]
 ----
 SELECT ARRAY_BINARY_SEARCH( [ 1 , 3 , 5 , 7 , 9 ] , 5) 
@@ -207,8 +211,9 @@ If any of the input [.var]`expr` arguments is not an array, then it returns `NUL
 
 === Example
 ====
-Combine two arrays into one.
+Combine two arrays into a single array.
 
+.Query
 [source,sqlpp]
 ----
 SELECT ARRAY_CONCAT( [ 1 , 2 , 3 ], [ 4 , 5 , 6 ] ) 
@@ -256,8 +261,9 @@ If the array [.var]`expr` contains [.var]`val`, then it returns `TRUE`; otherwis
 === Example
 
 ====
-Check if a value exists in an array.
+Check if the value `3` exists in a given array of numbers.
 
+.Query
 [source,sqlpp]
 ----
 SELECT ARRAY_CONTAINS( [ 1 , 2 , 3 , 4 , 5 ] , 3 ) 
@@ -296,8 +302,9 @@ If the [.var]`expr` argument is not an array, then it returns `NULL`.
 === Example
 
 ====
-Count the number of elements in an array.
+Count the number of elements in a given array.
 
+.Query
 [source,sqlpp]
 ----
 SELECT ARRAY_COUNT( [ 1 , 2 , 3 , 4 , 5 ] )
@@ -334,8 +341,9 @@ If the input [.var]`expr` is a non-array value, it returns `NULL`.
 === Example
 
 ====
-Remove duplicate elements from an array.
+Remove duplicate elements from a given array.
 
+.Query
 [source,sqlpp]
 ----
 SELECT ARRAY_DISTINCT( [ 1 , 2 , 2 , 3 , 4 , 4 , 5 ] )
@@ -382,6 +390,7 @@ If any of the arguments is a non-array, it returns `NULL`.
 ====
 Exclude elements of one array from another.
 
+.Query
 [source,sqlpp]
 ----
 SELECT ARRAY_EXCEPT( [ 1 , 2 , 3 , 4 , 5 ] , [ 2 , 4 ] )
@@ -426,6 +435,7 @@ If the input [.var]`expr` is a non-array, or if the input [.var]`depth` argument
 ====
 Flatten a nested array by 1 and 2 levels.
 
+.Query
 [source,sqlpp]
 ----
 SELECT 
@@ -481,8 +491,9 @@ If the input [.var]`expr` is a non-array, then it returns `NULL`.
 
 === Examples
 ====
-Find the first non-NULL value in an array.
+Find the first non-NULL value in a given array.
 
+.Query
 [source,sqlpp]
 ----
 SELECT ARRAY_IFNULL( [ NULL , NULL , 1 , 2 , 3 ] )
@@ -525,6 +536,7 @@ If the [.var]`expr` argument is a non-array or if the [.var]`position` argument 
 ====
 Insert `55` into the 2nd position of an array. 
 
+.Query
 [source,sqlpp]
 ----
 SELECT ARRAY_INSERT( [ 1 , 2 , 3 , 4 ] , 2 , 55 ) 
@@ -570,6 +582,7 @@ If any of the input arguments are non-array values, then it returns `NULL`.
 ====
 Compare three arrays to find common elements.
 
+.Query
 [source,sqlpp]
 ----
 SELECT ARRAY_INTERSECT( 
@@ -595,6 +608,7 @@ AS array_intersection;
 ====
 Compare three arrays with no common elements.
 
+.Query
 [source,sqlpp]
 ----
 SELECT ARRAY_INTERSECT( 
@@ -635,8 +649,9 @@ If the input argument is a non-array value, then it returns `NULL`.
 
 === Example
 ====
-Find the number of elements in an array.
+Find the number of elements in a given array.
 
+.Query
 [source,sqlpp]
 ----
 SELECT ARRAY_LENGTH( [ 1 , 2 , 3 , 4 , 5 ] ) 
@@ -672,8 +687,9 @@ If the input [.var]`expr` is a non-array value, then it returns `NULL`.
 
 === Example
 ====
-Find the largest value in an array.
+Find the largest value in a given array.
 
+.Query
 [source,sqlpp]
 ----
 SELECT
@@ -711,8 +727,9 @@ If the input [.var]`expr` is a non-array value, then it returns `NULL`.
 
 === Example
 ====
+Find the smallest value in a given array.
 
-
+.Query
 [source,sqlpp]
 ----
 SELECT
@@ -759,8 +776,9 @@ If the [.var]`expr` argument is a non-array, or if either of the [.var]`val` arg
 
 === Examples
 ====
-Move the 1st element in an array to the 3rd position in the array.
+Move the 1st element in a given array to the 3rd position in the array.
 
+.Query
 [source,sqlpp]
 ----
 SELECT ARRAY_MOVE(["a", "b", "c", "d", "e"], 0, 3) 
@@ -785,8 +803,9 @@ AS updated_array;
 ====
 
 ====
-Move the 1st element in an array to the penultimate position in the array.
+Move the 1st element in a given array to the penultimate position in the array.
 
+.Query
 [source,sqlpp]
 ----
 SELECT ARRAY_MOVE( [ "a" , "b" , "c" , "d" , "e" ] , 0 , -2) 
@@ -837,8 +856,9 @@ If either of the arguments are non-array values, it returns `NULL`.
 
 === Example
 ====
-Find the position of a number in an array.
+Find the position of the value `30` in a given array.
 
+.Query
 [source,sqlpp]
 ----
 SELECT ARRAY_POSITION( [ 10 , 20 , 30 , 40 , 50 ] , 30 )
@@ -878,8 +898,9 @@ If the last argument is a non-array, it returns `NULL`.
 
 === Example
 ====
-Add an element to the beginning of an array.
+Add the value `0` to the beginning of a given array.
 
+.Query
 [source,sqlpp]
 ----
 SELECT ARRAY_PREPEND( 0 , [ 1 , 2 , 3 , 4 , 5 ] )
@@ -928,8 +949,9 @@ If the first argument is a non-array, then it returns `NULL`.
 
 === Example
 ====
-Append a value to an array of numbers. 
+Append the value `5` to a given array of numbers.  
 
+.Query
 [source,sqlpp]
 ----
 SELECT ARRAY_PUT([1, 2, 3, 4], 5) AS updated_array;
@@ -981,11 +1003,12 @@ If any of the arguments do not start with a digit, then it returns an error.
 
 === Examples
 ====
-Make an array from 0 to 20 by stepping every 5th number.
+Generate an array of numbers from `0` to `20` with a step of `5`.
 
+.Query
 [source,sqlpp]
 ----
-SELECT ARRAY_RANGE( 0 , 25 , 5 ) AS gen_array_range_5;
+SELECT ARRAY_RANGE( 0 , 25 , 5 ) AS generated_array;
 ----
 
 .Results
@@ -993,7 +1016,7 @@ SELECT ARRAY_RANGE( 0 , 25 , 5 ) AS gen_array_range_5;
 ----
 [
   {
-    "gen_array_range_5": [
+    "generated_array": [
       0,
       5,
       10,
@@ -1006,11 +1029,12 @@ SELECT ARRAY_RANGE( 0 , 25 , 5 ) AS gen_array_range_5;
 ====
 
 ====
-Make an array from 0.1 to 1.1 by stepping every 2nd number.
+Generate an array of numbers from `0.1` to `1.1` with the default step `1`.
 
+.Query
 [source,sqlpp]
 ----
-SELECT ARRAY_RANGE( 0.1 , 2 ) AS gen_array_range_2;
+SELECT ARRAY_RANGE( 0.1 , 2 ) AS generated_array;
 ----
 
 .Results
@@ -1018,7 +1042,7 @@ SELECT ARRAY_RANGE( 0.1 , 2 ) AS gen_array_range_2;
 ----
 [
   {
-    "gen_array_range_2": [
+    "generated_array": [
       0.1,
       1.1
     ]
@@ -1028,11 +1052,12 @@ SELECT ARRAY_RANGE( 0.1 , 2 ) AS gen_array_range_2;
 ====
 
 ====
-Make an array from 10 to 3 by stepping down every 3rd number.
+Generate an array from `10` to `3` with a step of `-3`.
 
+.Query
 [source,sqlpp]
 ----
-SELECT ARRAY_RANGE( 10 , 3 , -3 ) AS gen_array_range_minus3;
+SELECT ARRAY_RANGE( 10 , 3 , -3 ) AS generated_array;
 ----
 
 .Results
@@ -1040,7 +1065,7 @@ SELECT ARRAY_RANGE( 10 , 3 , -3 ) AS gen_array_range_minus3;
 ----
 [
   {
-    "gen_array_range-3": [
+    "generated_array": [
       10,
       7,
       4
@@ -1089,6 +1114,7 @@ END AS filtered_names;
 ====
 Remove `3` and `5` from an array of numbers.
 
+.Query
 [source,sqlpp]
 ----
 SELECT ARRAY_REMOVE( [ 1 , 2 , 3 , 4 , 5 ] , 3, 5 ) 
@@ -1132,6 +1158,7 @@ If the [.var]`rep_int` argument is not an integer, then it returns `NULL`.
 ====
 Create an array with the value `"hello"` repeated 3 times.
 
+.Query
 [source,sqlpp]
 ----
 SELECT ARRAY_REPEAT("hello", 3) AS repeated_array;
@@ -1179,8 +1206,9 @@ If the first argument is not an array or if the second argument is `NULL`, then 
 
 === Example
 ====
-Replace all occurrences of `2` with `99` in an array.
+Replace all occurrences of `2` with `99` in a given array.
 
+.Query
 [source,sqlpp]
 ----
 SELECT ARRAY_REPLACE( [ 1 , 2 , 3 , 2 , 4 ] , 2 , 99) AS updated_array;
@@ -1237,6 +1265,7 @@ If the first argument is not an array, then it returns `NULL`.
 ====
 The following example shows how the ARRAY_REPLACE_EQUIVALENT function can replace `NULL` values, while the ARRAY_REPLACE function cannot.
 
+.Query
 [source,sqlpp]
 ----
 SELECT 
@@ -1281,8 +1310,9 @@ If the argument is a non-array value, then it returns `NULL`.
 
 === Example
 ====
-Reverse the order of elements in an array.
+Reverse the order of elements in a given array.
 
+.Query
 [source,sqlpp]
 ----
 SELECT ARRAY_REVERSE( [ 1 , 2 , 3 , 4 , 5 ] ) 
@@ -1324,8 +1354,9 @@ If the argument is a non-array value, then it returns `NULL`.
 
 === Example
 ====
-Sort the elements of the array in ascending order.
+Sort the elements of a given array in ascending order.
 
+.Query
 [source,sqlpp]
 ----
 SELECT ARRAY_SORT( [ 5 , 3 , 1 , 4 , 2 ] ) 
@@ -1411,6 +1442,7 @@ WITH sample AS (
 SELECT flights[*].airline
 FROM sample;
 ----
+
 .Results
 [source,json]
 ----
@@ -1589,6 +1621,7 @@ If the argument is a non-array value, then it returns `NULL`.
 ====
 Find the total of a given array of numbers.
 
+.Query
 [source,sqlpp]
 ----
 SELECT ARRAY_SUM( [ 0 , 1 , 1 , 2 , 3 , 5 ] ) as sum;
@@ -1635,6 +1668,7 @@ Refer to the following article for more information on the difference between a 
 ====
 Find the elements that appear in exactly one of these three input arrays.
 
+.Query
 [source,sqlpp]
 ----
 SELECT ARRAY_SYMDIFF( [ 1 , 2 ] , [ 1 , 2 , 4 ] , [ 1 , 3 ] ) 
@@ -1688,6 +1722,7 @@ Refer to the following article for more information on the difference between a 
 ====
 Find the elements that appear in an odd number of these three input arrays.
 
+.Query
 [source,sqlpp]
 ----
 SELECT ARRAY_SYMDIFFN( [ 1 , 2 ] , [ 1 , 2 , 4 ] , [ 1 , 3 ] ) 
@@ -1729,6 +1764,7 @@ If any of the arguments is a non-array value, then it returns `NULL`.
 ====
 List the union of three given arrays.
 
+.Query
 [source,sqlpp]
 ----
 SELECT ARRAY_UNION( [ 1 , 2 ] , [ 1 , 2 , 4 ] , [ 1 , 3 ] )
@@ -1754,6 +1790,7 @@ AS array_union;
 ====
 List the union of two given arrays with a string.
 
+.Query
 [source,sqlpp]
 ----
 SELECT ARRAY_UNION( [ 1 , 2 ] , [ 1 , 2 , 4 ] , "abc") 

--- a/modules/n1ql/pages/n1ql-language-reference/conditionalops.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/conditionalops.adoc
@@ -30,6 +30,51 @@ If it is equal to the search expression, the result of this expression is the TH
 * If none of the WHEN expressions are equal to the search expression, then the result of the CASE expression is the ELSE expression.
 * If no ELSE expression was provided, the result is NULL.
 
+=== Example
+
+The following example uses a CASE expression to categorize flights based on their `departed-on` date.
+
+====
+.Query
+[source,sqlpp]
+----
+WITH flight AS (
+   [
+      { "flight-id": "F101", "departed-on": "2025-12-01" },
+      { "flight-id": "F201" },
+      { "flight-id": "F301", "departed-on": "2025-12-02" }
+   ]
+)
+SELECT
+   `flight-id`,
+   CASE `departed-on`
+      WHEN "2025-12-01" THEN "First flight"
+      WHEN "2025-12-02" THEN "Second flight"
+      ELSE "Unknown flight"
+   END AS category
+FROM flight
+----
+
+.Result
+[source,json]
+----
+[
+  {
+    "flight-id": "F101",
+    "category": "First flight"
+  },
+  {
+    "flight-id": "F201",
+    "category": "Unknown flight"
+  },
+  {
+    "flight-id": "F301",
+    "category": "Second flight"
+  }
+]
+----
+====
+
 == Searched Case Expressions
 
 [source,ebnf]
@@ -50,29 +95,47 @@ The evaluation process is as follows:
 
 === Example
 
-The following example uses a CASE clause to handle documents that do not have a ship date.
-This scans all orders.
-If an order has a shipped-on date, it is provided in the result set.
-If an order does not have a shipped-on date, default text appears.
+The following example uses a CASE clause to determine whether a flight has departed.
+It scans all flights.
+If the flight has a `departed-on` date, it is provided in the result set.
+If not, the result shows the default text `"not-departed-yet"`.
 
 ====
 .Query
 [source,sqlpp]
 ----
+WITH flight AS (
+   [
+      { "flight-id": "F101", "departed-on": "2025-12-01" },
+      { "flight-id": "F201" },
+      { "flight-id": "F301", "departed-on": "2025-12-10" }
+   ]
+)
 SELECT
-   CASE WHEN `shipped-on`
-   IS NOT NULL THEN `shipped-on`
-   ELSE "not-shipped-yet"
-   END
-   AS shipped
-   FROM orders
+   `flight-id`,
+   CASE 
+      WHEN `departed-on` IS NOT NULL THEN `departed-on`
+      ELSE "not-departed-yet"
+   END AS departed
+FROM flight
 ----
 
 .Result
 [source,json]
 ----
-{ "shipped": "2013/01/02" },
-{ "shipped": "2013/01/12" },
-{ "shipped": "not-shipped-yet" },
+[
+  {
+    "flight-id": "F101",
+    "departed": "2025-12-01"
+  },
+  {
+    "flight-id": "F201",
+    "departed": "not-departed-yet"
+  },
+  {
+    "flight-id": "F301",
+    "departed": "2025-12-10"
+  }
+]
 ----
 ====

--- a/modules/n1ql/pages/n1ql-language-reference/stringops.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/stringops.adoc
@@ -27,35 +27,27 @@ The following example shows concatenation of two strings.
 .Query
 [source,sqlpp]
 ----
-SELECT fname || " " || lname AS full_name
-    FROM tutorial
+WITH airline AS (
+   [
+      { "name": "Delta Airlines", "code": "DL" },
+      { "name": "United Airlines", "code": "UA" }
+   ]
+)
+SELECT name || " (" || code || ")" AS full_airline_name
+FROM airline
 ----
 
 .Result
 [source,json]
 ----
- {
-  "results": [
-    {
-      "full_name": "Dave Smith"
-    },
-    {
-      "full_name": "Earl Johnson"
-    },
-    {
-      "full_name": "Fred Jackson"
-    },
-    {
-      "full_name": "Harry Jackson"
-    },
-    {
-      "full_name": "Ian Taylor"
-    },
-    {
-      "full_name": "Jane Edwards"
-    }
-  ]
-}
+[
+  {
+    "full_airline_name": "Delta Airlines (DL)"
+  },
+  {
+    "full_airline_name": "United Airlines (UA)"
+  }
+]
 ----
 ====
 


### PR DESCRIPTION
Jira: DOC-11109

Cleaned up examples on the following pages so that users can test and see results without needing to understand the underlying doc structure or schema. 

- [Conditional Operators](https://preview.docs-test.couchbase.com/docs-devex-DOC-11109-fix-sqlpp-examples/server/current/n1ql/n1ql-language-reference/conditionalops.html)
- [String Operators](https://preview.docs-test.couchbase.com/docs-devex-DOC-11109-fix-sqlpp-examples/server/current/n1ql/n1ql-language-reference/stringops.html)
- [Array Functions](https://preview.docs-test.couchbase.com/docs-devex-DOC-11109-fix-sqlpp-examples/server/current/n1ql/n1ql-language-reference/arrayfun.html)

Tested all examples locally to ensure they work. 