### PR TITLE
[AV-101989] Navigation Breadcrumbs Doc Updates

### DIFF
--- a/modules/eventing/pages/add-eventing-functions.adoc
+++ b/modules/eventing/pages/add-eventing-functions.adoc
@@ -18,7 +18,13 @@ See xref:cloud:clusters:modify-database.adoc#add-service[Add a Service] for more
 
 To add a new Eventing Function:
 
-. On the *Operational Clusters* page, select the cluster where you want to add a Function.
+. In the navigation breadcrumbs in the Capella UI, do 1 of the following: 
+
+.. Click your organization name and go to menu:Operational[]. 
+.. Click your current project name or search for a project and go to menu:Operational[].
+.. Expand the cluster breadcrumb and search for a cluster.
+
+. Select the cluster where you want to create a new Eventing Function.
 . Go to menu:Data Tools[Eventing].
 . Click btn:[Add Function].
 . Configure the <<function-settings,Function settings>>.

--- a/modules/search/pages/create-custom-analyzer.adoc
+++ b/modules/search/pages/create-custom-analyzer.adoc
@@ -22,7 +22,13 @@ For more information about how to change Services on your operational cluster, s
 
 To create a custom analyzer with the {page-ui-name} in Advanced Mode:
 
-. On the *Operational Clusters* page, select the operational cluster where you want to work with the Search Service. 
+. In the navigation breadcrumbs in the Capella UI, do 1 of the following: 
+
+.. Click your organization name and go to menu:Operational[]. 
+.. Click your current project name or search for a project and go to menu:Operational[].
+.. Expand the cluster breadcrumb and search for a cluster.
+
+. Select the cluster where you want to work with the Search Service.
 . Go to menu:Data Tools[Search].
 . Do one of the following:
 .. To work with an existing Search index, click the name of the index where you want to create a custom analyzer.

--- a/modules/search/pages/create-custom-character-filter.adoc
+++ b/modules/search/pages/create-custom-character-filter.adoc
@@ -22,7 +22,13 @@ For more information about how to change Services on your operational cluster, s
 
 To create a custom character filter with the {page-ui-name} in Advanced Mode:
 
-. On the *Operational Clusters* page, select the operational cluster where you want to work with the Search Service. 
+. In the navigation breadcrumbs in the Capella UI, do 1 of the following: 
+
+.. Click your organization name and go to menu:Operational[]. 
+.. Click your current project name or search for a project and go to menu:Operational[].
+.. Expand the cluster breadcrumb and search for a cluster.
+
+. Select the cluster where you want to work with the Search Service.
 . Go to menu:Data Tools[Search].
 . Do one of the following:
 .. To work with an existing Search index, click the name of the index where you want to create a custom character filter.

--- a/modules/search/pages/create-custom-date-time-parser.adoc
+++ b/modules/search/pages/create-custom-date-time-parser.adoc
@@ -22,7 +22,13 @@ For more information about how to change Services on your operational cluster, s
 
 To create a custom date/time parser with the {page-ui-name} in Advanced Mode: 
 
-. On the *Operational Clusters* page, select the operational cluster where you want to work with the Search Service. 
+. In the navigation breadcrumbs in the Capella UI, do 1 of the following: 
+
+.. Click your organization name and go to menu:Operational[]. 
+.. Click your current project name or search for a project and go to menu:Operational[].
+.. Expand the cluster breadcrumb and search for a cluster.
+
+. Select the cluster where you want to work with the Search Service.
 . Go to menu:Data Tools[Search].
 . Do one of the following:
 .. To work with an existing Search index, click the name of the index where you want to create a custom date/time parser.

--- a/modules/search/pages/create-custom-token-filter.adoc
+++ b/modules/search/pages/create-custom-token-filter.adoc
@@ -26,7 +26,13 @@ For more information about how to change Services on your operational cluster, s
 
 To create a custom token filter with the {page-ui-name} in Advanced Mode: 
 
-. On the *Operational Clusters* page, select the operational cluster where you want to work with the Search Service. 
+. In the navigation breadcrumbs in the Capella UI, do 1 of the following: 
+
+.. Click your organization name and go to menu:Operational[]. 
+.. Click your current project name or search for a project and go to menu:Operational[].
+.. Expand the cluster breadcrumb and search for a cluster.
+
+. Select the cluster where you want to work with the Search Service.
 . Go to menu:Data Tools[Search].
 . Click the name of the index where you want to create a custom analyzer.
 . Make sure to select *Enable Advanced Options*.

--- a/modules/search/pages/create-custom-tokenizer.adoc
+++ b/modules/search/pages/create-custom-tokenizer.adoc
@@ -24,7 +24,13 @@ For more information about how to change Services on your operational cluster, s
 
 To create a new custom tokenizer with the {page-ui-name} in Advanced Mode:
 
