### PR TITLE
DOC-11343: find "Index consistency" when searching for "scan consistency"

### DIFF
--- a/modules/learn/pages/services-and-indexes/indexes/index-replication.adoc
+++ b/modules/learn/pages/services-and-indexes/indexes/index-replication.adoc
@@ -3,7 +3,7 @@
 :page-topic-type: concept
 :page-partial:
 :page-aliases: indexes:index-replication,indexes:performance-consistency,understanding-couchbase:services-and-indexes/indexes/index-replication
-:keywords: consistency, consistent
+:keywords: consistency, consistent, scan consistency
 
 // Cross-references
 :index-service: xref:services-and-indexes/services/index-service.adoc

--- a/modules/learn/pages/services-and-indexes/indexes/index-replication.adoc
+++ b/modules/learn/pages/services-and-indexes/indexes/index-replication.adoc
@@ -110,6 +110,7 @@ For detailed information, refer to {index-partitioning}[Index Partitioning].
 [[index-consistency]]
 == Index Consistency
 
+(((scan consistency)))
 (((consistency)))
 (((consistent)))
 Whereas Couchbase Server handles data-mutations with _full consistency_ — all mutations to a given key are applied to the same vBucket, and become immediately available — it maintains indexes with degrees of _eventual consistency_, determined by means of the following query consistency-options, specified per query:

--- a/modules/learn/pages/services-and-indexes/indexes/index-replication.adoc
+++ b/modules/learn/pages/services-and-indexes/indexes/index-replication.adoc
@@ -1,9 +1,10 @@
 = Availability and Performance
-:description: The Index Service ensures availability and performance through replication and partitioning.
 :page-topic-type: concept
 :page-partial:
 :page-aliases: indexes:index-replication,indexes:performance-consistency,understanding-couchbase:services-and-indexes/indexes/index-replication
 :keywords: consistency, consistent, scan consistency
+:description: The Index Service ensures availability and performance through replication and partitioning. \
+You can control the scan consistency for individual queries.
 
 // Cross-references
 :index-service: xref:services-and-indexes/services/index-service.adoc
@@ -19,8 +20,7 @@
 :scan_consistency: xref:settings:query-settings.adoc#scan_consistency
 
 [abstract]
-The _Index Service_ ensures availability and performance through _replication_ and _partitioning_.
-The _consistency_ of query-results can be controlled per query.
+{description}
 
 .Examples on this Page
 ****


### PR DESCRIPTION
Jira issue: DOC-11343

Added "scan consistency" to the keywords and to the page description. I've also added it as a hidden index term, although I know Antora doesn't do anything with that currently.

Preview URL:
[Availability and Performance](https://preview.docs-test.couchbase.com/docs-devex-DOC-11343-scan-consistency/server/current/learn/services-and-indexes/indexes/index-replication.html)

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.