### PR TITLE
DOC-12762: Add VECTOR_DISTANCE() distance function in 7.6.6

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/functions.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/functions.adoc
@@ -29,4 +29,5 @@ Here are the categories of {sqlpp} functions:
 * xref:n1ql-language-reference/tokenfun.adoc[Token Functions]
 * xref:n1ql-language-reference/typefun.adoc[Type Functions]
 * xref:n1ql-language-reference/userfun.adoc[User-Defined Functions]
+* xref:n1ql-language-reference/vectorfun.adoc[Vector Functions]
 * xref:n1ql-language-reference/windowfun.adoc[Window Functions]

--- a/modules/n1ql/pages/n1ql-language-reference/vectorfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/vectorfun.adoc
@@ -3,6 +3,7 @@
 :page-topic-type: reference
 :page-status: Couchbase Server 7.6.6
 :page-partial:
+:stem: latexmath
 :example-caption!:
 :keywords: similarity
 
@@ -31,12 +32,12 @@ The array must have the same dimensions as the vector field.
 metric:: A string representing the distance metric to use when comparing the vectors.
 +
 [horizontal.compact]
-COSINE;; xref:vector-index:vectors-and-indexes-overview.adoc#cosine[Cosine Similarity]
-DOT;; xref:vector-index:vectors-and-indexes-overview.adoc#dot[Dot Product]
+COSINE;; <<cosine>>
+DOT;; <<dot>>
 L2;;
-EUCLIDEAN;; xref:vector-index:vectors-and-indexes-overview.adoc#euclidean[Euclidean Distance]  
+EUCLIDEAN;; <<euclidean>>
 L2_SQUARED;;
-EUCLIDEAN_SQUARED;; xref:vector-index:vectors-and-indexes-overview.adoc#euclidean-squared[Euclidean Squared Distance]
+EUCLIDEAN_SQUARED;; <<euclidean-squared>>
 
 === Return Value
 
@@ -98,3 +99,74 @@ The results show how the distance changes as the similarity decreases.
 ]
 ----
 ====
