### PR TITLE
[DOC-10291] Search Functions - Fix broken links and add FTS index definition

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/searchfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/searchfun.adoc
@@ -15,11 +15,6 @@ To use any of the search functions, the Search Service must be available on the 
 It's recommended that you create a suitable Search index for the searches that you want to run.
 For more information, refer to xref:search:create-search-indexes.adoc[].
 
-[NOTE]
---
-The examples in this page all assume that demonstration Search indexes have been created, as described in xref:fts:fts-demonstration-indexes.adoc[Demonstration Indexes].
---
-
 [float]
 === Authorization
 
@@ -111,7 +106,7 @@ For more information about how to format a full search request object, refer to 
 
 [NOTE]
 ====
-When specifying a complete Full Text Search request with the {sqlpp} SEARCH() function, if the value of the `size` parameter is greater than the xref:fts:fts-response-object-schema.adoc#request[maximum number of Full Text Search results], the query ignores the `size` parameter and returns all matching results.
+When specifying a complete Full Text Search request with the {sqlpp} SEARCH() function, if the value of the `size` parameter is greater than the xref:fts:fts-search-response.adoc[maximum number of Full Text Search results], the query ignores the `size` parameter and returns all matching results.
 
 This is different to the behavior of a complete Full Text Search request in the Search Service, where the query returns an error if the value of the `size` parameter is greater than the maximum number of Full Text Search results.
 ====
@@ -382,7 +377,7 @@ WHERE t1.type = "hotel" AND SEARCH(t1.description, "amazing");
 ----
 
 If the Full Text Search index being queried has its default mapping disabled and has a custom type mapping defined, the query needs to specify the type explicitly.
-The above query uses the demonstration index xref:fts:fts-demonstration-indexes.adoc#travel-sample-index-hotel-description[travel-sample-index-hotel-description], which has the custom type mapping "hotel".
+The above query uses the index `travel-sample-index-hotel-description`, which has the custom type mapping `hotel`.
 
 For more information about defining custom type mappings within a Search index, refer to xref:search:create-type-mapping.adoc[Create a Type Mapping].
 Note that for {sqlpp} queries, only Search indexes with one type mapping are searchable.
@@ -431,7 +426,7 @@ For more information about Vector Search and the Search Services, see xref:vecto
 .Search with XATTRs data and no suitable Search index
 ====
 
-If there is no suitable Search index, but you want to return XATTRs data from your documents in another part of your {sqlpp} query, you must use the xref:metafun.adoc#meta[META function] to select the XATTRs field you want to return.
+If there is no suitable Search index, but you want to return XATTRs data from your documents in another part of your {sqlpp} query, you must use the xref:n1ql-language-reference/metafun.adoc#meta[META function] to select the XATTRs field you want to return.
 {sqlpp} cannot return XATTRs data without a specific field name in your `SEARCH` function. 
 
 Add `_$xattrs` with a period (.) to the start of the field name you want to return in the `SEARCH` function. 

--- a/modules/n1ql/pages/n1ql-language-reference/searchfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/searchfun.adoc
@@ -17,7 +17,7 @@ For more information, refer to xref:search:create-search-indexes.adoc[].
 
 [NOTE]
 --
-The examples in this page assume that you have a full text search index created with this definition, unless specified otherwise.
+The examples on this page assume you have created a full-text search index using the following definition.
 
 [source,json]
 ----
@@ -266,8 +266,8 @@ Offset and Limit pushdown is possible if the query only has a SEARCH() predicate
 Group aggregates and projection are not pushed.
 
 NOTE: 
-If the `index` setting isn't specified within the options argument of the Search function, {sqlpp} can pick any FTS index available in the system that qualifies for the query. 
-If a number of FTS indexes qualify, then one that is defined most precise will be chosen.
+If you do not specify the `index` setting in the options argument of the Search function, {sqlpp} automatically selects a qualifying FTS index for the query.
+If multiple indexes qualify for the query, {sqlpp} selects the most precise one.
 
 === Examples
 
@@ -407,36 +407,8 @@ As an alternative, you could limit the number of results and order them using th
 
 .Search against a Full Text Search index that carries a custom type mapping
 ====
-.Query
-[source,sqlpp]
-----
-SELECT META(t1).id
-FROM hotel AS t1
-WHERE t1.type = "hotel" AND SEARCH(t1.description, "amazing");
-----
 