-. On the *Operational Clusters* page, select the operational cluster where you want to work with the Search Service. 
+. In the navigation breadcrumbs in the Capella UI, do 1 of the following: 
+
+.. Click your organization name and go to menu:Operational[]. 
+.. Click your current project name or search for a project and go to menu:Operational[].
+.. Expand the cluster breadcrumb and search for a cluster.
+
+. Select the cluster where you want to work with the Search Service. 
 . Go to menu:Data Tools[Search].
 . Do one of the following:
 .. To work with an existing Search index, click the name of the index where you want to create a custom analyzer.

--- a/modules/search/pages/create-search-index-alias.adoc
+++ b/modules/search/pages/create-search-index-alias.adoc
@@ -23,7 +23,13 @@ For more information, see xref:create-search-index-ui.adoc[].
 
 To create a Search index alias with the {page-ui-name}: 
 
-. On the *Operational Clusters* page, select the operational cluster where you want to work with the Search Service. 
+. In the navigation breadcrumbs in the Capella UI, do 1 of the following: 
+
+.. Click your organization name and go to menu:Operational[]. 
+.. Click your current project name or search for a project and go to menu:Operational[].
+.. Expand the cluster breadcrumb and search for a cluster.
+
+. Select the cluster where you want to work with the Search Service. 
 . Click btn:[Create Search Alias].
 
 == Next Steps

--- a/modules/search/pages/create-search-index-ui.adoc
+++ b/modules/search/pages/create-search-index-ui.adoc
@@ -25,7 +25,13 @@ For more information, see xref:cloud:clusters:data-service/manage-buckets.adoc[]
 
 To use the {page-ui-name} to create a Search index:
 
-. On the *Operational Clusters* page, select the operational cluster where you want to create a Search index. 
+. In the navigation breadcrumbs in the Capella UI, do 1 of the following: 
+
+.. Click your organization name and go to menu:Operational[]. 
+.. Click your current project name or search for a project and go to menu:Operational[].
+.. Expand the cluster breadcrumb and search for a cluster.
+
+. Select the cluster where you want to work with the Search Service.
 . Go to menu:Data Tools[Search].
 . Click btn:[Create Search Index].
 . (Optional) To add additional customization options to your Search index, click btn:[Enable Advanced Mode].

--- a/modules/search/pages/create-type-mapping.adoc
+++ b/modules/search/pages/create-type-mapping.adoc
@@ -31,7 +31,13 @@ For more information, see xref:create-search-index-ui.adoc[].
 
 To use the {page-ui-name} to create a new type mapping or mapping on a Search index: 
 
-. On the *Operational Clusters* page, select the operational cluster where you created your Search index. 
+. In the navigation breadcrumbs in the Capella UI, do 1 of the following: 
+
+.. Click your organization name and go to menu:Operational[]. 
+.. Click your current project name or search for a project and go to menu:Operational[].
+.. Expand the cluster breadcrumb and search for a cluster.
+
+. Select the cluster where you want to work with the Search Service. 
 . Go to menu:Data Tools[Search].
 . Click the name of the index where you want to create a new type mapping.
 . If you have not already, create at least 1 <<collection,collection type mapping>>.

--- a/modules/search/pages/import-search-index.adoc
+++ b/modules/search/pages/import-search-index.adoc
@@ -27,7 +27,13 @@ NOTE: Your JSON file must be smaller than 40 MB.
 
 To import a full xref:search-index-params.adoc[Search index definition] with the {page-ui-name}: 
 
-. On the *Operational Clusters* page, select the operational cluster where you want to import a JSON Search index definition.
+. In the navigation breadcrumbs in the Capella UI, do 1 of the following: 
+
+.. Click your organization name and go to menu:Operational[]. 
+.. Click your current project name or search for a project and go to menu:Operational[].
+.. Expand the cluster breadcrumb and search for a cluster.
+
+. Select the cluster where you want to work with the Search Service.
 . Go to menu:Data Tools[Search].
 . Click btn:[Import Search Index].
 . Upload a JSON file that contains your Search index definition.

--- a/modules/search/pages/search-query-auto-complete-ui.adoc
+++ b/modules/search/pages/search-query-auto-complete-ui.adoc
@@ -27,7 +27,13 @@ You can create a compatible Search index with the <<ui,{page-ui-name} in Advance
 
 To create the Search index in the {page-ui-name} with Advanced Mode:
 
-. On the *Operational Clusters* page, select the operational cluster where you want to create a Search index. 
+. In the navigation breadcrumbs in the Capella UI, do 1 of the following: 
+
+.. Click your organization name and go to menu:Operational[]. 
+.. Click your current project name or search for a project and go to menu:Operational[].
+.. Expand the cluster breadcrumb and search for a cluster.
+
+. Select the cluster where you want to work with the Search Service.
 . Go to menu:Data Tools[Search].
 . Click btn:[Create Search Index].
 . Click btn:[Enable Advanced Options].

