### PR TITLE
[DOC-10239] Add a missing parameter - statement_plus

### DIFF
--- a/modules/indexes/pages/index-replication.adoc
+++ b/modules/indexes/pages/index-replication.adoc
@@ -132,6 +132,8 @@ If index-maintenance is running behind, out-of-date results may be returned.
 If index-maintenance is running behind, the query waits for it to catch up.
 * `request_plus`: Executes the query, requiring the indexes first to be updated to the timestamp of the current query-request.
 If index-maintenance is running behind, the query waits for it to catch up.
+* `statement_plus`: Executes the query with strong consistency per statement.
+Before processing each statement, the service obtains a current vector timestamp and uses it as a lower bound for that statement.
 
 For {sqlpp}, the default consistency is `not_bounded`.
 // end::scan_consistency[]


### PR DESCRIPTION
Jira: DOC-10239

Updates the Index Consistency section to add a missing parameter `statement_plus`. 

Preview: [Index Consistency](https://preview.docs-test.couchbase.com/docs-devex-DOC-10239-statement-plus/server/current/indexes/index-replication.html#index-consistency)