### PR TITLE
[DOC-13903] Auto Reprepare for PREPARE Statements (Minor Release 7.6.10)

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
@@ -217,18 +217,20 @@ For information about how to set this value, see the table in the xref:learn:ser
 When active, the Query Service monitors index changes and flags statements for repreparation.
 During the next execution, the service generates a new plan. 
 
-The following sequence explains how the service optimizes a plan as you add indexes: 
-
-* No indexes: The service creates a plan using a sequential scan.
-* On adding a primary index: The service generates a new plan using the primary index during the next execution.
-* On adding a secondary index: The service again generates a new plan using the secondary index during the subsequent execution.
+For example, if you prepare a statement and no indexes exist, the service creates a plan that uses a sequential scan.
+If you then add a primary index, the service generates a new plan that uses this index the next time you run the statement.
+If you later add a secondary index, the service generates another plan that uses the secondary index during the next execution.
 
 If the feature is inactive, the statement continues to use the original plan (sequential scan) even after you create new indexes.
 
+[NOTE]
+====
 While auto-reprepare generates optimized query plans, it can increase the load on the Query Service.
-Any index modification triggers a repreparation, even if the change does not relate to a specific statement (such as dropping an unused primary index).
+Any index modification triggers a repreparation, even if the change does not affect a specific statement (such as dropping an unused primary index).
+
 To manage this, you can enable the feature temporarily when you create or drop indexes and disable it after repreparing all statements.
 If index changes are infrequent, the effect is minimal.
+====
 
 === Manual Reprepare
 

