### PR TITLE
DOC-13422 - The Eventing Memory Quota (DOCS-DEVEX repo)

### DIFF
--- a/modules/eventing/pages/eventing-memory-quota.adoc
+++ b/modules/eventing/pages/eventing-memory-quota.adoc
@@ -103,7 +103,7 @@ The OS OOM killer can cause abrupt process termination resulting in service down
 For this reason, proper system sizing is critical and should not be overlooked. 
 This includes planning total system memory as well as the number of workers configured across all Eventing functions.
 
-In a containerised environment, all the Eventing runtime processes like the eventing-producer and eventing-consumer, run within containers governed by cgroups with explicit memory limits. 
+In a containerized environment, all the Eventing runtime processes, like the eventing-producer and eventing-consumer, run within containers governed by cgroups with explicit memory limits. 
 In this case, memory enforcement occurs at the cgroup level and not at the overall host system level. 
 As a result, the underlying system constrains the Eventing processes based on the configured container memory limits, providing more predictable and controlled resource usage.
 

--- a/modules/eventing/pages/eventing-memory-quota.adoc
+++ b/modules/eventing/pages/eventing-memory-quota.adoc
@@ -155,7 +155,7 @@ Follow these recommendations to effectively manage Eventing memory usage:
 
 * Consider containerized deployments or cgroup-based memory limits in production environments.
 * Use container platforms such as Docker and Kubernetes to provide hard memory limits.
