### PR TITLE
CBSE-15405: Do not create index before doing restore / XDCR migration

### DIFF
--- a/modules/learn/pages/services-and-indexes/indexes/index-lifecycle.adoc
+++ b/modules/learn/pages/services-and-indexes/indexes/index-lifecycle.adoc
@@ -16,6 +16,10 @@ Index creation happens in two phases: the [def]_creation phase_ and the [def]_bu
 During the creation phase, the Index Service validates the user input, decides the host node for the index, and creates the index metadata on the host node.
 The build phase cannot start until the creation phase is complete.
 
+NOTE: When migrating data using XDCR, avoid creating any indexes before the migration to achieve higher throughput.
+You can create the indexes after the migration to assist with query performance.
+For more information, see xref:learn:clusters-and-availability/xdcr-with-scopes-and-collections.adoc#migration[Migration].
+
 == Index Building
 
 During the build phase, the Index Service reads the documents from the Data Service and builds the index.

--- a/modules/learn/pages/services-and-indexes/indexes/index-lifecycle.adoc
+++ b/modules/learn/pages/services-and-indexes/indexes/index-lifecycle.adoc
@@ -12,7 +12,7 @@ By carefully planning the structure of your data, and storing documents of diffe
 
 == Index Creation
 
-Index creation happens in two phases: the [def]_creation phase_ and the [def]_build phase_.
+Index creation happens in 2 phases: the creation phase and the build phase.
 During the creation phase, the Index Service validates the user input, decides the host node for the index, and creates the index metadata on the host node.
 The build phase cannot start until the creation phase is complete.
 
@@ -28,10 +28,10 @@ image::services-and-indexes/indexes/index-lifecycle-build.png[align=center]
 
 . The projector requests a DCP stream on the specified collection.
 . DCP streams only the documents in the collection.
-. The projector evaluates each document and extracts the indexed field(s).
+. The projector evaluates each document and extracts the indexed fields.
 . The indexed fields are forwarded to the indexer.
 
-Refer to xref:n1ql:n1ql-intro/queriesandresults.adoc#index-building[Index Building] for further details.
+For more information, see xref:n1ql:n1ql-intro/queriesandresults.adoc#index-building[Index Building].
 
 == Index Updates
 
@@ -41,13 +41,13 @@ image::services-and-indexes/indexes/index-lifecycle-update-1.png[align=center]
 
 image::services-and-indexes/indexes/index-lifecycle-update-2.png[align=center]
 
-. The projector keeps a _bucket-level_ DCP stream open for updates -- this limits the number of DCP connections.
+. The projector keeps a bucket-level DCP stream open for updates -- this limits the number of DCP connections.
 . When a document within the collection is updated, the projector utilizes the collection ID available with each mutation, and only evaluates the indexes defined for that collection.
 . The projector only sends updated indexed fields for the qualified indexes within the collection.
 
-There is no additional processing or disk overhead for indexes on unrelated collections.
+Indexes on unrelated collections have no additional processing or disk overhead.
 
-Refer to xref:learn:clusters-and-availability/intra-cluster-replication.adoc#database-change-protocol[Database Change Protocol (DCP)] for further details.
+For more information, see xref:learn:clusters-and-availability/intra-cluster-replication.adoc#database-change-protocol[Database Change Protocol (DCP)].
 
 == Index Scans
 
@@ -60,4 +60,4 @@ image::services-and-indexes/indexes/index-lifecycle-scan.png[align=center]
 
 The scan coordinator does not need to wait for indexes on other collections to be updated, even if documents in other collections are being mutated.
 
-Refer to xref:learn:services-and-indexes/indexes/index-scans.adoc[Index Scans] and xref:learn:services-and-indexes/indexes/index-replication.adoc#index-consistency[Index Consistency] for further details.
+For more information, see xref:learn:services-and-indexes/indexes/index-scans.adoc[Index Scans] and xref:learn:services-and-indexes/indexes/index-replication.adoc#index-consistency[Index Consistency].


### PR DESCRIPTION
CBSE-15405

This PR covers changes to the GSI index reference. For changes to the XDCR migration topic, see DOC-11555.

Documentation preview: [Index Creation](https://preview.docs-test.couchbase.com/docs-devex-CBSE-15405/server/current/learn/services-and-indexes/indexes/index-lifecycle.html#index-creation)

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.