+
+[#vector_similarity]
+== Vector Similarity Metrics
+
+You use metrics (also known as distance functions) to find similar vectors.
+When you use a vector function, you must specify which metric to use to compare vectors.
+Each metric works best for certain applications and types of data.
+
+Couchbase {product-name} supports four metrics:
+
+[#euclidean]
+=== Euclidean Distance
+
+Euclidean Distance (also known as L2) calculates the geometric distance between two vectors by finding the distance between the individual dimensions in the vectors.
+This method is most sensitive to the distance between the vectors in space, rather than their alignment.
+It's also sensitive to the scale of the vectors, where the length of one vector versus the other affects the relationship between the vectors.
+Use this method when the actual distance of the vectors and their magnitudes are important.
+This method is useful if the distance between vectors represents a real-world value.
+
+NOTE: When you select Euclidean Distance or L2 as the metric for a vector index, Couchbase {product-name} internally uses the <<#euclidean-squared>> metric (explained in the next section) to perform vector comparisons.
+This approach improves performance because it avoids performing a computationally expensive square root operation.
+Vector searches using the Euclidean Squared metric return the same relevant vectors and ranking of results as Euclidean Distance.
+If your query materializes or projects the actual distance between vectors, Couchbase {product-name} calculates the actual Euclidean Distance.
+For example, if your query returns the distance between vectors as a column, Couchbase {product-name} calculates the square root of the Euclidean Squared distance to return the actual Euclidean Distance.
+
+[#euclidean-squared]
+=== Euclidean Squared Distance
+
+Euclidean Squared Distance (also known as L2 Squared or L2^2^) is similar to Euclidean Distance.
+However, it does not take the square root of the sum distances between the vectors:
+
+
+Euclidean Distance Formula::
+latexmath:[L2(x, y) = \sqrt{\sum_{i=1}^n (x_i - y_i)^2}]
+
+
+Euclidean Squared Distance Formula::
+latexmath:[L2^2(x, y) = \sum_{i=1}^n (x_i - y_i)^2]
+
+
+Because it does not take the square root of the sums, Euclidean Squared Distance is faster to calculate than Euclidean Distance.
+However, it does not represent the actual distance between the vectors.
+The results of a vector search using L2 Squared as a metric always returns the same rankings that an L2 search returns.
+In cases where the dimensions of the vectors represent real-world values, L2 is more intuitive to use because it returns the actual distance between the vectors.
+
+Use this method when you need higher performance than Euclidean Distance.
+It's better in cases when comparing literal distances is less important than performance and where having the ranking of search results is sufficient.
+
+[#dot]
+=== Dot Product
+
+This metric finds related vectors by comparing the magnitude (length) and alignment of the vectors.
+Here, the proximity of the vectors in space is less important than whether they point in a similar direction and have the a similar magnitude.
+Vectors that point in similar directions (have a low angle between them) and have similar magnitude are strongly associated with each other.
+This method uses the similarity of the vectors' magnitudes to rank their relation.
+
+Use this method for tasks where ranking confidence is key.
+The magnitude of the vectors is important when determining the strength of the relationship.
+
+[#cosine]
+=== Cosine Similarity
+
+This metric is similar to the dot product.
+However, it normalizes the vectors (making them the same length) during comparison.
+Normalization means their magnitudes are not taken into account, just their alignment.
+This normalization makes this method better for comparing textual data because it's less sensitive to the length of the data.
+The magnitude of a vector generated by some text embedding models depend on the length of the source text.
+Normalizing vector magnitudes emphasizes the semantic meaning when performing comparisons.
+Therefore, Cosine Similarity can find the semantic relationship between a short question and a long article that's relevant to answering it.
+
+Use this method when you're performing searches that rely on semantic meaning.

--- a/modules/n1ql/pages/n1ql-language-reference/vectorfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/vectorfun.adoc
@@ -1,0 +1,400 @@
+= Vector Functions
+:description: Pattern-matching functions allow you to find regular expression patterns in strings or attributes.
+:page-topic-type: reference
+:example-caption!:
+:keywords: similarity
+
+{description}
+Regular expressions can formally represent various string search patterns using different special characters to indicate wildcards, positional characters, repetition, optional or mandatory sequences of letters, etc.
+{sqlpp} functions are available to find matching patterns, find position of matching pattern, or replace a pattern with a new string.
+
+For more information on all supported REGEX patterns, see https://golang.org/pkg/regexp/syntax[^].
+
+[[ann_distance,ANN_DISTANCE()]]
+== ANN_DISTANCE → see APPROX_VECTOR_DISTANCE
+
+Alias of <<approx_vector_distance>>.
+
+[[approx_vector_distance,APPROX_VECTOR_DISTANCE()]]
+== APPROX_VECTOR_DISTANCE(`vec`, `queryvec`, `metric` [,{nbsp}``nprobes`` [,{nbsp}``rerank`` [,{nbsp}``topNScan``]]])
+
+This function has an alias <<ann_distance>>.
+
+=== Description
+
+Finds the approximate distance between a provided vector and the content of a specified field that contains vector embeddings.
+
+This function is faster, but less precise than <<vector_distance>>.
+This function works with a hyperscale vector index or composite vector index that includes the field containing the vector embeddings.
+
+You should use this function in your production queries.
+
+=== Arguments
+
+vec:: The name of a field that contains vector embeddings.
+The field must contain an array of floating point numbers, or a base64 encoded string.
+
+queryvec:: An array of floating point numbers, or a base64 encoded string, representing the vector value to search for in the vector field.
+
+metric:: A string representing the distance metric to use when comparing the vectors.
+The distance metric should match the `similarity` setting that you used when you created the index.
++
+include::vector-index:partial$distance-metric-list.adoc[]
+
+nprobes:: [Optional] An integer representing the number of centroids to probe for matching vectors.
+If not specified, the function defaults to the `scan_nprobes` setting that you used when you created the index.
+If an invalid value is provided, defaults to `1`.
+
+rerank:: [Optional; can only be used when `nprobes` is specified]
+A boolean.
+If `false`, the function uses quantized vectors.
+It `true`, the function uses full vectors to reorder the results.
+The default is `false`.
+
+topNScan:: [Optional; can only be used when `nprobes` and `rerank` are specified]
+This option only applies if using a hyperscale vector index.
+A positive integer representing the number of results to return.
+The default is `0`, meaning the function uses the indexer default.
+
+=== Return Value
+
+Returns a numeric value representing the approximate vector distance.
+A lower value indicates greater similarity.
+
+=== Examples
+
+To try the examples in this section, you must install the `rgb` and `rgb-questions` collections, as described in xref:vector-index:hyperscale-vector-index.adoc#prerequisites[Prerequisites].
+
+The path to the required keyspace is specified by the query, so you do not need to set the query context.
+
+.REGEXP_MATCHES() Example 1
+====
+The following query finds all words beginning with upper or lower case B.
+
+.Query
+[source,sqlpp]
+----
+SELECT REGEXP_MATCHES("So, 'twas better Betty Botter bought a bit of better butter",
+                      "\\b[Bb]\\w+"); -- <1>
+----
+
+<1> The backslash that introduces an escape sequence in the regular expression must itself be escaped by another backslash in the {sqlpp} query.
+So `\b` (word boundary) must be entered as `\\b` and `\w` (word character) must be entered as `\\w`.
+
+.Results
+[source,json]
+----
+[
+  {
+    "$1": [
+      "better",
+      "Betty",
+      "Botter",
+      "bought",
+      "bit",
+      "better",
+      "butter"
+    ]
+  }
+]
+----
+====
+
+.REGEXP_MATCHES() Example 2
+====
+The following query finds sequences of two words beginning with upper or lower case B.
+
+.Query
+[source,sqlpp]
+----
+SELECT REGEXP_MATCHES("So, 'twas better Betty Botter bought a bit of better butter",
+                      "\\b[Bb]\\w+ \\b[Bb]\\w+");
+----
+
+.Results
+[source,json]
+----
+[
+  {
+    "$1": [
+      "better Betty",
+      "Botter bought", // <1>
+      "better butter"
+    ]
+  }
+]
+----
+
+<1> Note that `Betty Botter` is not found in this example, because `Betty` has already been found by the first match.
+====
+
+
+[[decode_vector,DECODE_VECTOR()]]
+== DECODE_VECTOR(`vector` [,{nbsp}``byte_order``])
+
+This function has an alias <<vector_decode>>.
+
+=== Description
+
+Reverses the encoding done by the <<encode_vector>> function.
+
+=== Arguments
+
+vector:: String, or any {sqlpp} expression that evaluates to a string, representing the base64 encoding of a vector value.
+
+byte_order:: [Optional] A boolean which determines the byte order of the vector value.
+If `true`, it is big-endian.
+If `false`, it is little-endian.
+The default is `false`.
+
+=== Return Value
+
+An array of float32 values.
+
+=== Examples
+
+.REGEXP_REPLACE() Example 1
+====
+.Query
+[source,sqlpp]
+----
+SELECT DECODE_VECTOR("zczMPc3MTD6amZk+zczMPg==") AS vector;
+----
+
+.Results
+[source,json]
+----
+[{
+    "vector": [
+        0.10000000149011612,
+        0.20000000298023224,
+        0.30000001192092896,
+        0.4000000059604645
+    ]
+}]
+----
+====
+
+.REGEXP_REPLACE() Example 2
+====
+In this example, the query retrieves first 4 documents and replaces the pattern of repeating n with emphasized NNNN.
+
+.Query
+[source,sqlpp]
+----
+SELECT DECODE_VECTOR("PczMzT5MzM0+mZmaPszMzQ==", true) AS vector;
+----
+
+.Results
+[source,json]
+----
+[{
+    "vector": [
+        0.10000000149011612,
+        0.20000000298023224,
+        0.30000001192092896,
+        0.4000000059604645
+    ]
+}]
+----
+====
+
+[[encode_vector,ENCODE_VECTOR()]]
+== ENCODE_VECTOR(`vector` [,{nbsp}``byte_order``])
+
+This function has an alias <<vector_encode>>.
+
+=== Description
+
+Returns the https://en.wikipedia.org/wiki/Base64[base64] encoding of a vector value.
+
+=== Arguments
+
+vector:: An array of float32 values, or any {sqlpp} expression that evaluates to an array of float32 values.
+
+byte_order:: [Optional] A boolean which determines the byte order of the vector value.
+If `true`, it is big-endian.
+If `false`, it is little-endian.
+The default is `false`.
+
+=== Return Value
+
+A string representing the base64 encoding of the input expression.
+
+=== Example
+
+====
+The following query finds positions of first occurrence of vowels in each word of the _name_ attribute.
+
+.Query
+[source,sqlpp]
+----
+SELECT ENCODE_VECTOR([0.1, 0.2, 0.3, 0.4]) AS base64;
+----
+
+.Results
+[source,json]
+----
+[
+  {
+    "base64": "zczMPc3MTD6amZk+zczMPg=="
+  }
+]
+----
+====
+
+====
+The following query finds positions of first occurrence of vowels in each word of the _name_ attribute.
+
+.Query
+[source,sqlpp]
+----
+SELECT ENCODE_VECTOR([0.1, 0.2, 0.3, 0.4], true) AS base64;
+----
+
+.Results
+[source,json]
+----
+[
+  {
+    "base64": "PczMzT5MzM0+mZmaPszMzQ=="
+  }
+]
+----
+====
+
+[[isvector,ISVECTOR()]]
+== ISVECTOR(`vec`, `dimension`, `float32`)
+
+// This function has no alias
+
+=== Description
+
+
+
+=== Arguments
+
+vec:: String, or any {sqlpp} expression that evaluates to a string.
+
+dimension:: String representing a supported regular expression.
+
+float32:: String representing a supported regular expression.
+
+=== Return Value
+
+Returns TRUE if the string value contains any sequence that matches the regular expression pattern.
+
+=== Example
+
+include::ROOT:partial$query-context.adoc[tag=section]
+
+====
+.Query
+[source,sqlpp]
+----
+SELECT name
+FROM landmark
+WHERE REGEXP_CONTAINS(name, "In+.*")
+LIMIT 5;
+----
+
+.Results
+[source,json]
+----
+[
+  {
+    "name": "Beijing Inn"
+  },
+  {
+    "name": "Sportsman Inn"
+  },
+  {
+    "name": "In-N-Out Burger"
+  },
+  {
+    "name": "Mel's Drive-In"
+  },
+  {
+    "name": "Inverness Castle"
+  }
+]
+----
+====
+
+[[knn_distance,KNN_DISTANCE()]]
+== KNN_DISTANCE → see VECTOR_DISTANCE
+
+Alias of <<vector_distance>>.
+
+[[vector_decode,VECTOR_DECODE()]]
+== VECTOR_DECODE → see DECODE_VECTOR
+
+Alias of <<decode_vector>>.
+
+[[vector_distance,VECTOR_DISTANCE()]]
+== VECTOR_DISTANCE(`vec`, `queryvec`, `metric`)
+
+This function has an alias <<knn_distance>>.
+
+=== Description
+
+Finds the exact distance between a provided vector and the content of a specified field that contains vector embeddings.
+
+This function is slower, but more precise than <<approx_vector_distance>>.
+This function does not use a hyperscale vector index or composite vector index to perform the comparison.
+Instead, it performs a brute-force search for similar vectors.
+
+You should use this function to check the accuracy of your production queries, and adjust the index and query settings to improve the recall accuracy.
+
+=== Arguments
+
+vec:: The name of a field that contains vector embeddings.
+The field must contain an array of floating point numbers, or a base64 encoded string.
+
+queryvec:: An array of floating point numbers, or a base64 encoded string, representing the vector value to search for in the vector field.
+
+metric:: A string representing the distance metric to use when comparing the vectors.
++
+include::vector-index:partial$distance-metric-list.adoc[]
+
+=== Return Value
+
+Returns a numeric value representing the vector distance.
+A lower value indicates greater similarity.
+
+=== Example
+
+To try the examples in this section, you must install the `rgb` and `rgb-questions` collections, as described in xref:vector-index:hyperscale-vector-index.adoc#prerequisites[Prerequisites].
+
+The path to the required keyspace is specified by the query, so you do not need to set the query context.
+
+====
+This example finds 10 colors from the `rgb` collection whose descriptions are most similar to the following presupplied question:
+
+> What is the color that is often linked to feelings of peace and tranquility, and is reminiscent of the clear sky on a calm day?
+
+.Query
+[source,sqlpp]
+----
+include::vector-index:example$hyperscale-idx-examples.sqlpp[tag=exact-query]
+----
+
+. The `vector` field in the `rgb-questions` collection contains the embedded vectors associated with the presupplied questions. @/couchbase_search_query.knn/
+
+. The `embedding_vector_dot` field in the `rgb` collection contains the embedded vectors associated with the color descriptions. @/embedding_vector_dot/
+
+The query returns 10 colors where the embedded vector associated with the color description is most similar to the embedded vector associated with the presupplied question.
+
+.Results
+[source,json]
+----
+include::vector-index:example$hyperscale-idx-data.json[tag=exact-query-results]
+----
+
+For more details and examples, see xref:vector-index:vector-index-best-practices.adoc#recall-accuracy[Determine Recall Rate].
+====
+
+[[vector_encode,VECTOR_ENCODE()]]
+== VECTOR_ENCODE → see ENCODE_VECTOR
+
+Alias of <<encode_vector>>.

--- a/modules/n1ql/pages/n1ql-language-reference/vectorfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/vectorfun.adoc
@@ -1,400 +1,100 @@
 = Vector Functions
-:description: Pattern-matching functions allow you to find regular expression patterns in strings or attributes.
+:description: Vector functions enable you to work with vector values.
 :page-topic-type: reference
+:page-status: Couchbase Server 7.6.6
+:page-partial:
 :example-caption!:
 :keywords: similarity
 
+[abstract]
 {description}
-Regular expressions can formally represent various string search patterns using different special characters to indicate wildcards, positional characters, repetition, optional or mandatory sequences of letters, etc.
-{sqlpp} functions are available to find matching patterns, find position of matching pattern, or replace a pattern with a new string.
 
-For more information on all supported REGEX patterns, see https://golang.org/pkg/regexp/syntax[^].
-
-[[ann_distance,ANN_DISTANCE()]]
-== ANN_DISTANCE → see APPROX_VECTOR_DISTANCE
-
-Alias of <<approx_vector_distance>>.
-
-[[approx_vector_distance,APPROX_VECTOR_DISTANCE()]]
-== APPROX_VECTOR_DISTANCE(`vec`, `queryvec`, `metric` [,{nbsp}``nprobes`` [,{nbsp}``rerank`` [,{nbsp}``topNScan``]]])
-
-This function has an alias <<ann_distance>>.
-
-=== Description
-
-Finds the approximate distance between a provided vector and the content of a specified field that contains vector embeddings.
-
-This function is faster, but less precise than <<vector_distance>>.
-This function works with a hyperscale vector index or composite vector index that includes the field containing the vector embeddings.
-
-You should use this function in your production queries.
-
-=== Arguments
-
-vec:: The name of a field that contains vector embeddings.
-The field must contain an array of floating point numbers, or a base64 encoded string.
-
-queryvec:: An array of floating point numbers, or a base64 encoded string, representing the vector value to search for in the vector field.
-
-metric:: A string representing the distance metric to use when comparing the vectors.
-The distance metric should match the `similarity` setting that you used when you created the index.
-+
-include::vector-index:partial$distance-metric-list.adoc[]
-
-nprobes:: [Optional] An integer representing the number of centroids to probe for matching vectors.
-If not specified, the function defaults to the `scan_nprobes` setting that you used when you created the index.
-If an invalid value is provided, defaults to `1`.
-
-rerank:: [Optional; can only be used when `nprobes` is specified]
-A boolean.
-If `false`, the function uses quantized vectors.
-It `true`, the function uses full vectors to reorder the results.
-The default is `false`.
-
-topNScan:: [Optional; can only be used when `nprobes` and `rerank` are specified]
-This option only applies if using a hyperscale vector index.
-A positive integer representing the number of results to return.
-The default is `0`, meaning the function uses the indexer default.
-
-=== Return Value
-
-Returns a numeric value representing the approximate vector distance.
-A lower value indicates greater similarity.
-
-=== Examples
-
-To try the examples in this section, you must install the `rgb` and `rgb-questions` collections, as described in xref:vector-index:hyperscale-vector-index.adoc#prerequisites[Prerequisites].
-
-The path to the required keyspace is specified by the query, so you do not need to set the query context.
-
-.REGEXP_MATCHES() Example 1
-====
-The following query finds all words beginning with upper or lower case B.
-
-.Query
-[source,sqlpp]
-----
-SELECT REGEXP_MATCHES("So, 'twas better Betty Botter bought a bit of better butter",
-                      "\\b[Bb]\\w+"); -- <1>
-----
-
-<1> The backslash that introduces an escape sequence in the regular expression must itself be escaped by another backslash in the {sqlpp} query.
-So `\b` (word boundary) must be entered as `\\b` and `\w` (word character) must be entered as `\\w`.
-
-.Results
-[source,json]
-----
-[
-  {
-    "$1": [
-      "better",
-      "Betty",
-      "Botter",
-      "bought",
-      "bit",
-      "better",
-      "butter"
-    ]
-  }
-]
-----
-====
-
-.REGEXP_MATCHES() Example 2
-====
-The following query finds sequences of two words beginning with upper or lower case B.
-
-.Query
-[source,sqlpp]
-----
-SELECT REGEXP_MATCHES("So, 'twas better Betty Botter bought a bit of better butter",
-                      "\\b[Bb]\\w+ \\b[Bb]\\w+");
-----
-
-.Results
-[source,json]
-----
-[
-  {
-    "$1": [
-      "better Betty",
-      "Botter bought", // <1>
-      "better butter"
-    ]
-  }
-]
-----
-
-<1> Note that `Betty Botter` is not found in this example, because `Betty` has already been found by the first match.
-====
-
-
-[[decode_vector,DECODE_VECTOR()]]
-== DECODE_VECTOR(`vector` [,{nbsp}``byte_order``])
-
-This function has an alias <<vector_decode>>.
-
-=== Description
-
-Reverses the encoding done by the <<encode_vector>> function.
-
-=== Arguments
-
-vector:: String, or any {sqlpp} expression that evaluates to a string, representing the base64 encoding of a vector value.
-
-byte_order:: [Optional] A boolean which determines the byte order of the vector value.
-If `true`, it is big-endian.
-If `false`, it is little-endian.
-The default is `false`.
-
-=== Return Value
-
-An array of float32 values.
-
-=== Examples
-
-.REGEXP_REPLACE() Example 1
-====
-.Query
-[source,sqlpp]
-----
-SELECT DECODE_VECTOR("zczMPc3MTD6amZk+zczMPg==") AS vector;
-----
-
-.Results
-[source,json]
-----
-[{
-    "vector": [
-        0.10000000149011612,
-        0.20000000298023224,
-        0.30000001192092896,
-        0.4000000059604645
-    ]
-}]
-----
-====
-
-.REGEXP_REPLACE() Example 2
-====
-In this example, the query retrieves first 4 documents and replaces the pattern of repeating n with emphasized NNNN.
-
-.Query
-[source,sqlpp]
-----
-SELECT DECODE_VECTOR("PczMzT5MzM0+mZmaPszMzQ==", true) AS vector;
-----
-
-.Results
-[source,json]
-----
-[{
-    "vector": [
-        0.10000000149011612,
-        0.20000000298023224,
-        0.30000001192092896,
-        0.4000000059604645
-    ]
-}]
-----
-====
-
-[[encode_vector,ENCODE_VECTOR()]]
-== ENCODE_VECTOR(`vector` [,{nbsp}``byte_order``])
-
-This function has an alias <<vector_encode>>.
-
-=== Description
-
-Returns the https://en.wikipedia.org/wiki/Base64[base64] encoding of a vector value.
-
-=== Arguments
-
-vector:: An array of float32 values, or any {sqlpp} expression that evaluates to an array of float32 values.
-
-byte_order:: [Optional] A boolean which determines the byte order of the vector value.
-If `true`, it is big-endian.
-If `false`, it is little-endian.
-The default is `false`.
-
-=== Return Value
-
-A string representing the base64 encoding of the input expression.
-
-=== Example
-
-====
-The following query finds positions of first occurrence of vowels in each word of the _name_ attribute.
-
-.Query
-[source,sqlpp]
-----
-SELECT ENCODE_VECTOR([0.1, 0.2, 0.3, 0.4]) AS base64;
-----
-
-.Results
-[source,json]
-----
-[
-  {
-    "base64": "zczMPc3MTD6amZk+zczMPg=="
-  }
-]
-----
-====
-
-====
-The following query finds positions of first occurrence of vowels in each word of the _name_ attribute.
-
-.Query
-[source,sqlpp]
-----
-SELECT ENCODE_VECTOR([0.1, 0.2, 0.3, 0.4], true) AS base64;
-----
-
-.Results
-[source,json]
-----
-[
-  {
-    "base64": "PczMzT5MzM0+mZmaPszMzQ=="
-  }
-]
-----
-====
-
-[[isvector,ISVECTOR()]]
-== ISVECTOR(`vec`, `dimension`, `float32`)
-
-// This function has no alias
-
-=== Description
-
-
-
-=== Arguments
-
-vec:: String, or any {sqlpp} expression that evaluates to a string.
-
-dimension:: String representing a supported regular expression.
-
-float32:: String representing a supported regular expression.
-
-=== Return Value
-
-Returns TRUE if the string value contains any sequence that matches the regular expression pattern.
-
-=== Example
-
-include::ROOT:partial$query-context.adoc[tag=section]
-
-====
-.Query
-[source,sqlpp]
-----
-SELECT name
-FROM landmark
-WHERE REGEXP_CONTAINS(name, "In+.*")
-LIMIT 5;
-----
-
-.Results
-[source,json]
-----
-[
-  {
-    "name": "Beijing Inn"
-  },
-  {
-    "name": "Sportsman Inn"
-  },
-  {
-    "name": "In-N-Out Burger"
-  },
-  {
-    "name": "Mel's Drive-In"
-  },
-  {
-    "name": "Inverness Castle"
-  }
-]
-----
-====
-
-[[knn_distance,KNN_DISTANCE()]]
-== KNN_DISTANCE → see VECTOR_DISTANCE
-
-Alias of <<vector_distance>>.
-
-[[vector_decode,VECTOR_DECODE()]]
-== VECTOR_DECODE → see DECODE_VECTOR
-
-Alias of <<decode_vector>>.
+Vector functions are supported in Couchbase Server 7.6.6 and later.
 
 [[vector_distance,VECTOR_DISTANCE()]]
 == VECTOR_DISTANCE(`vec`, `queryvec`, `metric`)
 
-This function has an alias <<knn_distance>>.
+// no alias
 
 === Description
 
 Finds the exact distance between a provided vector and the content of a specified field that contains vector embeddings.
 
-This function is slower, but more precise than <<approx_vector_distance>>.
-This function does not use a hyperscale vector index or composite vector index to perform the comparison.
-Instead, it performs a brute-force search for similar vectors.
-
-You should use this function to check the accuracy of your production queries, and adjust the index and query settings to improve the recall accuracy.
-
 === Arguments
 
-vec:: The name of a field that contains vector embeddings.
-The field must contain an array of floating point numbers, or a base64 encoded string.
+vec:: The name of a field that contains vectors.
+The field must contain an array of 32-bit floating point numbers.
 
-queryvec:: An array of floating point numbers, or a base64 encoded string, representing the vector value to search for in the vector field.
+queryvec:: An array of 32-bit floating point numbers representing the vector value to search for in the vector field.
+The array must have the same dimensions as the vector field.
 
 metric:: A string representing the distance metric to use when comparing the vectors.
 +
-include::vector-index:partial$distance-metric-list.adoc[]
+[horizontal.compact]
+COSINE;; xref:vector-index:vectors-and-indexes-overview.adoc#cosine[Cosine Similarity]
+DOT;; xref:vector-index:vectors-and-indexes-overview.adoc#dot[Dot Product]
+L2;;
+EUCLIDEAN;; xref:vector-index:vectors-and-indexes-overview.adoc#euclidean[Euclidean Distance]  
+L2_SQUARED;;
+EUCLIDEAN_SQUARED;; xref:vector-index:vectors-and-indexes-overview.adoc#euclidean-squared[Euclidean Squared Distance]
 
 === Return Value
 
 Returns a numeric value representing the vector distance.
-A lower value indicates greater similarity.
+If the vector value is missing, returns MISSING.
+If the vector value is null, returns NULL.
 
-=== Example
+=== Examples
 
-To try the examples in this section, you must install the `rgb` and `rgb-questions` collections, as described in xref:vector-index:hyperscale-vector-index.adoc#prerequisites[Prerequisites].
-
-The path to the required keyspace is specified by the query, so you do not need to set the query context.
-
+[#vector_distance_ex_simple]
+.VECTOR_DISTANCE() Example
 ====
-This example finds 10 colors from the `rgb` collection whose descriptions are most similar to the following presupplied question:
-
-> What is the color that is often linked to feelings of peace and tranquility, and is reminiscent of the clear sky on a calm day?
+The following query finds the exact vector distance between a query vector and three different embedded vectors.
 
 .Query
 [source,sqlpp]
 ----
-include::vector-index:example$hyperscale-idx-examples.sqlpp[tag=exact-query]
+WITH data AS ([
+  {"vector": [1, 2, 3, 4], "similarity": "identical"},
+  {"vector": [1, 2, 3, 5], "similarity": "close"},
+  {"vector": [6, 7, 8, 9], "similarity": "distant"}
+])
+SELECT
+  similarity,
+  VECTOR_DISTANCE(vector, [1, 2, 3, 4], "COSINE") AS cosine,
+  VECTOR_DISTANCE(vector, [1, 2, 3, 4], "DOT") AS dot,
+  VECTOR_DISTANCE(vector, [1, 2, 3, 4], "L2") AS l2,
+  VECTOR_DISTANCE(vector, [1, 2, 3, 4], "L2_SQUARED") AS l2_squared
+FROM data;
 ----
 
-. The `vector` field in the `rgb-questions` collection contains the embedded vectors associated with the presupplied questions. @/couchbase_search_query.knn/
-
-. The `embedding_vector_dot` field in the `rgb` collection contains the embedded vectors associated with the color descriptions. @/embedding_vector_dot/
-
-The query returns 10 colors where the embedded vector associated with the color description is most similar to the embedded vector associated with the presupplied question.
+The results show how the distance changes as the similarity decreases.
 
 .Results
 [source,json]
 ----
-include::vector-index:example$hyperscale-idx-data.json[tag=exact-query-results]
+[
+    {
+        "similarity": "identical",
+        "cosine": 0,
+        "dot": -30,
+        "l2": 0,
+        "l2_squared": 0
+    },
+    {
+        "similarity": "close",
+        "cosine": 0.00600091145203363,
+        "dot": -34,
+        "l2": 1,
+        "l2_squared": 1
+    },
+    {
+        "similarity": "distant",
+        "cosine": 0.0369131753138463,
+        "dot": -80,
+        "l2": 10,
+        "l2_squared": 100
+    }
+]
 ----
-
-For more details and examples, see xref:vector-index:vector-index-best-practices.adoc#recall-accuracy[Determine Recall Rate].
 ====
-
-[[vector_encode,VECTOR_ENCODE()]]
-== VECTOR_ENCODE → see ENCODE_VECTOR
-
-Alias of <<encode_vector>>.

--- a/modules/n1ql/partials/nav.adoc
+++ b/modules/n1ql/partials/nav.adoc
@@ -76,6 +76,7 @@
       **** xref:n1ql:n1ql-language-reference/tokenfun.adoc[]
       **** xref:n1ql:n1ql-language-reference/typefun.adoc[]
       **** xref:n1ql:n1ql-language-reference/userfun.adoc[]
+      **** xref:n1ql:n1ql-language-reference/vectorfun.adoc[]
       **** xref:n1ql:n1ql-language-reference/windowfun.adoc[]
     *** xref:n1ql:n1ql-language-reference/subqueries.adoc[]
       **** xref:n1ql:n1ql-language-reference/correlated-subqueries.adoc[]


### PR DESCRIPTION
Jira ticket: DOC-12762

This PR backports the VECTOR_DISTANCE() function to 7.6. It also includes an explanation of the vector similarity metrics, which are covered in the Vector Indexes topic in 8.0 and later.

Docs preview: [Vector Functions](https://preview.docs-test.couchbase.com/docs-devex-DOC-12762-vector-distance/server/current/n1ql/n1ql-language-reference/vectorfun.html)
Credentials: [Preview docs for internal review](https://couchbasecloud.atlassian.net/wiki/x/dYF_dQ#Preview-docs-for-internal-Couchbase-reviews)