--- a/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
@@ -229,7 +229,7 @@ If the feature is inactive, the statement continues to use the original plan (su
 
 While auto-reprepare generates optimized query plans, it can increase the load on the Query Service. 
 Any index modification, even if it's unrelated to a statement, can trigger a repreparation.
-For example, creating or dropping an index that the statement does not use can still flag it for repreparation.
+For example, creating or dropping an index that a statement does not use can still flag it for repreparation.
 In such cases, the statement reprepares only to select the same plan again, resulting in redundant work for the service.
 
 To manage this, you can enable the feature temporarily when you create or drop indexes and disable it after repreparing all statements.

--- a/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
@@ -203,7 +203,7 @@ Auto-prepare is disabled for {sqlpp} requests which contain parameters, if they 
 
 [[auto-reprepare]]
 == Auto-Reprepare
-[.status]#Couchbase Server 7.6.9#
+[.status]#Couchbase Server 7.6.10#
 
 The auto-reprepare feature automatically updates (reprepares) a prepared statement's execution plan whenever the GSI metadata version changes.
 This typically occurs when you create or drop indexes. 
@@ -214,23 +214,26 @@ With auto-reprepare, statements can use newer and more efficient indexes as they
 To enable this feature, set bit 23 (0×800000 or 8388608) of the `n1ql-feat-ctrl` setting. 
 For information about how to set this value, see the table in the xref:learn:services-and-indexes/indexes/query-without-index.adoc#manage-sequential-scans[Manage Sequential Scans] section. 
 
-When active, the Query Service monitors index changes and flags statements for repreparation.
-During the next execution, the service generates a new plan. 
+When the feature is active, the Query Service monitors index changes and flags statements for repreparation.
+The next time a flagged statement runs, the service generates a new plan for it.
 
-For example, if you prepare a statement and no indexes exist, the service creates a plan that uses a sequential scan.
-If you then add a primary index, the service generates a new plan that uses this index the next time you run the statement.
-If you later add a secondary index, the service generates another plan that uses the secondary index during the next execution.
+The following example shows how a plan improves as you add new indexes for a statement:
 
-If the feature is inactive, the statement continues to use the original plan (sequential scan) even after you create new indexes.
+* If you prepare a statement and no suitable indexes exist to support it, the Query Service creates a plan that uses a sequential scan.
+* If you then create a primary index that better supports the statement, the service flags the statement.
+On the next execution, the service generates a new plan that uses the primary index.
+* If you later create a secondary index that is an even better choice for the statement, the service flags the statement again.
+On the next execution, the service generates a new plan that uses the secondary index.
 
-[NOTE]
-====
-While auto-reprepare generates optimized query plans, it can increase the load on the Query Service.
-Any index modification triggers a repreparation, even if the change does not affect a specific statement (such as dropping an unused primary index).
+If the feature is inactive, the statement continues to use the original plan (such as a sequential scan) even after you create new indexes.
+
+While auto-reprepare generates optimized query plans, it can increase the load on the Query Service. 
+Any index modification, even if it's unrelated to a statement, can trigger a repreparation.
+For example, creating or dropping an index that the statement does not use can still flag it for repreparation.
+In such cases, the statement reprepares only to select the same plan again, resulting in redundant work for the service.
 
 To manage this, you can enable the feature temporarily when you create or drop indexes and disable it after repreparing all statements.
 If index changes are infrequent, the effect is minimal.
-====
 
 === Manual Reprepare
 

--- a/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
@@ -205,31 +205,29 @@ Auto-prepare is disabled for {sqlpp} requests which contain parameters, if they 
 == Auto-Reprepare
 [.status]#Couchbase Server 7.6.9#
 
-When the auto-reprepare feature is active, a prepared statement automatically updates (reprepares) its plan whenever the GSI metadata version changes. 
-This happens when you create or drop an index, allowing prepared statements to use newer, more efficient indexes as they become available.
+When the auto-reprepare feature is active, the Query Service automatically reprepares the execution plan of a prepared statement whenever the GSI metadata version changes.
+This allows prepared statements to use newer, more efficient indexes as they become available.
 
 To enable this feature, you must set bit 23 (0×800000 or 8388608) of the `n1ql-feat-ctrl` setting. 
 For information about how to set this value, see the table in the xref:learn:services-and-indexes/indexes/query-without-index.adoc#manage-sequential-scans[Manage Sequential Scans] section. 
 
-By default, a prepared statement is only reprepared if an index in its current plan becomes unavailable.
-With auto-reprepare, prepared statements can adapt to new indexes as well. 
-For example: 
+By default, the Query Service only reprepares a prepared statement if an index in its current plan becomes unavailable.
 
-* *When the feature is inactive*: 
-If no indexes exist when you prepare a statement, then the prepared plan uses a sequential scan.
-If you create a primary index or a secondary index later, the statement still continues to use the sequential scan and does not automatically benefit from the new indexes.
+When you enable auto-reprepare, the service monitors index changes and flags affected statements for repreparation.
+During the next execution, the service generates a new execution plan for the statement.
 
-* *When the feature is active*: 
-If you create a primary index after preparing a statement, the next time the statement executes, the Query Service generates a new plan using the primary index.
-Similarly, if a more optimal secondary index becomes available, the service flags the statement again and generates a new plan on the next execution using the new index.
+For example, if you prepare statement when no indexes exist, the service generates a plan that uses a sequential scan.
+If you then create a primary index, the service flags the statement and generates a new plan using that index during the next execution.
+If you later create a more optimal secondary index, the service flags the statement again and generates another plan using the secondary index during the next execution.
 
-Although this feature improves performance, it has a potential drawback. 
-Any change to indexes, even those unrelated to a specific statement, can trigger an update. 
-For example, creating an unrelated secondary index or dropping an unused primary index can cause a statement to be reprepared. 
-While the statement may select the existing plan again, this can lead to additional load.
+If the feature is inactive, the statement continues to use the original sequential scan plan even after you create indexes.
+
+While this feature generates more performant query plans, it can increase load on the Query Service.
+Any index modification causes the service to reprepare statements, even if the change is unrelated to the statement.
+For example, creating an unrelated secondary index or dropping an unused primary index triggers a repreparation. 
 If index changes are infrequent, the impact is minimal.
 
-To manage this effectively, you can enable or disable this feature as needed. 
+To manage performance, you can change the state of this feature as needed. 
 For example, you can enable the feature before creating new indexes and then disable it after all statements are reprepared.
 
 === Manual Reprepare

--- a/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
@@ -203,6 +203,7 @@ Auto-prepare is disabled for {sqlpp} requests which contain parameters, if they 
 
 [[auto-reprepare]]
 == Auto-Reprepare
+[.status]#Couchbase Server 7.6.9#
 
 When the auto-reprepare feature is active, a prepared statement automatically updates (reprepares) its plan whenever the GSI metadata version changes. 
 This happens when you create or drop an index, allowing prepared statements to use newer, more efficient indexes as they become available.

--- a/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
@@ -197,9 +197,53 @@ The process is similar to creating a prepared statement without a local name:
 
 The auto-prepare feature is inactive by default.
 You can turn the auto-prepare feature on or off using the `auto-prepare` service-level query setting.
-For more details, refer to xref:n1ql:n1ql-manage/query-settings.adoc#auto-prepare[].
+For more details, refer to xref:n1ql:n1ql-manage/query-settings.adoc#auto-prepare[Query Settings].
 
 Auto-prepare is disabled for {sqlpp} requests which contain parameters, if they do not use the PREPARE statement.
+
+[[auto-reprepare]]
+== Auto-Reprepare
+
+When the auto-reprepare feature is active, a prepared statement automatically updates (reprepares) its plan whenever the GSI metadata version changes. 
+This happens when you create or drop an index, allowing prepared statements to use newer, more efficient indexes as they become available.
+
+To enable this feature, you must set bit 23 (0×800000 or 8388608) of the `n1ql-feat-ctrl` setting. 
+For information about how to set this value, see the table in the xref:learn:services-and-indexes/indexes/query-without-index.adoc#manage-sequential-scans[Manage Sequential Scans] section. 
+
+By default, a prepared statement is only reprepared if an index in its current plan becomes unavailable.
+With auto-reprepare, prepared statements can adapt to new indexes as well. 
+For example: 
+
+* *When the feature is inactive*: 
+If no indexes exist when you prepare a statement, then the prepared plan uses a sequential scan.
+If you create a primary index or a secondary index later, the statement still continues to use the sequential scan and does not automatically benefit from the new indexes.
+
+* *When the feature is active*: 
+If you create a primary index after preparing a statement, the next time the statement executes, the Query Service generates a new plan using the primary index.
+Similarly, if a more optimal secondary index becomes available, the service flags the statement again and generates a new plan on the next execution using the new index.
+
+Although this feature improves performance, it has a potential drawback. 
+Any change to indexes, even those unrelated to a specific statement, can trigger an update. 
+For example, creating an unrelated secondary index or dropping an unused primary index can cause a statement to be reprepared. 
+While the statement may select the existing plan again, this can lead to additional load.
+If index changes are infrequent, the impact is minimal.
+
+To manage this effectively, you can enable or disable this feature as needed. 
+For example, you can enable the feature before creating new indexes and then disable it after all statements are reprepared.
+
+=== Manual Reprepare
+
+In addition to the automatic mode, you can also manually reprepare a statement. 
+To do this, update xref:n1ql:n1ql-manage/monitoring-n1ql-query.adoc#sys-prepared[system:prepareds] and unset the `planPreparedTime` field for the statement.
+
+For example, to reprepare a prepared statement named `NumParam` on a node with the IP address `127.0.0.1` and port `8091`, use the following query:
+
+[source,sqlpp]
+----
+UPDATE system:prepareds USE KEYS ["[127.0.0.1:8091]NumParam"] UNSET planPreparedTime;
+----
+
+You can repeat this operation after creating each relevant index to refresh the prepared statement's plan.
 
 [[auto-execute]]
 == Auto-Execute
@@ -214,7 +258,7 @@ You can use this when you need to execute the prepared statement again.
 
 The auto-execute feature is inactive by default.
 You can turn the auto-execute feature on or off using the `auto_execute` request-level query setting.
-For more details, refer to xref:n1ql:n1ql-manage/query-settings.adoc#auto_execute[].
+For more details, refer to xref:n1ql:n1ql-manage/query-settings.adoc#auto_execute[Query Settings].
 
 The auto-execute feature only works for {sqlpp} requests which actually contain the PREPARE statement.
 Prepared statements created by the <<auto-prepare,auto-prepare>> feature are not executed by the auto-execute feature.

--- a/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
@@ -205,34 +205,34 @@ Auto-prepare is disabled for {sqlpp} requests which contain parameters, if they 
 == Auto-Reprepare
 [.status]#Couchbase Server 7.6.9#
 
-When the auto-reprepare feature is active, the Query Service automatically reprepares the execution plan of a prepared statement whenever the GSI metadata version changes.
-This allows prepared statements to use newer, more efficient indexes as they become available.
+The auto-reprepare feature automatically updates (reprepares) a prepared statement's execution plan whenever the GSI metadata version changes.
+This typically occurs when you create or drop indexes. 
 
-To enable this feature, you must set bit 23 (0×800000 or 8388608) of the `n1ql-feat-ctrl` setting. 
+By default, the Query Service only reprepares a statement when an index in its current plan becomes unavailable.
+With auto-reprepare, statements can use newer and more efficient indexes as they become available.
+
+To enable this feature, set bit 23 (0×800000 or 8388608) of the `n1ql-feat-ctrl` setting. 
 For information about how to set this value, see the table in the xref:learn:services-and-indexes/indexes/query-without-index.adoc#manage-sequential-scans[Manage Sequential Scans] section. 
 
-By default, the Query Service only reprepares a prepared statement if an index in its current plan becomes unavailable.
+When active, the Query Service monitors index changes and flags statements for repreparation.
+During the next execution, the service generates a new plan. 
 
-When you enable auto-reprepare, the service monitors index changes and flags affected statements for repreparation.
-During the next execution, the service generates a new execution plan for the statement.
+The following sequence explains how the service optimizes a plan as you add indexes: 
 
-For example, if you prepare statement when no indexes exist, the service generates a plan that uses a sequential scan.
-If you then create a primary index, the service flags the statement and generates a new plan using that index during the next execution.
-If you later create a more optimal secondary index, the service flags the statement again and generates another plan using the secondary index during the next execution.
+* No indexes: The service creates a plan using a sequential scan.
+* On adding a primary index: The service generates a new plan using the primary index during the next execution.
+* On adding a secondary index: The service again generates a new plan using the secondary index during the subsequent execution.
 
-If the feature is inactive, the statement continues to use the original sequential scan plan even after you create indexes.
+If the feature is inactive, the statement continues to use the original plan (sequential scan) even after you create new indexes.
 
-While this feature generates more performant query plans, it can increase load on the Query Service.
-Any index modification causes the service to reprepare statements, even if the change is unrelated to the statement.
-For example, creating an unrelated secondary index or dropping an unused primary index triggers a repreparation. 
-If index changes are infrequent, the impact is minimal.
-
-To manage performance, you can change the state of this feature as needed. 
-For example, you can enable the feature before creating new indexes and then disable it after all statements are reprepared.
+While auto-reprepare generates optimized query plans, it can increase the load on the Query Service.
+Any index modification triggers a repreparation, even if the change does not relate to a specific statement (such as dropping an unused primary index).
+To manage this, you can enable the feature temporarily when you create or drop indexes and disable it after repreparing all statements.
+If index changes are infrequent, the effect is minimal.
 
 === Manual Reprepare
 
-In addition to the automatic mode, you can also manually reprepare a statement. 
+You can also can manually reprepare a specific statement. 
 To do this, update xref:n1ql:n1ql-manage/monitoring-n1ql-query.adoc#sys-prepared[system:prepareds] and unset the `planPreparedTime` field for the statement.
 
 For example, to reprepare a prepared statement named `NumParam` on a node with the IP address `127.0.0.1` and port `8091`, use the following query:
@@ -241,8 +241,7 @@ For example, to reprepare a prepared statement named `NumParam` on a node with t
 ----
 UPDATE system:prepareds USE KEYS ["[127.0.0.1:8091]NumParam"] UNSET planPreparedTime;
 ----
-
-You can repeat this operation after creating each relevant index to refresh the prepared statement's plan.
+You can repeat this operation after creating each relevant index and refresh the prepared statement's plan.
 
 [[auto-execute]]
 == Auto-Execute


### PR DESCRIPTION
Added the auto reprepare functionality for PREPARE statements (for 7.6.10). 
Also fixed two links that weren't rendering correctly. 

- Jira: DOC-13903
- Preview: [Auto Reprepare](https://preview.docs-test.couchbase.com/docs-devex-DOC-13903-automatic-reprepare/server/current/n1ql/n1ql-language-reference/prepare.html#auto-reprepare)
- [Preview credentials](https://couchbasecloud.atlassian.net/wiki/x/dYF_dQ#Preview-docs-for-internal-review)