### PR TITLE
[DOC-9707] Add XATTR example to META()

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/metafun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/metafun.adoc
@@ -1396,7 +1396,7 @@ Next, run the following query to retrieve the XATTR attribute `metadata`.
 .Query to retrieve
 [source,sqlpp]
 ----
-SELECT META().xattrs.metadata AS metadata
+SELECT META().xattrs.metadata
 FROM `travel-sample`.`inventory`.`landmark`
 USE KEYS ["landmark_1001"];
 ----

--- a/modules/n1ql/pages/n1ql-language-reference/metafun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/metafun.adoc
@@ -1218,7 +1218,7 @@ Attempting to select the entire `META().xattrs` object will return an empty resu
 ====
 * Starting with Couchbase Server 8.0, you can include up to 15 XATTRs per query.
 * You can also use the `META().xattrs` property to access xref:learn:data/extended-attributes-fundamentals.adoc#virtual-extended-attributes[virtual XATTRs]
-(see <<meta-ex4>>).
+(see <<meta-ex5>>).
 However, this is an expensive operation and may increase query latency.
 ====
 
@@ -1339,6 +1339,81 @@ LIMIT 3;
 ====
 
 [[meta-ex4, Example 4]]
+.Return a specific XATTR
+====
+
+To run this example, you must first create a document with key `landmark_1001` and add an XATTR attribute `metadata` to it. 
+
+.Query to insert
+[source, sqlpp]
+----
+INSERT INTO `travel-sample`.`inventory`.`landmark` (KEY, VALUE, OPTIONS)
+VALUES (
+    "landmark_1001",
+    {
+        "title": "Gillingham (Kent)",
+        "name": "Hollywood Bowl",
+        "alt": null,
+        "address": "4 High Street, ME7 1BB",
+        "directions": null,
+        "phone": null,
+        "tollfree": null,
+        "email": null,
+        "url": "http://www.thehollywoodbowl.co.uk",
+        "hours": null,
+        "image": null,
+        "price": null,
+        "content": "A newly extended lively restaurant 
+              located in the high street, 
+              an American Hollywood style restaurant 
+              beautifully decorated with old photos 
+              and a great menu including burgers and ribs.",
+        "geo": {
+            "lat": 51.38937,
+            "lon": 0.5427,
+            "accuracy": "RANGE_INTERPOLATED"
+        },
+        "activity": "eat",
+        "type": "landmark",
+        "id": 10020,
+        "country": "United Kingdom",
+        "city": "Gillingham",
+        "state": null
+    },
+    {
+        "xattrs": {
+            "metadata": {
+                "created_by": "admin",
+                "created_at": "2026-01-05"
+            }
+        }
+    }
+);
+----
+
+Next, run the following query to retrieve the XATTR attribute `metadata`.
+
+.Query to retrieve
+[source,sqlpp]
+----
+SELECT META().xattrs.metadata AS metadata
+FROM `travel-sample`.`inventory`.`landmark`
+USE KEYS ["landmark_1001"];
+----
+
+.Results
+[source,json]
+----
+[{
+    "metadata": {
+        "created_at": "2026-01-05",
+        "created_by": "admin"
+    }
+}]
+----
+====
+
+[[meta-ex5, Example 5]]
 .Return a virtual XATTR
 ====
 .Query


### PR DESCRIPTION
Jira: DOC-9707

Added an example showing how to retrieve extended attributes (XATTRs) with the META function. 

Preview: [XATTR Example](https://preview.docs-test.couchbase.com/docs-devex-DOC-9707-xattr-example/server/current/n1ql/n1ql-language-reference/metafun.html#meta-ex4)