--- a/modules/search/pages/set-advanced-settings.adoc
+++ b/modules/search/pages/set-advanced-settings.adoc
@@ -29,7 +29,13 @@ For more information, see xref:create-search-index-ui.adoc[].
 
 To set advanced settings for a Search index with the {page-ui-name}:
 
-. On the *Operational Clusters* page, select the operational cluster where you created your Search index. 
+. In the navigation breadcrumbs in the Capella UI, do 1 of the following: 
+
+.. Click your organization name and go to menu:Operational[]. 
+.. Click your current project name or search for a project and go to menu:Operational[].
+.. Expand the cluster breadcrumb and search for a cluster.
+
+. Select the cluster where you want to work with the Search Service.
 . Go to menu:Data Tools[Search].
 . Click the name of the index where you want to configure advanced settings.
 . Click btn:[Enable Advanced Mode].

--- a/modules/search/pages/set-type-identifier.adoc
+++ b/modules/search/pages/set-type-identifier.adoc
@@ -43,7 +43,13 @@ For more information, see xref:create-type-mapping.adoc[].
 
 To set a document filter for a Search index with the {page-ui-name}:
 
-. On the *Operational Clusters* page, select the operational cluster where you want to work with the Search Service. 
+. In the navigation breadcrumbs in the Capella UI, do 1 of the following: 
+
+.. Click your organization name and go to menu:Operational[]. 
+.. Click your current project name or search for a project and go to menu:Operational[].
+.. Expand the cluster breadcrumb and search for a cluster.
+
+. Select the cluster where you want to work with the Search Service.
 . Go to menu:Data Tools[Search].
 . Do 1 of the following:
 .. To work with an existing Search index, click the name of the index where you want to create a document filter.

--- a/modules/search/pages/simple-search-ui.adoc
+++ b/modules/search/pages/simple-search-ui.adoc
@@ -24,7 +24,13 @@ For more information about how to create a Search index, see xref:create-search-
 
 To run a simple search with the {page-ui-name}: 
 
-. On the *Operational Clusters* page, select the operational cluster where you created your Search index. 
+. In the navigation breadcrumbs in the Capella UI, do 1 of the following: 
+
+.. Click your organization name and go to menu:Operational[]. 
+.. Click your current project name or search for a project and go to menu:Operational[].
+.. Expand the cluster breadcrumb and search for a cluster.
+
+. Select the cluster where you created your Search index.
 . Go to menu:Data Tools[Search]. 
 . Next to your Search index or xref:index-aliases.adoc[index alias], click btn:[Search].
 . In the *Search* field, enter a search query. 

--- a/modules/tutorials/pages/java-tutorial/install-couchbase-java-sdk.adoc
+++ b/modules/tutorials/pages/java-tutorial/install-couchbase-java-sdk.adoc
@@ -35,7 +35,13 @@ Before you can establish a connection to your cluster, you must obtain the publi
 
 To configure your connection: 
 
-. On the *Operational Clusters* page, click the name of your free tier operational cluster.
+. In the navigation breadcrumbs in the Capella UI, do 1 of the following: 
+
+.. Click your organization name and go to menu:Operational[]. 
+.. Click your current project name or search for a project and go to menu:Operational[].
+.. Expand the cluster breadcrumb and search for your free cluster.
+
+. Click the name of your free tier operational cluster.
 
 . Go to menu:Connect[SDKs].
 

--- a/modules/tutorials/pages/java-tutorial/retrieving-documents.adoc
+++ b/modules/tutorials/pages/java-tutorial/retrieving-documents.adoc
@@ -41,7 +41,13 @@ The index helps your cluster find specific data when you run a query.
 
 To define an index:
 
-. On the *Operational Clusters* page, click the name of your free tier operational cluster.
+. In the navigation breadcrumbs in the Capella UI, do 1 of the following: 
+
+.. Click your organization name and go to menu:Operational[]. 
+.. Click your current project name or search for a project and go to menu:Operational[].
+.. Expand the cluster breadcrumb and search for your free cluster.
+
+. Click the name of your free tier operational cluster.
 
 . Go to menu:Data Tools[Query]. 
 

--- a/modules/tutorials/pages/migration-tutorial-capella/sql-migration-tutorial-capella.adoc
+++ b/modules/tutorials/pages/migration-tutorial-capella/sql-migration-tutorial-capella.adoc
@@ -8,7 +8,7 @@
 == Introduction
 
 In this tutorial, 