-.Results
-[source,json]
-----
-[
-  {
-    "id": "hotel_20422"
-  },
-  {
-    "id": "hotel_22096"
-  },
-  {
-    "id": "hotel_25243"
-  },
-  {
-    "id": "hotel_27741"
-  }
-]
-----
-
-If the Full Text Search index being queried has its default mapping disabled and has a custom type mapping defined, the query needs to specify the type explicitly.
-
-The above query uses the following index definition: 
+Before running this example, create a Search index with a custom type mapping as described below.
 
 [source, json]
 ----
@@ -482,6 +454,35 @@ The above query uses the following index definition:
   "uuid": ""
 }
 ----
+
+.Query
+[source,sqlpp]
+----
+SELECT META(t1).id
+FROM hotel AS t1
+WHERE t1.type = "hotel" AND SEARCH(t1.description, "amazing");
+----
+
+.Results
+[source,json]
+----
+[
+  {
+    "id": "hotel_20422"
+  },
+  {
+    "id": "hotel_22096"
+  },
+  {
+    "id": "hotel_25243"
+  },
+  {
+    "id": "hotel_27741"
+  }
+]
+----
+If the Full Text Search index being queried has its default mapping disabled and has a custom type mapping defined, the query needs to specify the type explicitly.
+
 For more information about defining custom type mappings within a Search index, refer to xref:search:create-type-mapping.adoc[Create a Type Mapping].
 Note that for {sqlpp} queries, only Search indexes with one type mapping are searchable.
 Also the supported type identifiers at the moment are "type_field" and "docid_prefix"; "docid_regexp" isn't supported yet for SEARCH queries via {sqlpp}.

--- a/modules/n1ql/pages/n1ql-language-reference/searchfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/searchfun.adoc
@@ -15,6 +15,57 @@ To use any of the search functions, the Search Service must be available on the 
 It's recommended that you create a suitable Search index for the searches that you want to run.
 For more information, refer to xref:search:create-search-indexes.adoc[].
 
+[NOTE]
+--
+The examples in this page assume that you have a full text search index created with this definition, unless specified otherwise.
+
+[source,json]
+----
+{
+ "name": "travel-sample-inventory-hotels",
+ "type": "fulltext-index",
+ "params": {
+  "doc_config": {
+   "mode": "scope.collection.type_field",
+   "type_field": "type"
+  },
+  "mapping": {
+   "default_analyzer": "standard",
+   "default_datetime_parser": "dateTimeOptional",
+   "default_field": "_all",
+   "default_mapping": {
+    "dynamic": true,
+    "enabled": false
+   },
+   "default_type": "_default",
+   "docvalues_dynamic": false,
+   "index_dynamic": true,
+   "store_dynamic": false,
+   "type_field": "_type",
+   "types": {
+    "inventory.hotel": {
+     "dynamic": true,
+     "enabled": true
+    }
+   }
+  },
+  "store": {
+   "indexType": "scorch",
+   "segmentVersion": 15
+  }
+ },
+ "sourceType": "gocbcore",
+ "sourceName": "travel-sample",
+ "sourceUUID": "",
+ "sourceParams": {},
+ "planParams": {
+  "indexPartitions": 1
+ },
+ "uuid": ""
+}
+----
+--
+
 [float]
 === Authorization
 
@@ -226,7 +277,7 @@ The following queries are equivalent:
 [source,sqlpp]
 ----
 SELECT META(t1).id
-FROM airline AS t1
+FROM hotel AS t1
 WHERE SEARCH(t1.country, "+United +States");
 ----
 
@@ -234,7 +285,7 @@ WHERE SEARCH(t1.country, "+United +States");
 [source,sqlpp]
 ----
 SELECT META(t1).id
-FROM airline AS t1
+FROM hotel AS t1
 WHERE SEARCH(t1, "country:\"United States\"");
 ----
 
@@ -242,20 +293,19 @@ WHERE SEARCH(t1, "country:\"United States\"");
 [source,json]
 ----
 [
- 
-  {
-    "id": "airline_10"
+ {
+    "id": "hotel_27826"
   },
   {
-    "id": "airline_10123"
+    "id": "hotel_12928"
   },
   {
-    "id": "airline_10226"
+    "id": "hotel_25795"
   },
   {
-    "id": "airline_10748"
-  },
-  // ...
+    "id": "hotel_25507"
+  },  
+  ...
 ]
 ----
 
