### PR TITLE
[NO ISSUE] Fix a formatting error on the Search Functions page

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/searchfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/searchfun.adoc
@@ -265,8 +265,7 @@ Order pushdown is possible only if query ORDER BY has only <<search_score>> on t
 Offset and Limit pushdown is possible if the query only has a SEARCH() predicate, using a single search index -- no IntersectScan or OrderIntersectScan.
 Group aggregates and projection are not pushed.
 
-NOTE: 
-If you do not specify the `index` setting in the options argument of the Search function, {sqlpp} automatically selects a qualifying FTS index for the query.
+NOTE: If you do not specify the `index` setting in the options, {sqlpp} automatically selects a qualifying FTS index for the query.
 If multiple indexes qualify for the query, {sqlpp} selects the most precise one.
 
 === Examples


### PR DESCRIPTION
A tiny change to fix a formatting error on the Search Functions page (something that I introduced while updating the page recently). 

Preview: [Search Functions](https://preview.docs-test.couchbase.com/docs-devex-search-functions-formatting-error/server/current/n1ql/n1ql-language-reference/searchfun.html#limitations)