### PR TITLE
DOC-12784-correcting-base64-namespace

### DIFF
--- a/modules/eventing/pages/eventing-language-constructs.adoc
+++ b/modules/eventing/pages/eventing-language-constructs.adoc
@@ -490,18 +490,18 @@ function OnUpdate(doc, meta) {
 
 
 [#base64_call]
-=== `base64()`
+=== base64
 
 ifeval::['{page-component-version}' == '7.6'] 
 _(Introduced in Couchbase Server 7.6)_
 endif::[]
 
-The `base64()` functions let you pack large-dimensional arrays of floats as base64 encoded strings when you use the Eventing Service to generate vector embeddings.
+The Couchbase base64 feature lets you pack large-dimensional arrays of floats as base64 encoded strings when you use the Eventing Service to generate vector embeddings.
 This encoding process stores and transmits arrays as text, ensuring data integrity and compatibility with text-based systems.
 
-The following `base64()` functions are available:
+The Couchbase base64 offers the following functions:
 
-* `base64Encode()`, which takes a JSON argument and returns a base64 string.
+* `couchbase.base64Encode()`, which takes a JSON argument and returns a base64 string.
 +
 [source,javascript]
 ----
@@ -511,7 +511,7 @@ function OnUpdate(doc, meta) {
 }
 ----
 +
-* `base64Decode()`, which takes a base64 encoded string and returns a value string.
+* `couchbase.base64Decode()`, which takes a base64 encoded string and returns a value string.
 +
 [source,javascript]
 ----
@@ -522,8 +522,11 @@ function OnUpdate(doc, meta) {
 ----
 +
 * `couchbase.base64Float32ArrayEncode()`, which takes a float32 number array and returns a base64 string.
+
 * `couchbase.base64Float32ArrayDecode()`, which takes a base64 encoded string and returns a float32 number array.
+
 * `couchbase.base64Float64ArrayEncode()`, which takes a float64 number array and returns a base64 string.
+
 * `couchbase.base64Float64ArrayDecode()`, which takes a base64 encoded string and returns a float64 number array.
 
 [#timers_general]


### PR DESCRIPTION
[DOC-12784](https://jira.issues.couchbase.com/browse/DOC-12784)

Changed the Eventing Base64 APIs' documentation to include **couchbase** namespace. The documentation incorrectly represented these Base64 APIs as global functions. Changed them.

[Docs preview](https://preview.docs-test.couchbase.com/docs-devex-DOC-12784-Eventing-Base64APIs-missing-couchbase-namespace/server/current/eventing/eventing-language-constructs.html#build-in-functions)

[Preview credentials](https://couchbasecloud.atlassian.net/wiki/x/dYF_dQ#Preview-docs-for-internal-review)

[DOC-12784]: https://couchbasecloud.atlassian.net/browse/DOC-12784?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