-you will make use of  `cbimport` to migrate an example test database from MySQL to Couchbase Capella.
+you will make use of `cbimport` to migrate an example test database from MySQL to Couchbase Capella.
 
 == Prerequisites
 
@@ -41,20 +41,11 @@ You will also need to create the bucket, scope, and collections to accept the st
 '''
 .Create the cluster.
 
-. Sign in to your Capella instance. 
-You will be presented showing the operational clusters along with the project that the cluster is attached to.
+. Sign in to the Capella UI.
 
-. Press the btn:[Create Cluster] button.
+. Go to menu:Projects[].
 
-. Now create a new project with a name of your choice. 
-
-. You will now be given the opportunity to create a new cluster which will be attached to your project.
-For this exercise, we're going to create a new project for our data migration, 
-so click on the link to take you to the Project list.
-+
-image::tutorials:select-project.png[,60%]
-+
-. Press the btn:[Create Project] button on the top right of the list. 
+. Click btn:[Create Project]. 
 This will take you to a dialog from where you can fill in the name of your new project.
 +
 image::tutorials:create-project.png[,60%]
@@ -69,7 +60,7 @@ TIP: You can also navigate to your project by finding it in the Project List and
 +
 image::tutorials:create-cluster.png[,60%]
 +
-. Select your cluster options (you may use the _free_ option if it's available), then press btn:[Create Cluster]. +
+. Select your cluster options (you may use the _free_ option if it's available), then press btn:[Create Cluster].
 After a short interval, your new cluster will be provisioned.
 +
 image::tutorials:new-cluster.png[,60%]

--- a/modules/vector-search/pages/create-vector-search-index-ui.adoc
+++ b/modules/vector-search/pages/create-vector-search-index-ui.adoc
@@ -40,7 +40,13 @@ include::partial$download-sample-partial.adoc[]
 
 To create a Search Vector Index in Capella:
 
-. On the *Operational Clusters* page, select the operational cluster where you want to create a Search index.
+. In the navigation breadcrumbs in the Capella UI, do 1 of the following: 
+
+.. Click your organization name and go to menu:Operational[]. 
+.. Click your current project name or search for a project and go to menu:Operational[].
+.. Expand the cluster breadcrumb and search for a cluster.
+
+. Select the cluster where you want to create a Search Vector Index.
 . Do 1 of the following: 
 .. Use the <<vector-indexes-flow,Vector Index creation flow>>. 
 .. Use the <<search-flow,Search creation flow>>.

--- a/modules/vector-search/pages/pre-filtering-vector-search.adoc
+++ b/modules/vector-search/pages/pre-filtering-vector-search.adoc
@@ -36,7 +36,13 @@ For the best results, consider using the sample Search Vector Index from xref:cr
 
 To add pre-filtering to a Vector Search query: 
 
-. On the *Operational Clusters* page, select the operational cluster where you created your Search index. 
+. In the navigation breadcrumbs in the Capella UI, do 1 of the following: 
+
+.. Click your organization name and go to menu:Operational[]. 
+.. Click your current project name or search for a project and go to menu:Operational[].
+.. Expand the cluster breadcrumb and search for a cluster.
+
+. Select the cluster where you created your Search Vector Index.
 . Go to menu:Data Tools[Search]. 
 . Next to your Search Vector Index, click btn:[Search].
 . In the *Search* field, enter a search query that includes a `filter` object with your `knn` object.

--- a/modules/vector-search/pages/run-vector-search-ui.adoc
+++ b/modules/vector-search/pages/run-vector-search-ui.adoc
@@ -31,7 +31,13 @@ For the best results, consider using the sample Search Vector Index from xref:cr
 
 To run a Vector Search with the {page-ui-name}: 
 
-. On the *Operational Clusters* page, select the operational cluster where you created your Search index. 
+. In the navigation breadcrumbs in the Capella UI, do 1 of the following: 
+
+.. Click your organization name and go to menu:Operational[]. 
+.. Click your current project name or search for a project and go to menu:Operational[].
+.. Expand the cluster breadcrumb and search for a cluster.
+
+. Select the cluster where you created your Search Vector Index. 
 . Go to menu:Data Tools[Search]. 
 . Next to your Search Vector Index, click btn:[Search].
 . In the *Search* field, enter a search query.


### PR DESCRIPTION
Updates to the Capella devex docs for navigation breadcrumbs improvements. 

The breadcrumbs make it a little more straightforward for us to try and direct users.

Preview site: https://preview.docs-test.couchbase.com/docs-capella-AV-101989-navigation-breadcrumbs-updates/home/cloud.html

(It's going to be easier to just look at the diffs for this one)

Credentials for Preview: https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords

**MUST BE MERGED WITH https://github.com/couchbase/docs-capella/pull/321**