-* cgroups enforce OS-level memory restrictions.
+* Use cgroups to enforce OS-level memory restrictions.
 This approach adds a safety layer beyond the Eventing Service memory quota.
 
 [#size]

--- a/modules/eventing/pages/eventing-memory-quota.adoc
+++ b/modules/eventing/pages/eventing-memory-quota.adoc
@@ -3,7 +3,7 @@
 :page-toclevels: 2
 :pshintitle: Eventing Service Memory Quota
 :category: Eventing
-:keywords: eventing,eventing-service,memory,quota,worker,garbage-collection
+:keywords: eventing, memory, quota, worker, garbage-collection
 
 
 :description: The Eventing Service memory quota does not enforce a hard memory limit on the Eventing subsystem, including worker processes. 

--- a/modules/eventing/pages/eventing-memory-quota.adoc
+++ b/modules/eventing/pages/eventing-memory-quota.adoc
@@ -149,7 +149,7 @@ Follow these recommendations to effectively manage Eventing memory usage:
 === Use cgroups for Enforcement
 
 * Consider containerized deployments or cgroup-based memory limits in production environments.
-* Container platforms such as Docker and Kubernetes provide hard memory limits.
+* Use container platforms such as Docker and Kubernetes to provide hard memory limits.
 * cgroups enforce OS-level memory restrictions.
 This approach adds a safety layer beyond the Eventing Service memory quota.
 

--- a/modules/eventing/pages/eventing-memory-quota.adoc
+++ b/modules/eventing/pages/eventing-memory-quota.adoc
@@ -98,7 +98,8 @@ In a non-containerized environment, such as bare-metal servers, virtual machines
 These processes effectively have no hard upper bound on memory usage. 
 Collectively, these processes can consume all available system memory. 
 
-This can lead to unintended consequences, such as out-of-memory (OOM) conditions that might trigger the OS OOM killer and result in abrupt process termination resulting in service downtime. 
+This can lead to unintended consequences, such as out-of-memory (OOM) conditions that might trigger the OS OOM killer. 
+The OS OOM killer can cause abrupt process termination resulting in service downtime. 
 For this reason, proper system sizing is critical and should not be overlooked. 
 This includes planning total system memory as well as the number of workers configured across all Eventing functions.
 

--- a/modules/eventing/pages/eventing-memory-quota.adoc
+++ b/modules/eventing/pages/eventing-memory-quota.adoc
@@ -28,7 +28,7 @@ The Eventing Service divides its total memory quota uniformly across all workers
 Per-Worker quota = Total memory quota ÷ Total number of workers
 ....
 
-For example, if you had a memory quota of 256{nbsp}MB, with 4 total workers, each worker would use 64{nbsp}MB of memory, or 256 MB ÷ 4 workers.
+For example, if you had a memory quota of 256{nbsp}MB, with 4 total workers, each worker would use 64{nbsp}MB of memory, or 256{nbsp}MB ÷ 4 workers.
 
 Each worker receives an equal share of the total quota, regardless of the actual memory usage of individual functions.
 

--- a/modules/eventing/pages/eventing-memory-quota.adoc
+++ b/modules/eventing/pages/eventing-memory-quota.adoc
@@ -90,7 +90,11 @@ As a result, setting a memory quota does not guarantee that Eventing Functions r
 [#no-enforce-c-groups]
 === Memory Management in Containerized and Non-Containerized Environments
 
-In a non-containerised environment (for example, bare-metal servers, virtual machines, or EC2 instances), the Eventing runtime deploys 2 classes of processes, the eventing-producer and the multiple eventing-consumer processes. 
+In a non-containerized environment, such as bare-metal servers, virtual machines, or EC2 instances, the Eventing runtime deploys 2 classes of processes: 
+
+* The eventing-producer 
+* Multiple eventing-consumer processes
+
 These processes effectively have no hard upper bound on memory usage. 
 Collectively, these processes can consume all available system memory. 
 

--- a/modules/eventing/pages/eventing-memory-quota.adoc
+++ b/modules/eventing/pages/eventing-memory-quota.adoc
@@ -88,16 +88,20 @@ JavaScript runtime heaps may still contain live (non-garbage) objects that:
 As a result, setting a memory quota does not guarantee that Eventing Functions remain within that limit.
 
 [#no-enforce-c-groups]
-=== No OS-Level Enforcement Outside cgroups
+=== Memory Management in Containerized vs Non-Containerized Environments
 
-In non-containerized environments, the operating system does not enforce the memory quota.
+In a non-containerised environment (for example, bare-metal servers, virtual machines, or EC2 instances), the Eventing runtime deploys 2 classes of processes, the eventing-producer and the multiple eventing-consumer processes. 
+These processes effectively have no hard upper bound on memory usage. 
+Collectively, these processes can consume all available system memory. 
 
-You must monitor the Eventing Service's memory usage using system tools.
+This can lead to unintended consequences, such as out-of-memory (OOM) conditions that might trigger the OS OOM killer and result in abrupt process termination resulting in service downtime. 
+For this reason, proper system sizing is critical and should not be overlooked. 
+This includes planning total system memory as well as the number of workers configured across all Eventing functions.
 
-If you configure too many workers for your Eventing Functions, you can cause memory exhaustion in your cluster. 
-High memory-consuming Eventing Functions can affect your overall system stability.
+In a containerised environment, all the Eventing runtime processes like the eventing-producer and eventing-consumer, run within containers governed by cgroups with explicit memory limits. 
+In this case, memory enforcement occurs at the cgroup level and not at the overall host system level. 
+As a result, the underlying system constrains the Eventing processes based on the configured container memory limits, providing more predictable and controlled resource usage.
 
-Again, the Eventing Service does not automatically stop or throttle execution when total memory exceeds the quota. 
 
 [#worker-sizing-memory]
 === Worker Sizing Impacts Memory

--- a/modules/eventing/pages/eventing-memory-quota.adoc
+++ b/modules/eventing/pages/eventing-memory-quota.adoc
@@ -88,7 +88,7 @@ JavaScript runtime heaps may still contain live (non-garbage) objects that:
 As a result, setting a memory quota does not guarantee that Eventing Functions remain within that limit.
 
 [#no-enforce-c-groups]
-=== Memory Management in Containerized vs Non-Containerized Environments
+=== Memory Management in Containerized and Non-Containerized Environments
 
 In a non-containerised environment (for example, bare-metal servers, virtual machines, or EC2 instances), the Eventing runtime deploys 2 classes of processes, the eventing-producer and the multiple eventing-consumer processes. 
 These processes effectively have no hard upper bound on memory usage. 

--- a/modules/eventing/pages/eventing-memory-quota.adoc
+++ b/modules/eventing/pages/eventing-memory-quota.adoc
@@ -59,11 +59,11 @@ Memory held by live objects in the JavaScript runtime heap remains allocated, so
 
 When memory usage approaches the per-worker quota limit, the JavaScript runtime may trigger garbage collection to reclaim memory. 
 
+The Eventing Service invokes a stop-the-world JavaScript runtime garbage collection to reduce memory inside the JavaScript runtime isolate running each Eventing Function.
+
 The garbage collector may delay the stop-the-world collection because it's optimized for throughput. 
 
 The runtime might not reclaim memory without a delay, which can temporarily affect the Eventing Service's memory consumption.
-
-The Eventing Service invokes a stop-the-world JavaScript runtime garbage collection to reduce memory inside the JavaScript runtime isolate running each Eventing Function.
 
 == Limitations and Considerations
 

--- a/modules/eventing/pages/eventing-memory-quota.adoc
+++ b/modules/eventing/pages/eventing-memory-quota.adoc
@@ -176,7 +176,8 @@ This approach adds a safety layer beyond the Eventing Service memory quota.
 * Profile Eventing Functions to identify memory-intensive operations.
 
 == See Also
-* xref:eventing-service-overview.adoc[Eventing Service Overview]
-* xref:eventing-service-settings.adoc[Eventing Service Settings]
-* xref:manage:eventing/manage-eventing.adoc[Managing the Eventing Service]
-* xref:troubleshooting/eventing-troubleshooting.adoc[Eventing Service Troubleshooting]
+* xref:eventing-overview.adoc[Eventing Service]
+* xref:eventing-Terminologies.adoc[Eventing Terminology]
+* xref:manage-eventing-functions.adoc[Manage Eventing Functions]
+* xref:troubleshooting-best-practices.adoc[Troubleshooting and Best Practices]
+* xref:eventing-faq.adoc[Frequently Asked Questions]

--- a/modules/eventing/pages/eventing-memory-quota.adoc
+++ b/modules/eventing/pages/eventing-memory-quota.adoc
@@ -2,10 +2,10 @@
 
 :description: The Eventing Service memory quota does not enforce a hard memory limit on the Eventing subsystem, including worker processes. 
 
-This page explains how the memory quota actually works, how the Eventing Service distributes it across workers, and its limitations in non-containerized environments.
-
 [abstract]
 {description}
+
+This page explains how the memory quota actually works, how the Eventing Service distributes it across workers, and its limitations in non-containerized environments.
 
 == About the Eventing Service Memory Quota
 

--- a/modules/eventing/pages/eventing-memory-quota.adoc
+++ b/modules/eventing/pages/eventing-memory-quota.adoc
@@ -1,4 +1,11 @@
 = Eventing Service Memory Quota 
+:page-topic-type: concept
+:page-toclevels: 2
+:page-topic-type: reference
+:pshintitle: Eventing Service Memory Quota
+:category: Eventing
+:keywords: eventing,eventing-service,memory,quota,worker,garbage-collection
+
 
 :description: The Eventing Service memory quota does not enforce a hard memory limit on the Eventing subsystem, including worker processes. 
 
@@ -101,7 +108,7 @@ Collectively, these processes can consume all available system memory.
 This can lead to unintended consequences, such as out-of-memory (OOM) conditions that might trigger the OS OOM killer. 
 The OS OOM killer can cause abrupt process termination resulting in service downtime. 
 For this reason, proper system sizing is critical and should not be overlooked. 
-This includes planning total system memory as well as the number of workers configured across all Eventing functions.
+This includes planning total system memory as well as the number of workers configured across all Eventing Functions.
 
 In a containerized environment, all the Eventing runtime processes, like the eventing-producer and eventing-consumer, run within containers governed by cgroups with explicit memory limits. 
 In this case, memory enforcement occurs at the cgroup level and not at the overall host system level. 

--- a/modules/eventing/pages/eventing-memory-quota.adoc
+++ b/modules/eventing/pages/eventing-memory-quota.adoc
@@ -1,14 +1,8 @@
 = Eventing Service Memory Quota 
 :page-topic-type: concept
 :page-toclevels: 2
-<<<<<<< HEAD
 
-:keywords: eventing,eventing-service,memory,quota,worker,garbage-collection
-=======
-:pshintitle: Eventing Service Memory Quota
-:category: Eventing
 :keywords: eventing, memory, quota, worker, garbage-collection
->>>>>>> origin/DOC-13422-Eventing-Memory-Quota_FOR_DEVEX
 
 
 :description: The Eventing Service memory quota does not enforce a hard memory limit on the Eventing subsystem, including worker processes. 

--- a/modules/eventing/pages/eventing-memory-quota.adoc
+++ b/modules/eventing/pages/eventing-memory-quota.adoc
@@ -173,7 +173,7 @@ This approach adds a safety layer beyond the Eventing Service memory quota.
 * Release object references when data is no longer needed.
 * Profile Eventing Functions to identify memory-intensive operations.
 
-== Related Links 
+== See Also
 * xref:eventing-service-overview.adoc[Eventing Service Overview]
 * xref:eventing-service-settings.adoc[Eventing Service Settings]
 * xref:manage:eventing/manage-eventing.adoc[Managing the Eventing Service]

--- a/modules/eventing/pages/eventing-memory-quota.adoc
+++ b/modules/eventing/pages/eventing-memory-quota.adoc
@@ -178,6 +178,5 @@ This approach adds a safety layer beyond the Eventing Service memory quota.
 == See Also
 * xref:eventing-overview.adoc[Eventing Service]
 * xref:eventing-Terminologies.adoc[Eventing Terminology]
-* xref:manage-eventing-functions.adoc[Manage Eventing Functions]
 * xref:troubleshooting-best-practices.adoc[Troubleshooting and Best Practices]
 * xref:eventing-faq.adoc[Frequently Asked Questions]

--- a/modules/eventing/pages/eventing-memory-quota.adoc
+++ b/modules/eventing/pages/eventing-memory-quota.adoc
@@ -1,7 +1,6 @@
 = Eventing Service Memory Quota 
 :page-topic-type: concept
 :page-toclevels: 2
-:page-topic-type: reference
 :pshintitle: Eventing Service Memory Quota
 :category: Eventing
 :keywords: eventing,eventing-service,memory,quota,worker,garbage-collection

--- a/modules/eventing/pages/eventing-memory-quota.adoc
+++ b/modules/eventing/pages/eventing-memory-quota.adoc
@@ -1,8 +1,7 @@
 = Eventing Service Memory Quota 
 :page-topic-type: concept
 :page-toclevels: 2
-:pshintitle: Eventing Service Memory Quota
-:category: Eventing
+
 :keywords: eventing,eventing-service,memory,quota,worker,garbage-collection
 
 

--- a/modules/eventing/pages/eventing-memory-quota.adoc
+++ b/modules/eventing/pages/eventing-memory-quota.adoc
@@ -1,0 +1,171 @@
+= Eventing Service Memory Quota 
+
+:description: The Eventing Service memory quota does not enforce a hard memory limit on the Eventing subsystem, including worker processes. 
+
+This page explains how the memory quota actually works, how the Eventing Service distributes it across workers, and its limitations in non-containerized environments.
+
+[abstract]
+{description}
+
+== About the Eventing Service Memory Quota
+
+The Eventing Service uses the quota for:
+
+* <<worker-queue-sizing,>>: Controls the maximum size of each worker's input queue.
+* <<gc-trigger,>>: Determines when the Eventing Service invokes the JavaScript environment's GC to reclaim memory.
+
+The memory quota is not an absolute memory cap.
+The quota does not restrict the total memory consumed by JavaScript runtime heaps or Eventing processes.
+
+The Eventing Service divides its total memory quota uniformly across all workers in all deployed functions:
+....
+Per-Worker quota = Total memory quota ÷ Total number of workers
+....
+
+For example, if you had a memory quota of 256{nbsp}MB, with 4 total workers, each worker would use 64{nbsp}MB of memory, or 256 MB ÷ 4 workers.
+
+Each worker receives an equal share of the total quota, regardless of the actual memory usage of individual functions.
+
+As you deploy more functions or add workers per function, the per-worker quota decreases proportionally.
+A smaller per-worker quota can affect performance if individual functions require substantial memory for processing.
+
+In VM or bare-metal deployments, Eventing Functions can exceed the configured quota at runtime.
+Understanding this behavior helps you to appropriately size and monitor your Eventing Functions in production environments.
+
+
+=== Minimum Size
+
+The memory quota for the Eventing Service must be a minimum of 256{nbsp}MB. 
+Couchbase does not support memory quota values smaller than 256{nbsp}MB.
+
+
+== Worker Queue Sizing
+
+Each worker maintains a bounded input queue that receives changes to documents from the xref:server:learn:clusters-and-availability/intra-cluster-replication.adoc#database-change-protocol[Database Change Protocol (DCP)] stream. 
+
+The per-worker quota determines the maximum size of this queue.
+
+When the queue exceeds this size, the Eventing Service throttles the DCP stream to prevent unbounded memory growth.
+
+Throttling temporarily pauses the mutation flow, ensuring workers do not become overwhelmed when processing lags behind the mutation rate. 
+
+[#gc-trigger]
+== Garbage Collection (GC) Triggering
+
+The Eventing Service's garbage collection (GC) frees memory occupied by unreachable objects that are no longer in use by Eventing Functions.
+
+Garbage collection reclaims memory only from objects that are no longer in use. 
+Memory held by live objects in the JavaScript runtime heap remains allocated, so total usage may exceed the per-worker quota.
+
+When memory usage approaches the per-worker quota limit, the JavaScript runtime may trigger garbage collection to reclaim memory. 
+
+The garbage collector may delay the stop-the-world collection because it's optimized for throughput. 
+
+The runtime might not reclaim memory without a delay, which can temporarily affect the Eventing Service's memory consumption.
+
+The Eventing Service invokes a stop-the-world JavaScript runtime garbage collection to reduce memory inside the JavaScript runtime isolate running each Eventing Function.
+
+== Limitations and Considerations
+
+To prevent operational issues while using the Eventing Service, keep the following in mind while configuring the memory quota:
+
+* <<no-hard-limit,>>
+* <<no-enforce-c-groups,>>
+* <<worker-sizing-memory,>>
+* <<quota-per-worker,>>
+
+[#no-hard-limit]
+=== Not a Hard Limit
+
+The Eventing Service memory quota does not restrict total memory usage. 
+
+JavaScript runtime heaps may still contain live (non-garbage) objects that:
+
+* Garbage collection cannot reclaim.
+* The quota does not include.
+* Continue to consume memory beyond the configured limit.
+
+As a result, setting a memory quota does not guarantee that Eventing Functions remain within that limit.
+
+[#no-enforce-c-groups]
+=== No OS-Level Enforcement Outside cgroups
+
+In non-containerized environments, the operating system does not enforce the memory quota.
+
+You must monitor the Eventing Service's memory usage using system tools.
+
+If you configure too many workers for your Eventing Functions, you can cause memory exhaustion in your cluster. 
+High memory-consuming Eventing Functions can affect your overall system stability.
+
+Again, the Eventing Service does not automatically stop or throttle execution when total memory exceeds the quota. 
+
+[#worker-sizing-memory]
+=== Worker Sizing Impacts Memory
+
+When configuring the memory quota for the Eventing Service, consider the per-worker quota when determining the number of workers.
+Avoid over-provisioning workers when Eventing Functions require substantial memory.
+
+For best results, try to balance your worker count against your available memory. 
+
+[#quota-per-worker]
+=== Quota Applies Per Worker
+
+The memory quota does not isolate memory usage between Eventing Functions.
+All workers draw from the same total memory quota.
+
+A memory-intensive function can reduce the memory available to other Eventing Functions.
+
+Eventing does not support per-function memory limits or reservations.
+
+== Best Practices
+
+Follow these recommendations to effectively manage Eventing memory usage: 
+
+* <<monitor,>>
+* <<test,>>
+* <<use-cgroups,>>
+* <<size,>>
+* <<review,>>
+
+[#monitor]
+=== Monitor Memory Usage
+
+* Use system-level monitoring tools to track actual memory consumption.
+* Monitor memory usage for the Eventing process and individual workers.
+* Configure alerts for memory thresholds well below system limits.
+
+[#test]
+=== Test in Representative Environments
+
+* Test Eventing Functions under production-like load conditions.
+* Measure actual memory consumption during peak processing.
+* Validate that memory usage remains within acceptable limits.
+
+[#use-cgroups]
+=== Use cgroups for Enforcement
+
+* Consider containerized deployments or cgroup-based memory limits in production environments.
+* Container platforms such as Docker and Kubernetes provide hard memory limits.
+* cgroups enforce OS-level memory restrictions.
+This approach adds a safety layer beyond the Eventing Service memory quota.
+
+[#size]
+=== Size the Memory Quota Appropriately
+
+* Set the Eventing Service memory quota based on expected worker count and Eventing Function complexity.
+* Allow additional headroom on top of the 256{nbsp}MB default for production workloads.
+* Account for peak processing scenarios, not just average load.
+
+[#review]
+=== Review Function Memory Efficiency
+
+* Optimize JavaScript code to minimize memory allocation.
+* Avoid accumulating large data structures in the function scope.
+* Release object references when data is no longer needed.
+* Profile Eventing Functions to identify memory-intensive operations.
+
+== Related Links 
+* xref:eventing-service-overview.adoc[Eventing Service Overview]
+* xref:eventing-service-settings.adoc[Eventing Service Settings]
+* xref:manage:eventing/manage-eventing.adoc[Managing the Eventing Service]
+* xref:troubleshooting/eventing-troubleshooting.adoc[Eventing Service Troubleshooting]

--- a/modules/eventing/pages/eventing-memory-quota.adoc
+++ b/modules/eventing/pages/eventing-memory-quota.adoc
@@ -1,10 +1,7 @@
 = Eventing Service Memory Quota 
 :page-topic-type: concept
 :page-toclevels: 2
-
-:keywords: eventing, memory, quota, worker, garbage-collection
-
-
+:keywords: eventing, memory, quota, worker, garbage collection, sizing
 :description: The Eventing Service memory quota does not enforce a hard memory limit on the Eventing subsystem, including worker processes. 
 
 [abstract]

--- a/modules/eventing/partials/nav.adoc
+++ b/modules/eventing/partials/nav.adoc
@@ -1,4 +1,4 @@
-* xref:eventing:eventing-overview.adoc[Run a Function on Data Change]
+››* xref:eventing:eventing-overview.adoc[Run a Function on Data Change]
  ** xref:eventing:eventing-Terminologies.adoc[Terminology]
  ** xref:eventing:eventing-language-constructs.adoc[Language Constructs]
   *** xref:eventing:eventing-advanced-keyspace-accessors.adoc[Advanced Keyspace Accessors]
@@ -66,6 +66,7 @@
   *** Performance Functions
    **** xref:eventing:eventing-handler-fasterToLocalString.adoc[fasterToLocalString]
  ** xref:eventing:eventing-debugging-and-diagnosability.adoc[Debugging and Diagnosability]
+ ** xref:eventing:eventing-memory-quota.adoc[Eventing Memory Quota]
  ** xref:eventing:eventing-statistics.adoc[Statistics]
  ** xref:eventing:troubleshooting-best-practices.adoc[Troubleshooting and Best Practices]
  ** xref:eventing:eventing-faq.adoc[Frequently Asked Questions]

--- a/modules/eventing/partials/nav.adoc
+++ b/modules/eventing/partials/nav.adoc
@@ -1,4 +1,4 @@
-››* xref:eventing:eventing-overview.adoc[Run a Function on Data Change]
+* xref:eventing:eventing-overview.adoc[Run a Function on Data Change]
  ** xref:eventing:eventing-Terminologies.adoc[Terminology]
  ** xref:eventing:eventing-language-constructs.adoc[Language Constructs]
   *** xref:eventing:eventing-advanced-keyspace-accessors.adoc[Advanced Keyspace Accessors]


### PR DESCRIPTION
[DOC-13422](https://jira.issues.couchbase.com/browse/DOC-13422)

Created and added a new document for Eventing Memory Quota and linked it from the Sizing Guidelines document. Also modified the Sizing Guidelines doc.

[Docs preview for Sizing Guidelines](https://preview.docs-test.couchbase.com/docs-server-DOC-13422-Eventing-Memory-Quota/server/current/install/sizing-general.html)
and
[Docs preview for Eventing Memory Quota](https://preview.docs-test.couchbase.com/docs-server-DOC-13422-Eventing-Memory-Quota/server/current/eventing/eventing-memory-quota.html)

[Preview credentials](https://couchbasecloud.atlassian.net/wiki/x/dYF_dQ#Preview-docs-for-internal-review)

**NOTE For Writer**: DO NOT Forget that this PR must be merged with the PR --> (https://github.com/couchbase/docs-server/pull/4055)

[DOC-13422]: https://couchbasecloud.atlassian.net/browse/DOC-13422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