@@ -342,7 +392,6 @@ WHERE SEARCH(t1, {
   // ...
 ]
 ----
-
 This query returns 5 results, and the results are ordered, as specified by the search options.
 As an alternative, you could limit the number of results and order them using the {sqlpp} xref:n1ql-language-reference/limit.adoc[LIMIT] and xref:n1ql-language-reference/orderby.adoc[ORDER BY] clauses.
 ====
@@ -377,8 +426,53 @@ WHERE t1.type = "hotel" AND SEARCH(t1.description, "amazing");
 ----
 
 If the Full Text Search index being queried has its default mapping disabled and has a custom type mapping defined, the query needs to specify the type explicitly.
-The above query uses the index `travel-sample-index-hotel-description`, which has the custom type mapping `hotel`.
 
+The above query uses the following index definition: 
+
+[source, json]
+----
+{
+  "name": "travel-sample-hotels",
+  "type": "fulltext-index",
+  "params": {
+    "doc_config": {
+      "mode": "type_field",
+      "type_field": "type"
+    },
+    "mapping": {
+      "default_analyzer": "standard",
+      "default_datetime_parser": "dateTimeOptional",
+      "default_field": "_all",
+      "default_mapping": {
+        "dynamic": true,
+        "enabled": false
+      },
+      "default_type": "_default",
+      "index_dynamic": true,
+      "store_dynamic": true,
+      "type_field": "type",
+      "types": {
+        "hotel": {
+          "dynamic": true,
+          "enabled": true
+        }
+      }
+    },
+    "store": {
+      "indexType": "scorch",
+      "segmentVersion": 15
+    }
+  },
+  "sourceType": "gocbcore",
+  "sourceName": "travel-sample",
+  "sourceUUID": "",
+  "sourceParams": {},
+  "planParams": {
+    "indexPartitions": 1
+  },
+  "uuid": ""
+}
+----
 For more information about defining custom type mappings within a Search index, refer to xref:search:create-type-mapping.adoc[Create a Type Mapping].
 Note that for {sqlpp} queries, only Search indexes with one type mapping are searchable.
 Also the supported type identifiers at the moment are "type_field" and "docid_prefix"; "docid_regexp" isn't supported yet for SEARCH queries via {sqlpp}.
@@ -604,11 +698,13 @@ This query only uses one data source, so there is no need to specify the keyspac
 .Results
 [source,json]
 ----
-[
-  {
-    "name": "Marina del Rey Marriott"
-  }
-]
+[{
+    "name": "Marina del Rey Marriott",
+    "meta": {
+        "id": "hotel_17598",
+        "score": 2.1256278997816835
+    }
+}]
 ----
 ====
 
@@ -667,19 +763,21 @@ LIMIT 3;
 .Results
 [source,json]
 ----
-[
-  {
-    "description": "3 Star Hotel next to the Mountain Railway terminus and set in 30 acres of grounds which include Dolbadarn Castle",
-    "name": "The Royal Victoria Hotel"
-  },
-  {
-    "description": "370 guest rooms offering both water and mountain view.",
-    "name": "Marina del Rey Marriott"
-  },
-  {
-    "description": "This small family run hotel captures the spirit of Mull and is a perfect rural holiday retreat. The mountain and sea blend together to give fantastic, panoramic views from the hotel which is in an elevated position on the shoreline. Panoramic views are also available from the bar and restaurant which serves local produce 7 days a week.",
-    "name": "The Glenforsa Hotel"
-  }
+[{
+        "name": "Marina del Rey Marriott",
+        "description": "370 guest rooms offering both water and mountain view.",
+        "score": 2.1256278997816835
+    },
+    {
+        "name": "Clwydian Holidays",
+        "description": "Log cabin glamping in a rural setting with panoramic views toward the Clwydian Mountain Range.",
+        "score": 1.6956645086702617
+    },
+    {
+        "name": "The Royal Victoria Hotel",
+        "description": "3 Star Hotel next to the Mountain Railway terminus and set in 30 acres of grounds which include Dolbadarn Castle",
+        "score": 1.5030458987111712
+    }
 ]
 ----
 ====

--- a/modules/n1ql/pages/n1ql-language-reference/searchfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/searchfun.adoc
@@ -265,6 +265,10 @@ Order pushdown is possible only if query ORDER BY has only <<search_score>> on t
 Offset and Limit pushdown is possible if the query only has a SEARCH() predicate, using a single search index -- no IntersectScan or OrderIntersectScan.
 Group aggregates and projection are not pushed.
 
+NOTE: 
+If the `index` setting isn't specified within the options argument of the Search function, {sqlpp} can pick any FTS index available in the system that qualifies for the query. 
+If a number of FTS indexes qualify, then one that is defined most precise will be chosen.
+
 === Examples
 
 include::ROOT:partial$query-context.adoc[tag=section]
@@ -339,7 +343,7 @@ WHERE SEARCH(t1, {
   {
     "name": "New Road Guest House (B&B)"
   },
-  // ...
+  ...
 ]
 ----
 
@@ -381,15 +385,20 @@ WHERE SEARCH(t1, {
 ----
 [
   {
+    "name": "The Aviator Hotel"
+  },
+  {
+    "name": "Premier Inn Birmingham Central East"
+  },
+  {
+    "name": "Castle Hotel"
+  },
+  {
+    "name": "Suites at Fisherman's Wharf"
+  },
+  {
     "name": "Waunifor"
-  },
-  {
-    "name": "Bistro Prego With Rooms"
-  },
-  {
-    "name": "Thornehill Broome Beach Campground"
-  },
-  // ...
+  }
 ]
 ----
 This query returns 5 results, and the results are ordered, as specified by the search options.
@@ -664,7 +673,7 @@ LIMIT 3;
       "score": 0.3471730605306995 // <.>
     }
   },
-  // ...
+  ...
 ]
 ----
 
@@ -765,17 +774,23 @@ LIMIT 3;
 ----
 [{
         "name": "Marina del Rey Marriott",
-        "description": "370 guest rooms offering both water and mountain view.",
+        "description": "370 guest rooms 
+            offering both water and mountain view.",
         "score": 2.1256278997816835
     },
     {
         "name": "Clwydian Holidays",
-        "description": "Log cabin glamping in a rural setting with panoramic views toward the Clwydian Mountain Range.",
+        "description": "Log cabin glamping 
+            in a rural setting with panoramic views 
+            toward the Clwydian Mountain Range.",
         "score": 1.6956645086702617
     },
     {
         "name": "The Royal Victoria Hotel",
-        "description": "3 Star Hotel next to the Mountain Railway terminus and set in 30 acres of grounds which include Dolbadarn Castle",
+        "description": "3 Star Hotel next to 
+          the Mountain Railway terminus 
+          and set in 30 acres of grounds 
+          which include Dolbadarn Castle",
         "score": 1.5030458987111712
     }
 ]

--- a/modules/n1ql/pages/n1ql-language-reference/searchfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/searchfun.adoc
@@ -54,7 +54,7 @@ The Search Service then creates a temporary index in memory to perform the searc
 This process may be slower than using a suitable Search index.
 --
 
-If there is no suitable Search index, but you want to return XATTRs data from your documents in another part of your {sqlpp} query, you must use the xref:metafun.adoc#meta[META function] to select the XATTRs field you want to return.
+If there is no suitable Search index, but you want to return XATTRs data from your documents in another part of your {sqlpp} query, you must use the xref:n1ql-language-reference/metafun.adoc#meta[META function] to select the XATTRs field you want to return.
 {sqlpp} cannot return XATTRs data without a specific field name. 
 
 If you do have a Search index available for your query that includes XATTRs data, and you still want to use that data outside of the SEARCH function, you must use the <<search_meta,SEARCH_META() function>> to select the XATTRs field. 

--- a/modules/n1ql/pages/n1ql-language-reference/searchfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/searchfun.adoc
@@ -408,7 +408,7 @@ As an alternative, you could limit the number of results and order them using th
 .Search against a Full Text Search index that carries a custom type mapping
 ====
 
-Before running this example, create a Search index with a custom type mapping as described below.
+Before running the query, create a Search index with a custom type mapping using the following definition:
 
 [source, json]
 ----


### PR DESCRIPTION
Jira: DOC-10291

Made the following changes to the SQL++ Search Functions doc:

- Fixed broken links
- Added demo FTS index definition (which was previously missing)
- Updated examples to align with the index definition

Preview: [Search Functions](https://preview.docs-test.couchbase.com/docs-devex-DOC-10291-search-broken-links/server/current/n1ql/n1ql-language-reference/searchfun.html)