### PR TITLE
[DOC-2423] Update Aggregate Functions

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/aggregatefun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/aggregatefun.adoc
@@ -69,15 +69,13 @@ include::partial$grammar/n1ql.ebnf[tag=aggregate-quantifier]
 
 image::n1ql-language-reference/aggregate-quantifier.png["Syntax diagram", align=left]
 
-The *aggregate quantifier* determines whether the function aggregates all values in the group, or distinct values only.
+An aggregate quantifier determines whether the function aggregates all values in a group or only distinct values.
+You can use the quantifiers only with aggregate functions.
 
-`ALL`:: All objects are included in the computation.
-`DISTINCT`:: Only distinct objects are included in the computation.
+`ALL`:: Includes all values in the computation.
+`DISTINCT`:: Includes only distinct values in the computation.
 
-This quantifier can only be used with aggregate functions.
-
-This quantifier is optional.
-If omitted, the default value is `ALL`.
+The quantifiers are optional and the default value is `ALL`.
 
 [[filter-clause]]
 === FILTER Clause
@@ -123,7 +121,7 @@ All other aggregate functions return NULL.
 
 === Description
 
-Returns an array of non-MISSING values from an aggregated group.
+Returns an array of non-MISSING values from an expression.
 
 You can use the `ALL` or `DISTINCT` quantifier to specify which values to include in the calculation.
 For more information, see <<aggregate-quantifier>>.
@@ -205,7 +203,7 @@ This function has a synonym <<mean>>.
 
 === Description
 
-Returns the arithmetic mean (average) of all numeric values in an aggregated group.
+Returns the arithmetic mean (average) of all numeric values in an expression.
 
 You can use the `ALL` or `DISTINCT` quantifier to specify which values to include in the calculation.
 For more information, see <<aggregate-quantifier>>.
@@ -316,7 +314,7 @@ AS input;
 
 === Description
 
-Returns the count of all non-NULL and non-MISSING values in an aggregated group. footnote:count[]
+Returns the count of all non-NULL and non-MISSING values in an expression. footnote:count[]
 
 You can use the `ALL` or `DISTINCT` quantifier to specify which values to include in the calculation.
 For more information, see <<aggregate-quantifier>>.
@@ -379,7 +377,7 @@ AS input;
 
 === Description
 
-Returns the count of numeric values in an aggregated group. footnote:count[]
+Returns the count of numeric values in an expression. footnote:count[]
 
 You can use the `ALL` or `DISTINCT` quantifier to specify which values to include in the calculation.
 For more information, see <<aggregate-quantifier>>.
@@ -445,7 +443,7 @@ AS input;
 
 === Description
 
-Returns the maximum value in an aggregated group.
+Returns the maximum value in an expression.
 The function ignores `MISSING` and `NULL` values.
 
 When comparing values of different data types, the function uses {sqlpp} xref:n1ql-language-reference/datatypes.adoc#collation[collation rules] to determine precedence.
@@ -541,7 +539,7 @@ Synonym of <<avg>>.
 
 === Description
 
-Returns the median of all numeric values in an aggregated group.
+Returns the median of all numeric values in an expression.
 
 You can use the `ALL` or `DISTINCT` quantifier to specify which values to include in the calculation.
 For more information, see <<aggregate-quantifier>>.
@@ -634,7 +632,7 @@ THerefore, the median is the mean of the 2 middle values (`2` and `3`), which is
 
 === Description
 
-Returns the minimum value in an aggregated group.
+Returns the minimum value in an expression.
 The function ignores `MISSING` and `NULL` values.
 
 When comparing values of different data types, the function uses {sqlpp} xref:n1ql-language-reference/datatypes.adoc#collation[collation rules] to determine precedence.
@@ -725,7 +723,7 @@ When comparing string values, the function uses alphabetical order to determine 
 
 === Description
 
-Returns the <<eqn_samp_std_dev, corrected sample standard deviation>> of all numeric values in an aggregated group.
+Returns the <<eqn_samp_std_dev, corrected sample standard deviation>> of all numeric values in an expression.
 
 You can use the `ALL` or `DISTINCT` quantifier to specify which values to include in the calculation.
 For more information, see <<aggregate-quantifier>>.
@@ -815,7 +813,7 @@ AS input;
 
 === Description
 
-Returns the <<eqn_pop_std_dev,population standard deviation>> of all numeric values in an aggregated group.
+Returns the <<eqn_pop_std_dev,population standard deviation>> of all numeric values in an expression.
 
 You can use the `ALL` or `DISTINCT` quantifier to specify which values to include in the calculation.
 For more information, see <<aggregate-quantifier>>.
@@ -880,7 +878,7 @@ AS input;
 
 === Description
 
-Returns the <<eqn_samp_std_dev, corrected sample standard deviation>> of all numeric values in an aggregated group.
+Returns the <<eqn_samp_std_dev, corrected sample standard deviation>> of all numeric values in an expression.
 
 You can use the `ALL` or `DISTINCT` quantifier to specify which values to include in the calculation.
 For more information, see <<aggregate-quantifier>>.
@@ -969,7 +967,7 @@ AS input;
 
 === Description
 
-Returns the arithmetic sum of all number values in an aggregated group. 
+Returns the arithmetic sum of all number values in an expression. 
 
 You can use the `ALL` or `DISTINCT` quantifier to specify which values to include in the calculation.
 For more information, see <<aggregate-quantifier>>.
@@ -1034,7 +1032,7 @@ AS input;
 
 === Description
 
-Returns the unbiased sample variance (the square of the <<eqn_samp_std_dev,corrected sample standard deviation>>) of all numeric values in an aggregated group.
+Returns the unbiased sample variance (the square of the <<eqn_samp_std_dev,corrected sample standard deviation>>) of all numeric values in an expression.
 
 You can use the `ALL` or `DISTINCT` quantifier to specify which values to include in the calculation.
 For more information, see <<aggregate-quantifier>>.
@@ -1126,7 +1124,7 @@ This function has a synonym <<var_pop>>.
 
 === Description
 
-Returns the population variance (the square of the <<eqn_pop_std_dev,population standard deviation>>) of all numeric values in an aggregated group.
+Returns the population variance (the square of the <<eqn_pop_std_dev,population standard deviation>>) of all numeric values in an expression.
 
 You can use the `ALL` or `DISTINCT` quantifier to specify which values to include in the calculation.
 For more information, see <<aggregate-quantifier>>.
@@ -1214,7 +1212,7 @@ This function has a synonym <<var_samp>>.
 
 === Description
 
-Returns the unbiased sample variance (the square of the <<eqn_samp_std_dev,corrected sample standard deviation>>) of all numeric values in an aggregated group.
+Returns the unbiased sample variance (the square of the <<eqn_samp_std_dev,corrected sample standard deviation>>) of all numeric values in an expression.
 
 You can use the `ALL` or `DISTINCT` quantifier to specify which values to include in the calculation.
 For more information, see <<aggregate-quantifier>>.

--- a/modules/n1ql/pages/n1ql-language-reference/aggregatefun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/aggregatefun.adoc
@@ -32,7 +32,7 @@ The function names are case insensitive.
 You can only use aggregate functions in `SELECT`, `LETTING`, `HAVING`, and `ORDER BY` clauses.
 When using an aggregate function in a query, the query operates as an aggregate query.
 
-In Couchbase Server Enterprise Edition, aggregate functions can also be used as {windowfun}[window functions] when they are used with a window specification, which is introduced by the `OVER` keyword.
+In Couchbase Server Enterprise Edition, you can use aggregate functions as {windowfun}[window functions] by specifying a window definition using the <<over-clause>>.
 
 include::partial$n1ql-language-reference/window-intro.adoc[tag=syntax]
 
@@ -40,7 +40,7 @@ include::partial$n1ql-language-reference/window-intro.adoc[tag=syntax]
 == Syntax
 
 This section describes the generic syntax of aggregate functions.
-Refer to sections below for details of individual aggregate functions.
+For details of individual aggregate functions, see the sections that follow.
 
 [source,ebnf]
 ----

--- a/modules/n1ql/pages/n1ql-language-reference/aggregatefun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/aggregatefun.adoc
@@ -36,7 +36,7 @@ In Couchbase Server Enterprise Edition, aggregate functions can also be used as 
 
 include::partial$n1ql-language-reference/window-intro.adoc[tag=syntax]
 
-[[agg-func-syntax]]
+[[aggregate-syntax]]
 == Syntax
 
 This section describes the generic syntax of aggregate functions.
@@ -123,90 +123,112 @@ All other aggregate functions return NULL.
 
 === Description
 
-This function returns an array of all non-MISSING values from a specified expression.
+This function takes all non-MISSING values from an expression and returns them as an array. 
+The function ignores MISSING values, but includes NULL values in the resulting array.
 
 You can use the following quantifiers to control the values in the resulting array: 
 
-* `ALL` - Includes all non-MISSING values, including NULL.
-* `DISTINCT` - Includes only distinct non-MISSING values, including NULL.
+* `ALL` - includes every non-MISSING value.  
+This is the default behavior.
+* `DISTINCT` - includes only distinct values and removes duplicates.
+
+For more information about quantifiers, see <<aggregate-quantifier>>.
 
 === Arguments
 
-See <<agg-func-syntax>>.
+expression:: [Required] 
+A valid {expression}[expression] that contains the values to aggregate.
+
+NOTE: You can also add optional clauses like FILTER and OVER to this function. 
+For more information, see <<aggregate-syntax>>.
 
 === Return Value
 
-An array of non-MISSING values.
+An array of aggregated values. 
+
+The function returns NULL if all values in the group are either MISSING or empty.
 
 === Examples
-include::ROOT:partial$query-context.adoc[tag=section]
 
+.List all airlines into an array
 ====
-List all values of the `Cleanliness` reviews given:
-
 .Query
 [source,sqlpp]
 ----
-SELECT ARRAY_AGG() AS 
+SELECT ARRAY_AGG(airline) AS result
+FROM ["United", "Delta", "United", 
+      "Southwest", NULL, MISSING] 
+AS airline;
 ----
 
 .Results
 [source,json]
 ----
-[
-  {
-    "Reviews": [
-      -1,
-      -1,
-      -1,
-      -1,
-      -1,
-      // ...
+[{
+    "result": [
+        null,
+        "Delta",
+        "Southwest",
+        "United",
+        "United"
     ]
-  }
-]
+}]
 ----
 ====
 
+.List unique airlines into an array
 ====
-List all unique values of the `Cleanliness` reviews given:
-
 .Query
 [source,sqlpp]
 ----
-SELECT ARRAY_AGG(DISTINCT reviews[0].ratings.Cleanliness) AS Reviews
-FROM hotel;
+SELECT ARRAY_AGG( DISTINCT airline) AS result
+FROM ["United", "Delta", "United", 
+      "Southwest", NULL, MISSING] 
+AS airline;
 ----
 
 .Results
 [source,json]
 ----
-[
-  {
-    "UniqueReviews": [
-      -1,
-      1,
-      2,
-      3,
-      4,
-      5
+[{
+    "result": [
+        null,
+        "Delta",
+        "Southwest",
+        "United"
     ]
-  }
-]
+}]
 ----
 ====
 
 [[avg,AVG()]]
 == [[avg_distinct]]AVG( {startsb} ALL | DISTINCT {endsb} `expression`)
 
-This function has an alias <<mean>>.
+This function has a synonym <<mean>>.
+
+=== Description
+
+This function computes the arithmetic mean (average) of all numeric values in an expression.
+
+You can use the ALL or DISTINCT quantifiers to control the values used in the calculation.
+By default, the function uses the ALL quantifier and includes every non-MISSING value. 
+The DISTINCT quantifier uses only distinct values and helps remove duplicates from the calculation. 
+For more information about these quantifiers, see <<aggregate-quantifier>>.
+
+==== Arguments
+
+ALL | DISTINCT:: [Optional] Specifies whether to include all values or only distinct values in the calculation.
+
+expression:: [Required]
+A valid {expression}[expression] that contains values to aggregate.
+
+NOTE: You can also add optional clauses like FILTER and OVER as arguments to this function. 
+For more information, see <<aggregate-syntax>>.
 
 === Return Value
-With the `ALL` quantifier, or no quantifier, returns the arithmetic mean (average) of all the number values in the group.
 
-With the `DISTINCT` quantifier, returns the arithmetic mean (average) of all the distinct number values in the group.
-
-Returns NULL if there are no number values in the group.
+The function returns a number that represents the arithmetic mean.
+It returns NULL if all values in the group are MISSING, non-numeric, or NULL.
 
 === Examples
 include::ROOT:partial$query-context.adoc[tag=section]
@@ -248,6 +270,14 @@ Results in 0.5 since all routes have only 1 or 0 stops.
 
 [[count_all,COUNT(*)]]
 == COUNT(*)
+
+=== Description
+
+This function counts all input rows for the group, regardless of value.
+
+=== Arguments
+
+*:: [Required] A wildcard that specifies counting all input rows.
 
 === Return Value
 Returns count of all the input rows for the group, regardless of value. footnote:count[{doc-count}]

--- a/modules/n1ql/pages/n1ql-language-reference/aggregatefun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/aggregatefun.adoc
@@ -123,9 +123,12 @@ All other aggregate functions return NULL.
 
 === Description
 
-The `ARRAY_AGG()` function takes all the non-MISSING values of the specified expression and returns them as an array.
+This function returns an array of all non-MISSING values from a specified expression.
 
-You can use the `ALL` or `DISTINCT` quantifier to specify whether to include all values or only distinct values in the resulting array.
+You can use the following quantifiers to control the values in the resulting array: 
+
+* `ALL` - Includes all non-MISSING values, including NULL.
+* `DISTINCT` - Includes only distinct non-MISSING values, including NULL.
 
 === Arguments
 
@@ -133,9 +136,7 @@ See <<agg-func-syntax>>.
 
 === Return Value
 
-With the `ALL` quantifier, or no quantifier, returns an array of the non-MISSING values, including NULL values.
-
-With the `DISTINCT` quantifier, returns an array of the distinct non-MISSING values, including NULL values.
+An array of non-MISSING values.
 
 === Examples
 include::ROOT:partial$query-context.adoc[tag=section]
@@ -146,8 +147,7 @@ List all values of the `Cleanliness` reviews given:
 .Query
 [source,sqlpp]
 ----
-SELECT ARRAY_AGG(reviews[0].ratings.Cleanliness) AS Reviews
-FROM hotel;
+SELECT ARRAY_AGG() AS 
 ----
 
 .Results

--- a/modules/n1ql/pages/n1ql-language-reference/aggregatefun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/aggregatefun.adoc
@@ -126,13 +126,13 @@ All other aggregate functions return NULL.
 This function takes all non-MISSING values from an expression and returns them as an array. 
 The function ignores MISSING values, but includes NULL values in the resulting array.
 
-You can use the following quantifiers to control the values in the resulting array: 
+You can specify a quantifier to control what values to include in the resulting array:
 
 * `ALL` - includes every non-MISSING value.  
 By default, the function uses this quantifier.
 * `DISTINCT` - includes only distinct values and removes duplicates.
 
-For more information about quantifiers, see <<aggregate-quantifier>>.
+For more information, see <<aggregate-quantifier>>.
 
 === Arguments
 
@@ -211,10 +211,17 @@ This function has a synonym <<mean>>.
 
 Returns the arithmetic mean (average) of all numeric values in an expression.
 
-You can use the ALL or DISTINCT quantifiers to control the values used in the calculation.
-By default, the function uses the ALL quantifier and includes every non-MISSING value. 
-The DISTINCT quantifier uses only distinct values and helps remove duplicates from the calculation. 
-For more information about these quantifiers, see <<aggregate-quantifier>>.
+//tag::quantifiers[]
+
+You can specify a quantifier to control what values to include in the calculation.
+
+* `ALL` - Includes every numeric value.
+By default, the function uses this quantifier.
+* `DISTINCT` - Includes only unique numeric values and ignores duplicates.
+
+For more information, see <<aggregate-quantifier>>.
+
+//end::quantifiers[]
 
 ==== Arguments
 
@@ -275,11 +282,11 @@ The calculation considers only the distinct numeric values and the average is (1
 
 === Description
 
-Returns the count of all input rows in a group. footnote:count[{doc-count}]
+Returns the count of all input rows in an aggregated group. footnote:count[{doc-count}]
 
-The wildcard (`*`) indicates all rows are to be counted, including rows with NULL and MISSING values.
+The wildcard (*) indicates all rows are to be counted, including rows with `NULL` and `MISSING` values.
 
-TIP: To count only non-NULL and non-MISSING values in an expression, use <<count, COUNT(`expression`)>>.
+TIP: To count only non-NULL and non-MISSING values in an expression, use <<count, COUNT(expression)>>.
 
 === Arguments
 
@@ -287,7 +294,7 @@ This function does not take any arguments.
 
 === Return Value
 
-A number that represents the count of all objects. 
+A number that represents the count of all rows. 
 
 The function returns `0` if the group is empty. 
 
@@ -328,15 +335,17 @@ You can specify a quantifier to control which values to count:
 By default, the function uses this quantifier.
 * `DISTINCT` - Counts only unique values and ignores duplicates.
 
-In both cases, the function ignores MISSING and NULL values.
+In both cases, the function ignores `MISSING` and `NULL` values.
 
-TIP: To count all values including NULL and MISSING, use <<count_all, COUNT(*)>>.
+For more information about quantifiers, see <<aggregate-quantifier>>.
+
+TIP: To count all values including `NULL` and `MISSING`, use <<count_all, COUNT(*)>>.
 
 === Return Value
 
 A number that represents the count of values.
 
-The function returns `0` if all values are MISSING, NULL, or empty.
+The function returns `0` if all values are `MISSING`, `NULL`, or empty.
 
 === Examples
 
@@ -394,6 +403,8 @@ You can specify a quantifier to control which numeric values to include:
 * `ALL` - Counts every numeric value.
 By default, the function uses this quantifier.
 * `DISTINCT` - Counts only unique numeric values and ignores duplicates.
+
+For more information, see <<aggregate-quantifier>>.
 
 === Arguments
 
@@ -453,23 +464,37 @@ AS input;
 [[max,MAX()]]
 == MAX( {startsb} ALL | DISTINCT {endsb} `expression`)
 
+=== Description
+
+Returns the maximum value in an expression.
+The function ignores `MISSING` and `NULL` values.
+
+When comparing values of different data types, the function uses {sqlpp} xref:n1ql-language-reference/datatypes.adoc#collation[collation rules] to determine precedence.
+
+NOTE: The `ALL` and `DISTINCT` quantifiers do not affect the result of this function. 
+The maximum value remains the same whether or not duplicates are included.
+
+=== Arguments
+
+See <<aggregate-syntax>>.
+
 === Return Value
 
-Returns the maximum non-NULL, non-MISSING value in the group in {sqlpp} collation order.
+The function returns 1 of the following:
 
-This function returns the same result with the `ALL` quantifier, the `DISTINCT` quantifier, or no quantifier.
+* The maximum value in the group.
+* `NULL` if all values are either `MISSING` or `NULL`.
 
 === Examples
-include::ROOT:partial$query-context.adoc[tag=section]
 
-.Max of an integer field
+.Maximum value in a numeric list
 ====
-Find the northernmost latitude of any hotel in the `hotel` keyspace:
-
 .Query
 [source,sqlpp]
 ----
-SELECT MAX(geo.lat) AS MaxLatitude FROM hotel;
+SELECT MAX(input) AS max_value
+FROM [1, 3, 2, 3, MISSING, NULL]
+AS input;
 ----
 
 .Results
@@ -477,20 +502,20 @@ SELECT MAX(geo.lat) AS MaxLatitude FROM hotel;
 ----
 [
   {
-    "MaxLatitude": 60.15356
+    "max_value": 3
   }
 ]
 ----
 ====
 
-.Max of a string field
+.Maximum value in a list with mixed types
 ====
-Find the hotel whose name is last alphabetically in the `hotel` keyspace:
-
 .Query
 [source,sqlpp]
 ----
-SELECT MAX(name) AS MaxName FROM hotel;
+SELECT MAX(input) AS max_value
+FROM [1, 2, 3, "airline", "2025-12-01T00:00:00Z", NULL]
+AS input;
 ----
 
 .Results
@@ -498,23 +523,21 @@ SELECT MAX(name) AS MaxName FROM hotel;
 ----
 [
   {
-    "MaxName": "pentahotel Birmingham"
+    "max_value": "airline"
   }
 ]
 ----
+The function returns "airline" because strings have a higher precedence than numbers and dates. 
 ====
 
-That result might have been surprising since lowercase letters come after uppercase letters and are therefore "higher" than uppercase letters.
-To avoid this uppercase/lowercase confusion, you should first make all values uppercase or lowercase, as in the following example.
-
-.Max of a string field, regardless of case
+.Maximum value in a string list
 ====
-Find the hotel whose name is last alphabetically in the `hotel` keyspace:
-
 .Query
 [source,sqlpp]
 ----
-SELECT MAX(UPPER(name)) AS MaxName FROM hotel;
+SELECT MAX(input) AS max_value
+FROM ["United", "Delta", "American", "Southwest"]
+AS input;
 ----
 
 .Results
@@ -522,41 +545,56 @@ SELECT MAX(UPPER(name)) AS MaxName FROM hotel;
 ----
 [
   {
-    "MaxName": "YOSEMITE LODGE AT THE FALLS"
+    "max_value": "United"
   }
 ]
 ----
+When comparing string values, the function uses alphabetical order to determine the maximum value.
 ====
 
 [[mean,MEAN()]]
 == [[mean_distinct]]MEAN( {startsb} ALL | DISTINCT {endsb} `expression`)
 
-Alias for <<avg>>.
+Synonym of <<avg>>.
 
 [[median,MEDIAN()]]
 == [[median_distinct]]MEDIAN( {startsb} ALL | DISTINCT {endsb} `expression`)
 
+=== Description
+
+Returns the median of all numeric values in an expression.
+
+You can specify a quantifier to control which values to include in the calculation:
+
+* `ALL` - Includes every numeric value.
+By default, the function uses this quantifier.
+* `DISTINCT` - Includes only unique numeric values and ignores duplicates.
+
+For more information, see <<aggregate-quantifier>>.
+
+=== Arguments
+
+See <<aggregate-syntax>>.
+
 === Return Value
 
-With the `ALL` quantifier, or no quantifier, returns the median of all the number values in the group.
-If there is an even number of number values, returns the mean of the median two values.
+The function returns 1 of the following:
 
-With the `DISTINCT` quantifier, returns the median of all the distinct number values in the group.
-If there is an even number of distinct number values, returns the mean of the median two values.
-
-Returns NULL if there are no number values in the group.
+* A number that represents the median value.
+* A number that represents the mean of the two median values if there is an even number of numeric values.
+* NULL if there are no numeric values in the group.
 
 === Examples
-include::ROOT:partial$query-context.adoc[tag=section]
 
+.Find the median of all values with an odd count
 ====
-Find the median altitude of airports in the `airport` keyspace:
 
 .Query
 [source,sqlpp]
 ----
-SELECT MEDIAN(geo.alt) AS MedianAltitude
-FROM airport;
+SELECT MEDIAN(input) AS median_value
+FROM [1, 2, 3, 3, 4, MISSING, NULL, "abc"]
+AS input;
 ----
 
 .Results
@@ -564,19 +602,22 @@ FROM airport;
 ----
 [
   {
-    "MedianAltitude": 361.5
-  }
+    "median_value": 3
+ }
 ]
 ----
+Since the number of numeric values is odd, the median is the middle value (`3`).
 ====
 
+.Find the median of all values with an even count
 ====
-Find the median of distinct altitudes of airports in the `airport` keyspace:
 
 .Query
 [source,sqlpp]
 ----
-SELECT MEDIAN(DISTINCT geo.alt) AS MedianAltitude FROM airport;
+SELECT MEDIAN(input) AS median_value
+FROM [1, 2, 3, 3, 4, 4, MISSING, NULL, "abc"]
+AS input;
 ----
 
 .Results
@@ -584,101 +625,162 @@ SELECT MEDIAN(DISTINCT geo.alt) AS MedianAltitude FROM airport;
 ----
 [
   {
-    "MedianDistinctAltitude": 758
+    "median_value": 3
+ }
+]
+----
+Since the count of numeric values is even, the median is the mean of the two middle values (`3` and `3`), which is `3`.
+====
+
+.Find the median of distinct values
+====
+.Query
+[source,sqlpp]
+----
+SELECT MEDIAN(DISTINCT input) AS median_value
+FROM [1, 2, 3, 3, 4, 4, MISSING, NULL, "abc"]
+AS input;
+----  
+
+.Results
+[source,json]
+----
+[
+  {
+    "median_value": 2.5
   }
 ]
 ----
+Since the count of distinct numeric values is even, the median is the mean of the two middle values (`2` and `3`), which is `2.5`.
 ====
 
 [[min,MIN()]]
 == MIN( {startsb} ALL | DISTINCT {endsb} `expression`)
 
+=== Description
+
+Returns the minimum value in an expression.
+The function ignores `MISSING` and `NULL` values.
+
+When comparing values of different data types, the function uses {sqlpp} xref:n1ql-language-reference/datatypes.adoc#collation[collation rules] to determine precedence.
+
+NOTE: The `ALL` and `DISTINCT` quantifiers do not affect the result of this function.
+The minimum value remains the same whether or not duplicates are included.
+
+=== Arguments
+
+See <<aggregate-syntax>>.
+
 === Return Value
 
-Returns the minimum non-NULL, non-MISSING value in the group in {sqlpp} collation order.
+The function returns 1 of the following:
 
-This function returns the same result with the `ALL` quantifier, the `DISTINCT` quantifier, or no quantifier.
+* The minimum value in the group.
+* `NULL` if all values are either `MISSING` or `NULL`.
 
 === Examples
-include::ROOT:partial$query-context.adoc[tag=section]
 
-.Min of an integer field
+.Find the minimum value in a numeric list
 ====
-Find the southernmost latitude of any hotel in the `hotel` keyspace:
 
 .Query
 [source,sqlpp]
 ----
-include::example$functions/min-num.n1ql[]
+SELECT MIN(input) AS min_value
+FROM [3, 1, 2, 1, MISSING, NULL]
+AS input;
 ----
 
 .Results
 [source,json]
 ----
-include::example$functions/min-num.jsonc[]
+[
+  {
+    "min_value": 1
+  }
+]
 ----
 ====
 
-.Min of a string field
+.Find the minimum value in a list with mixed types
 ====
-Find the hotel whose name is first alphabetically in the `hotel` keyspace:
-
 .Query
 [source,sqlpp]
 ----
-include::example$functions/min-string.n1ql[]
+SELECT MIN(input) AS min_value
+FROM [1, 2, 3, "airline", "2025-12-01T00:00:00Z", NULL]
+AS input; 
 ----
 
 .Results
 [source,json]
 ----
-include::example$functions/min-string.jsonc[]
+[
+  {
+    "min_value": 1
+  }
+]
 ----
+The function returns `1` because numbers have a lower precedence than strings and dates.
 ====
 
-That result might have been surprising since some symbols come before letters and are therefore "lower" than letters.
-To avoid this symbol confusion, you can specify letters only, as in the following example.
-
-.Min of a string field, regardless of preceding non-letters
+.Find the minimum value in a string list
 ====
-Find the first hotel alphabetically in the `hotel` keyspace:
-
 .Query
 [source,sqlpp]
 ----
-include::example$functions/min-filter.n1ql[]
-----
-
+SELECT MIN(input) AS min_value
+FROM ["United", "Delta", "American", "Southwest"]
+AS input;
+----  
 .Results
 [source,json]
 ----
-include::example$functions/min-filter.jsonc[]
+[
+  {
+    "min_value": "American"
+  }
+]
 ----
+When comparing string values, the function uses alphabetical order to determine the minimum value.
 ====
 
 [[stddev,STDDEV()]]
 == [[stddev_distinct]]STDDEV( {startsb} ALL | DISTINCT {endsb} `expression`)
 
+=== Description
+
+Returns the <<eqn_samp_std_dev, corrected sample standard deviation>> of all numeric values in an expression.
+
+You can specify a quantifier to control which values to include in the calculation:
+* `ALL` - Includes every numeric value.
+By default, the function uses this quantifier.
+* `DISTINCT` - Includes only unique numeric values and ignores duplicates.
+
+For more information, see <<aggregate-quantifier>>.
+
+=== Arguments
+See <<aggregate-syntax>>.
+
 === Return Value
 
-With the `ALL` quantifier, or no quantifier, returns the <<eqn_samp_std_dev,corrected sample standard deviation>> of all the number values in the group.
+The function returns 1 of the following:
 
-With the `DISTINCT` quantifier, returns the <<eqn_samp_std_dev,corrected sample standard deviation>> of all the distinct number values in the group.
-
-Returns NULL if there are no number values in the group.
+* A number that represents the corrected sample standard deviation.
+* `0` if the group contains only 1 numeric value.
+* NULL if there are no numeric values in the group.
 
 === Examples
-include::ROOT:partial$query-context.adoc[tag=section]
 
+.Find the sample standard deviation of all values
 ====
-Find the sample standard deviation of all values:
 
 .Query
 [source,sqlpp]
 ----
-SELECT STDDEV(reviews[0].ratings.Cleanliness) AS StdDev
-FROM hotel
-WHERE city="London";
+SELECT STDDEV(input) AS std_dev_all
+FROM [1, 2, 3, 4, 4, MISSING, NULL, "abc"]
+AS input;
 ----
 
 .Results
@@ -686,45 +788,41 @@ WHERE city="London";
 ----
 [
   {
-    "StdDev": 2.0554275433769753
+    "std_dev_all": 1.3038404810405297
   }
 ]
 ----
 ====
 
+.Find the sample standard deviation when there is only one numeric value
 ====
-Find the sample standard deviation of a single value:
-
 .Query
 [source,sqlpp]
 ----
-SELECT STDDEV(reviews[0].ratings.Cleanliness) AS StdDevSingle
-FROM hotel
-WHERE name="Sachas Hotel";
+SELECT STDDEV(input) AS std_dev_single
+FROM [3, NULL, "abc"]
+AS input;
 ----
-
 .Results
 [source,json]
 ----
 [
   {
-    "StdDevSingle": 0 <1>
+    "std_dev_single": 0
   }
 ]
 ----
-
-<1> There is only one matching result in the input, so the function returns `0`.
+There is only one numeric value in the input, so the standard deviation is `0`.
 ====
 
+.Find the sample standard deviation of distinct values
 ====
-Find the sample standard deviation of distinct values:
-
 .Query
 [source,sqlpp]
 ----
-SELECT STDDEV(DISTINCT reviews[0].ratings.Cleanliness) AS StdDev
-FROM hotel
-WHERE city="London";
+SELECT STDDEV(DISTINCT input) AS std_dev_distinct
+FROM [1, 2, 2, 3, 4, 4, MISSING, NULL, "abc"]
+AS input; 
 ----
 
 .Results
@@ -732,7 +830,7 @@ WHERE city="London";
 ----
 [
   {
-    "StdDevDistinct": 2.1602468994692865
+    "std_dev_distinct": 1.2909944487358056
   }
 ]
 ----
@@ -741,26 +839,39 @@ WHERE city="London";
 [[stddev_pop,STDDEV_POP()]]
 == [[stddev_pop_distinct]]STDDEV_POP( {startsb} ALL | DISTINCT {endsb} `expression`)
 
+=== Description
+
+Returns the <<eqn_pop_std_dev,population standard deviation>> of all numeric values in an expression.
+
+You can specify a quantifier to control which values to include in the calculation:
+
+* `ALL` - Includes every numeric value.
+By default, the function uses this quantifier.
+* `DISTINCT` - Includes only unique numeric values and ignores duplicates.
+
+For more information, see <<aggregate-quantifier>>.
+
+=== Arguments
+See <<aggregate-syntax>>.
+
 === Return Value
 
-With the `ALL` quantifier, or no quantifier, returns the <<eqn_pop_std_dev,population standard deviation>> of all the number values in the group.
+The function returns 1 of the following:
 
-With the `DISTINCT` quantifier, returns the <<eqn_pop_std_dev,population standard deviation>> of all the distinct number values in the group.
-
-Returns NULL if there are no number values in the group.
+* A number that represents the population standard deviation.
+* `0` if the group contains only 1 numeric value.
+* NULL if there are no numeric values in the group.
 
 === Examples
-include::ROOT:partial$query-context.adoc[tag=section]
 
+.Find the population standard deviation of all values
 ====
-Find the population standard deviation of all values:
-
 .Query
 [source,sqlpp]
 ----
-SELECT STDDEV_POP(reviews[0].ratings.Cleanliness) AS PopStdDev
-FROM hotel
-WHERE city="London";
+SELECT STDDEV_POP(input) AS pop_std_dev
+FROM [1, 2, 3, 4, 4, MISSING, NULL, "abc"]
+AS input;
 ----
 
 .Results
@@ -768,21 +879,20 @@ WHERE city="London";
 ----
 [
   {
-    "PopStdDev": 2.0390493736539432
+    "pop_std_dev": 1.16619037896906
   }
 ]
 ----
 ====
 
+.Find the population standard deviation of distinct values
 ====
-Find the population standard deviation of distinct values:
-
 .Query
 [source,sqlpp]
 ----
-SELECT STDDEV_POP(DISTINCT reviews[0].ratings.Cleanliness) AS PopStdDev
-FROM hotel
-WHERE city="London";
+SELECT STDDEV_POP(DISTINCT input) AS pop_std_dev_distinct
+FROM [1, 2, 2, 3, 4, 4, MISSING, NULL, "abc"]
+AS input; 
 ----
 
 .Results
@@ -790,7 +900,7 @@ WHERE city="London";
 ----
 [
   {
-      "PopStdDevDistinct": 1.9720265943665387
+    "pop_std_dev_distinct": 1.118033988749895
   }
 ]
 ----
@@ -799,21 +909,34 @@ WHERE city="London";
 [[stddev_samp,STDDEV_SAMP()]]
 == [[stddev_samp_distinct]]STDDEV_SAMP( {startsb} ALL | DISTINCT {endsb} `expression`)
 
-A near-synonym for <<stddev>>.
-The only difference is that `STDDEV_SAMP()` returns NULL if there is only one matching element.
+=== Description
+
+Returns the <<eqn_samp_std_dev, corrected sample standard deviation>> of all numeric values in an expression.
+
+The function is similar to <<stddev>>, but it returns `NULL` if there is only one matching element. 
+
+
+=== Arguments
+
+See <<aggregate-syntax>>.
+
+=== Return Value
+
+The function returns 1 of the following:
+
+* A number that represents the corrected sample standard deviation.
+* NULL if there are fewer than 2 numeric values in the group.
 
 === Example
-include::ROOT:partial$query-context.adoc[tag=section]
 
+.Find the sample standard deviation
 ====
-Find the sample standard deviation of a single value:
-
 .Query
 [source,sqlpp]
 ----
-SELECT STDDEV_SAMP(reviews[0].ratings.Cleanliness) AS StdDevSingle
-FROM hotel
-WHERE name="Sachas Hotel";
+SELECT STDDEV_SAMP(input) AS std_dev_sample
+FROM [3, NULL, "abc"]
+AS input;
 ----
 
 .Results
@@ -821,59 +944,48 @@ WHERE name="Sachas Hotel";
 ----
 [
   {
-    "StdDevSamp": null <1>
+    "std_dev_sample": null
   }
 ]
 ----
-
-<1> There is only one matching result in the input, so the function returns NULL.
+There is only one numeric value in the group, so the function returns NULL.
 ====
 
 [[sum,SUM()]]
 == [[sum_distinct]]SUM( {startsb} ALL | DISTINCT {endsb} `expression`)
 
+=== Description
+
+Returns the arithmetic sum of all number values in an expression. 
+
+You can specify a quantifier to control which values to include in the calculation:
+* `ALL` - Includes every number value.
+By default, the function uses this quantifier.
+* `DISTINCT` - Includes only unique number values and ignores duplicates.
+
+For more information, see <<aggregate-quantifier>>.
+
+=== Arguments
+
+See <<aggregate-syntax>>.
+
 === Return Value
 
-With the `ALL` quantifier, or no quantifier, returns the sum of all the number values in the group.
+The function returns 1 of the following:
 
-With the `DISTINCT` quantifier, returns the arithmetic sum of all the distinct number values in the group.
-
-Returns NULL if there are no number values in the group.
+* A number that represents the arithmetic sum.
+* NULL if there are no number values in the group.
 
 === Examples
-include::ROOT:partial$query-context.adoc[tag=section]
 
+.Find the sum total of all numbers
 ====
-Find the sum total of all airline route stops in the `route` keyspace:
-
 .Query
 [source,sqlpp]
 ----
-SELECT SUM(stops) AS SumOfStops FROM route;
-----
-
-NOTE: In the `route` keyspace, nearly all flights are non-stop (0 stops) and only six flights have 1 stop, so we expect 6 flights of 1 stop each, a total of 6.
-
-.Results
-[source,json]
-----
-[
-  {
-    "SumOfStops": 6 <1>
-  }
-]
-----
-
-<1> There are 6 routes with 1 stop each.
-====
-
-====
-Find the sum total of all unique numbers of airline route stops in the `route` keyspace:
-
-.Query
-[source,sqlpp]
-----
-SELECT SUM(DISTINCT stops) AS SumOfStops FROM route;
+SELECT SUM(input) AS total_sum
+FROM [1, 2, 3, 4, 4, MISSING, NULL, "abc"]
+AS input;
 ----
 
 .Results
@@ -881,40 +993,72 @@ SELECT SUM(DISTINCT stops) AS SumOfStops FROM route;
 ----
 [
   {
-    "SumOfDistinctStops": 1 <1>
+    "total_sum": 14
   }
 ]
 ----
+====
 
-<1> There are only 0 and 1 stops per route; and 0 + 1 = 1.
+.Find the sum total of distinct numbers
+====
+.Query
+[source,sqlpp]
+----
+SELECT SUM(DISTINCT input) AS total_sum
+FROM [1, 2, 3, 4, 4, MISSING, NULL, "abc"]
+AS input;
+----
+
+.Results
+[source,json]
+----
+[
+  {
+    "total_sum": 10
+  }
+]
+----
 ====
 
 [[variance,VARIANCE()]]
 == [[variance_distinct]]VARIANCE( {startsb} ALL | DISTINCT {endsb} `expression`)
 
+=== Description
+
+Returns the unbiased sample variance (the square of the <<eqn_samp_std_dev,corrected sample standard deviation>>) of all numeric values in an expression.
+
+You can specify a quantifier to control which values to include in the calculation:
+* `ALL` - Includes every numeric value.
+By default, the function uses this quantifier.
+* `DISTINCT` - Includes only unique numeric values and ignores duplicates.
+
+For more information, see <<aggregate-quantifier>>.
+
+NOTE: This function is similar to <<variance_samp>>, but it returns `0` if there is only one matching element.
+Whereas `VARIANCE_SAMP()` returns `NULL` in that case.
+
+=== Arguments
+
+See <<aggregate-syntax>>.
+
 === Return Value
 
-With the `ALL` quantifier, or no quantifier, returns the unbiased sample variance (the square of the <<eqn_samp_std_dev,corrected sample standard deviation>>) of all the number values in the group.
+The function returns 1 of the following:
 
-With the `DISTINCT` quantifier, returns the unbiased sample variance (the square of the <<eqn_samp_std_dev,corrected sample standard deviation>>) of all the distinct number values in the group.
-
-Returns NULL if there are no number values in the group.
-
-This function has a near-synonym <<variance_samp>>.
-The only difference is that `VARIANCE()` returns NULL if there is only one matching element.
+* A number that represents the unbiased sample variance.
+* `0` if the group contains only 1 numeric value.
+* NULL if there are no numeric values in the group.
 
 === Examples
-include::ROOT:partial$query-context.adoc[tag=section]
 
+.Find the sample variance of all values
 ====
-Find the sample variance of all values:
-
 .Query
 [source,sqlpp]
 ----
-SELECT VARIANCE(reviews[0].ratings.Cleanliness) AS Variance
-FROM hotel
-WHERE city="London";
+SELECT VARIANCE(input) AS variance
+FROM [1, 2, 3, 4, 4, MISSING, NULL, "abc"]
+AS input;
 ----
 
 .Results
@@ -922,21 +1066,20 @@ WHERE city="London";
 ----
 [
   {
-    "Variance": 4.224782386072708
+    "variance": 1.7
   }
 ]
 ----
 ====
 
+.Find the sample variance of a single numeric value
 ====
-Find the sample variance of a single value:
-
 .Query
 [source,sqlpp]
 ----
-SELECT VARIANCE(reviews[0].ratings.Cleanliness) AS VarianceSingle
-FROM hotel
-WHERE name="Sachas Hotel";
+SELECT VARIANCE(input) AS variance_single
+FROM [3, NULL, "abc"]
+AS input;
 ----
 
 .Results
@@ -944,23 +1087,21 @@ WHERE name="Sachas Hotel";
 ----
 [
   {
-    "VarianceSingle": 0 <1>
+    "variance_single": 0
   }
 ]
 ----
-
-<1> There is only one matching result in the input, so the function returns `0`.
+There is only matching value in the input, so the variance is `0`.
 ====
 
+.Find the sampling variance of distinct values
 ====
-Find the sampling variance of distinct values:
-
 .Query
 [source,sqlpp]
 ----
-SELECT VARIANCE(DISTINCT reviews[0].ratings.Cleanliness) AS Variance
-FROM hotel
-WHERE city="London";
+SELECT VARIANCE(DISTINCT input) AS variance
+FROM [1, 2, 3, 4, 4, MISSING, NULL, "abc"]
+AS input;
 ----
 
 .Results
@@ -968,7 +1109,7 @@ WHERE city="London";
 ----
 [
   {
-    "VarianceDistinct": 4.666666666666667
+    "variance": 1.6666666666666667
   }
 ]
 ----
@@ -977,28 +1118,40 @@ WHERE city="London";
 [[variance_pop,VARIANCE_POP()]]
 == [[variance_pop_distinct]]VARIANCE_POP( {startsb} ALL | DISTINCT {endsb} `expression`)
 
-This function has an alias <<var_pop>>.
+This function has a synonym <<var_pop>>.
+
+=== Description
+
+Returns the population variance (the square of the <<eqn_pop_std_dev,population standard deviation>>) of all numeric values in an expression.
+
+You can specify a quantifier to control which values to include in the calculation:
+* `ALL` - Includes every numeric value.
+By default, the function uses this quantifier.
+* `DISTINCT` - Includes only unique numeric values and ignores duplicates.
+
+For more information, see <<aggregate-quantifier>>.
+
+=== Arguments
+
+See <<aggregate-syntax>>.
 
 === Return Value
 
-With the `ALL` quantifier, or no quantifier, returns the population variance (the square of the <<eqn_pop_std_dev,population standard deviation>>) of all the number values in the group.
+The function returns 1 of the following:
 
-With the `DISTINCT` quantifier, returns the population variance (the square of the <<eqn_pop_std_dev,population standard deviation>>) of all the distinct number values in the group.
-
-Returns NULL if there are no number values in the group.
+* A number that represents the population variance.
+* NULL if there are no numeric values in the group.
 
 === Examples
-include::ROOT:partial$query-context.adoc[tag=section]
 
+.Find the population variance of all values
 ====
-Find the population variance of all values:
-
 .Query
 [source,sqlpp]
 ----
-SELECT VARIANCE_POP(reviews[0].ratings.Cleanliness) AS PopVariance
-FROM hotel
-WHERE city="London";
+SELECT VARIANCE_POP(input) AS pop_variance_all
+FROM [1, 2, 3, 4, 4, MISSING, NULL, "abc"]
+AS input;
 ----
 
 .Results
@@ -1006,21 +1159,20 @@ WHERE city="London";
 ----
 [
   {
-    "PopVariance": 4.157722348198537
+    "pop_variance_all": 1.3599999999999999
   }
 ]
 ----
 ====
 
+.Find the population variance of distinct values
 ====
-Find the population variance of distinct values:
-
 .Query
 [source,sqlpp]
 ----
-SELECT VARIANCE_POP(DISTINCT reviews[0].ratings.Cleanliness) AS PopVarianceDistinct
-FROM hotel
-WHERE city="London";
+SELECT VARIANCE_POP(DISTINCT input) AS pop_variance_distinct
+FROM [1, 2, 3, 4, 4, MISSING, NULL, "abc"]
+AS input;
 ----
 
 .Results
@@ -1028,7 +1180,7 @@ WHERE city="London";
 ----
 [
   {
-      "PopVarianceDistinct": 3.8888888888888893
+    "pop_variance_distinct": 1.25
   }
 ]
 ----
@@ -1037,23 +1189,42 @@ WHERE city="London";
 [[variance_samp,VARIANCE_SAMP()]]
 == [[variance_samp_distinct]]VARIANCE_SAMP( {startsb} ALL | DISTINCT {endsb} `expression`)
 
-A near-synonym for <<variance>>.
-The only difference is that `VARIANCE_SAMP()` returns NULL if there is only one matching element.
+This function has a synonym <<var_samp>>.
 
-This function has an alias <<var_samp>>.
+=== Description
 
-=== Example
-include::ROOT:partial$query-context.adoc[tag=section]
+Returns the unbiased sample variance (the square of the <<eqn_samp_std_dev,corrected sample standard deviation>>) of all numeric values in an expression.
 
+You can specify a quantifier to control which values to include in the calculation:
+* `ALL` - Includes every numeric value.
+By default, the function uses this quantifier.
+* `DISTINCT` - Includes only unique numeric values and ignores duplicates.
+
+For more information, see <<aggregate-quantifier>>.
+
+NOTE: This function is similar to <<variance>>, but it returns `NULL` when there is only one matching element.
+Whereas `VARIANCE()` returns `0` in that case.
+
+=== Arguments
+
+See <<aggregate-syntax>>.
+
+=== Return Value
+
+The function returns 1 of the following:
+* A number that represents the unbiased sample variance.
+* NULL if there is fewer than 2 numeric values in the group.
+
+=== Examples
+
+.Find the sample standard deviation of all values
 ====
-Find the sample standard deviation of a single value:
-
 .Query
 [source,sqlpp]
 ----
-SELECT VARIANCE_SAMP(reviews[0].ratings.Cleanliness) AS VarianceSamp
-FROM hotel
-WHERE name="Sachas Hotel";
+SELECT VARIANCE_SAMP(input) AS variance_samp
+FROM [1, 2, 3, 4, 4, MISSING, NULL, "abc"]
+AS input;
 ----
 
 .Results
@@ -1061,23 +1232,42 @@ WHERE name="Sachas Hotel";
 ----
 [
   {
-    "VarianceSamp": null <1>
+    "variance_samp": 1.7
   }
 ]
 ----
+====
 
-<1> There is only one matching result in the input, so the function returns NULL.
+.Find the sample variance of a single numeric value
+====
+.Query
+[source,sqlpp]
+----
+SELECT VARIANCE_SAMP(input) AS variance_single
+FROM [3, NULL, "abc"]
+AS input;
+----
+
+.Results
+[source,json]
+----
+[
+  {
+    "variance_single": null
+  }
+]
+----
 ====
 
 [[var_pop,VAR_POP()]]
 == [[var_pop_distinct]]VAR_POP( {startsb} ALL | DISTINCT {endsb} `expression`)
 
-Alias for <<variance_pop>>.
+Synonym of <<variance_pop>>.
 
 [[var_samp,VAR_SAMP()]]
 == [[var_samp_distinct]]VAR_SAMP( {startsb} ALL | DISTINCT {endsb} `expression`)
 
-Alias for <<variance_samp>>.
+Synonym of <<variance_samp>>.
 
 == Formulas
 

--- a/modules/n1ql/pages/n1ql-language-reference/aggregatefun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/aggregatefun.adoc
@@ -75,7 +75,7 @@ You can use the quantifiers only with aggregate functions.
 `ALL`:: Includes all values in the computation.
 `DISTINCT`:: Includes only distinct values in the computation.
 
-The quantifiers are optional and the default value is `ALL`.
+These quantifiers are optional and the default value is `ALL`.
 
 [[filter-clause]]
 === FILTER Clause
@@ -553,7 +553,7 @@ See <<aggregate-syntax>>.
 The function returns 1 of the following:
 
 * A number that represents the median value.
-* A number that represents the mean of the 2 median values if the count of numeric values is even.
+* A number that represents the mean of the 2 median values if the number of numeric values is even.
 * `NULL` if there are no numeric values in the group.
 
 === Examples
@@ -624,7 +624,7 @@ AS input;
 ]
 ----
 In this example, the number of distinct numeric values is even.
-THerefore, the median is the mean of the 2 middle values (`2` and `3`), which is `2.5`.
+Therefore, the median is the mean of the 2 middle values (`2` and `3`), which is `2.5`.
 ====
 
 [[min,MIN()]]

--- a/modules/n1ql/pages/n1ql-language-reference/aggregatefun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/aggregatefun.adoc
@@ -123,16 +123,12 @@ All other aggregate functions return NULL.
 
 === Description
 
-This function takes all non-MISSING values from an expression and returns them as an array. 
-The function ignores MISSING values, but includes NULL values in the resulting array.
+Returns an array of non-MISSING values from an aggregated group.
 
-You can specify a quantifier to control what values to include in the resulting array:
-
-* `ALL` - includes every non-MISSING value.  
-By default, the function uses this quantifier.
-* `DISTINCT` - includes only distinct values and removes duplicates.
-
+You can use the `ALL` or `DISTINCT` quantifier to specify which values to include in the calculation.
 For more information, see <<aggregate-quantifier>>.
+
+The function ignores `MISSING` values, but includes `NULL` values.
 
 === Arguments
 
@@ -142,12 +138,12 @@ See <<aggregate-syntax>>.
 
 The function returns 1 of the following:
 
-* An array of aggregated values. 
-* NULL if all values in the group are either MISSING or empty.
+* An array of non-MISSING values. 
+* `NULL` if all values are `MISSING`.
 
 === Examples
 
-.Aggregate all values into an array
+.List all values into an array
 ====
 .Query
 [source,sqlpp]
@@ -175,7 +171,7 @@ AS input;
 ----
 ====
 
-.Aggregate distinct values into an array
+.List distinct values into an array
 ====
 .Query
 [source,sqlpp]
@@ -209,19 +205,10 @@ This function has a synonym <<mean>>.
 
 === Description
 
-Returns the arithmetic mean (average) of all numeric values in an expression.
+Returns the arithmetic mean (average) of all numeric values in an aggregated group.
 
-//tag::quantifiers[]
-
-You can specify a quantifier to control what values to include in the calculation.
-
-* `ALL` - Includes every numeric value.
-By default, the function uses this quantifier.
-* `DISTINCT` - Includes only unique numeric values and ignores duplicates.
-
+You can use the `ALL` or `DISTINCT` quantifier to specify which values to include in the calculation.
 For more information, see <<aggregate-quantifier>>.
-
-//end::quantifiers[]
 
 ==== Arguments
 
@@ -231,82 +218,17 @@ See <<aggregate-syntax>>.
 
 The function returns 1 of the following:
 
-* A number that represents the arithmetic mean.
-* NULL if there are no numeric values in the group.
-
-It returns NULL if all values in the group are MISSING, non-numeric, or NULL.
+* A number that represents the mean.
+* `NULL` if all values are non-numeric, `MISSING`, or `NULL`.
 
 === Examples
 
-.Find the average of all numbers in a mixed array
+.Find the average of all numbers
 ====
 .Query
 [source,sqlpp]
 ----
-SELECT AVG(input) AS avg_number
-FROM [1, 1, 2, 2, 3, MISSING, NULL, "abc"]
-AS input;
-----
-
-.Results
-[source,json]
-----
-[{
-    "avg_number": 1.8
-}]
-----
-====
-
-.Find the average of distinct numbers in a mixed array
-====
-.Query
-[source,sqlpp]
-----
-SELECT AVG(DISTINCT input) AS avg_distinct_number
-FROM [1, 1, 2, 2, 3, MISSING, NULL, "abc"]
-AS input;
-----
-
-.Results
-[source,sqlpp]
-----
-[{
-    "avg_distinct_number": 2
-}]
-----
-The calculation considers only the distinct numeric values and the average is (1 + 2 + 3) / 3 = 2.
-====
-
-[[count_all,COUNT(*)]]
-== COUNT(*)
-
-=== Description
-
-Returns the count of all input rows in an aggregated group. footnote:count[{doc-count}]
-
-The wildcard (*) indicates all rows are to be counted, including rows with `NULL` and `MISSING` values.
-
-TIP: To count only non-NULL and non-MISSING values in an expression, use <<count, COUNT(expression)>>.
-
-=== Arguments
-
-This function does not take any arguments. 
-
-=== Return Value
-
-A number that represents the count of all rows. 
-
-The function returns `0` if the group is empty. 
-
-=== Example
-
-.Count all values in a mixed array
-====
-
-.Query
-[source,sqlpp]
-----
-SELECT COUNT(*) AS count_all
+SELECT AVG(input) AS avg_all
 FROM [1, 1, 2, 2, 3, MISSING, NULL, "abc"]
 AS input;
 ----
@@ -316,7 +238,74 @@ AS input;
 ----
 [
   {
-    "count_all": 8
+    "avg_all": 1.8
+  }
+]
+----
+====
+
+.Find the average of distinct numbers
+====
+.Query
+[source,sqlpp]
+----
+SELECT AVG(DISTINCT input) AS avg_distinct
+FROM [1, 1, 2, 2, 3, MISSING, NULL, "abc"]
+AS input;
+----
+
+.Results
+[source,sqlpp]
+----
+[
+  {
+    "avg_distinct": 2
+  }
+]
+----
+In this example, the average is (1 + 2 + 3) / 3 = 2.
+====
+
+[[count_all,COUNT(*)]]
+== COUNT(`*`)
+
+=== Description
+
+Returns the total count of all rows in an aggregated group. footnote:count[{doc-count}]
+
+The `*` wildcard indicates that the function should count all rows, including those with `NULL` and `MISSING` values.
+
+TIP: To get the count of only non-NULL and non-MISSING values in a group, use <<count, COUNT(expression)>>.
+
+=== Arguments
+
+This function does not take any arguments. 
+
+=== Return Value
+
+The function returns 1 of the following:
+
+* A number that represents the count of all rows. 
+* `0` if the group is empty. 
+
+=== Example
+
+.Find the count of all rows 
+====
+.Query
+[source,sqlpp]
+----
+SELECT COUNT(*) AS count_all_rows
+FROM [1, 1, 2, 2, 3, MISSING, NULL, "abc"]
+AS input;
+----
+
+.Results
+[source,json]
+----
+[
+  {
+    "count_all_rows": 8
   }
 ]
 ----
@@ -327,29 +316,23 @@ AS input;
 
 === Description
 
-Returns the count of non-NULL and non-MISSING values in an expression. footnote:count[]
+Returns the count of all non-NULL and non-MISSING values in an aggregated group. footnote:count[]
 
-You can specify a quantifier to control which values to count: 
+You can use the `ALL` or `DISTINCT` quantifier to specify which values to include in the calculation.
+For more information, see <<aggregate-quantifier>>.
 
-* `ALL` - Counts every value in the expression.
-By default, the function uses this quantifier.
-* `DISTINCT` - Counts only unique values and ignores duplicates.
-
-In both cases, the function ignores `MISSING` and `NULL` values.
-
-For more information about quantifiers, see <<aggregate-quantifier>>.
-
-TIP: To count all values including `NULL` and `MISSING`, use <<count_all, COUNT(*)>>.
+TIP: To get the count of all rows, including those with `NULL` and `MISSING` values, use <<count_all, COUNT(*)>>.
 
 === Return Value
 
-A number that represents the count of values.
+The function returns 1 of the following:
 
-The function returns `0` if all values are `MISSING`, `NULL`, or empty.
+* A number that represents the count. 
+* `0` if all values are `MISSING` or `NULL`.
 
 === Examples
 
-.Count all values 
+.Find the count of all values 
 ====
 .Query
 [source,sqlpp]
@@ -370,12 +353,12 @@ AS input;
 ----
 ====
 
-.Count unique values
+.Find the count of distinct values 
 ====
 .Query
 [source,sqlpp]
 ----
-SELECT COUNT(DISTINCT input) AS count_all
+SELECT COUNT(DISTINCT input) AS count_distinct
 FROM [1, 1, 2, 2, 3, MISSING, NULL, "abc"]
 AS input;
 ----
@@ -385,7 +368,7 @@ AS input;
 ----
 [
   {
-    "count_all": 4
+    "count_distinct": 4
   }
 ]
 ----
@@ -396,14 +379,9 @@ AS input;
 
 === Description
 
-Returns the count of numeric values in an expression. footnote:count[]
+Returns the count of numeric values in an aggregated group. footnote:count[]
 
-You can specify a quantifier to control which numeric values to include: 
-
-* `ALL` - Counts every numeric value.
-By default, the function uses this quantifier.
-* `DISTINCT` - Counts only unique numeric values and ignores duplicates.
-
+You can use the `ALL` or `DISTINCT` quantifier to specify which values to include in the calculation.
 For more information, see <<aggregate-quantifier>>.
 
 === Arguments
@@ -412,13 +390,14 @@ See <<aggregate-syntax>>.
 
 === Return Value
 
-A number that represents the count of numeric values.
+The function returns 1 of the following:
 
-The function returns `0` if there are no numeric values.
+* A number that represents the count.
+* `0` if there are no numeric values.
 
 === Examples
 
-.Count all numeric values 
+.Find the count of all numeric values 
 ====
 .Query
 [source,sqlpp]
@@ -439,7 +418,7 @@ AS input;
 ----
 ====
 
-.Count distinct numeric values 
+.Find the count of distinct numeric values 
 ==== 
 
 .Query
@@ -466,7 +445,7 @@ AS input;
 
 === Description
 
-Returns the maximum value in an expression.
+Returns the maximum value in an aggregated group.
 The function ignores `MISSING` and `NULL` values.
 
 When comparing values of different data types, the function uses {sqlpp} xref:n1ql-language-reference/datatypes.adoc#collation[collation rules] to determine precedence.
@@ -487,12 +466,12 @@ The function returns 1 of the following:
 
 === Examples
 
-.Maximum value in a numeric list
+.Find the max value from a group of numbers
 ====
 .Query
 [source,sqlpp]
 ----
-SELECT MAX(input) AS max_value
+SELECT MAX(input) AS max_value_num
 FROM [1, 3, 2, 3, MISSING, NULL]
 AS input;
 ----
@@ -502,18 +481,18 @@ AS input;
 ----
 [
   {
-    "max_value": 3
+    "max_value_num": 3
   }
 ]
 ----
 ====
 
-.Maximum value in a list with mixed types
+.Find the max value from a group with mixed types
 ====
 .Query
 [source,sqlpp]
 ----
-SELECT MAX(input) AS max_value
+SELECT MAX(input) AS max_value_all
 FROM [1, 2, 3, "airline", "2025-12-01T00:00:00Z", NULL]
 AS input;
 ----
@@ -523,19 +502,19 @@ AS input;
 ----
 [
   {
-    "max_value": "airline"
+    "max_value_all": "airline"
   }
 ]
 ----
-The function returns "airline" because strings have a higher precedence than numbers and dates. 
+The function returns `airline` because strings have a higher precedence than numbers and dates. 
 ====
 
-.Maximum value in a string list
+.Find the max value from a group of strings
 ====
 .Query
 [source,sqlpp]
 ----
-SELECT MAX(input) AS max_value
+SELECT MAX(input) AS max_value_string
 FROM ["United", "Delta", "American", "Southwest"]
 AS input;
 ----
@@ -545,7 +524,7 @@ AS input;
 ----
 [
   {
-    "max_value": "United"
+    "max_value_string": "United"
   }
 ]
 ----
@@ -562,14 +541,9 @@ Synonym of <<avg>>.
 
 === Description
 
-Returns the median of all numeric values in an expression.
+Returns the median of all numeric values in an aggregated group.
 
-You can specify a quantifier to control which values to include in the calculation:
-
-* `ALL` - Includes every numeric value.
-By default, the function uses this quantifier.
-* `DISTINCT` - Includes only unique numeric values and ignores duplicates.
-
+You can use the `ALL` or `DISTINCT` quantifier to specify which values to include in the calculation.
 For more information, see <<aggregate-quantifier>>.
 
 === Arguments
@@ -581,12 +555,12 @@ See <<aggregate-syntax>>.
 The function returns 1 of the following:
 
 * A number that represents the median value.
-* A number that represents the mean of the two median values if there is an even number of numeric values.
-* NULL if there are no numeric values in the group.
+* A number that represents the mean of the 2 median values if the count of numeric values is even.
+* `NULL` if there are no numeric values in the group.
 
 === Examples
 
-.Find the median of all values with an odd count
+.Find the median when the number of values is odd
 ====
 
 .Query
@@ -606,10 +580,10 @@ AS input;
  }
 ]
 ----
-Since the number of numeric values is odd, the median is the middle value (`3`).
+In this example, the median is the middle value `3`.
 ====
 
-.Find the median of all values with an even count
+.Find the median when the number of values is even
 ====
 
 .Query
@@ -629,7 +603,7 @@ AS input;
  }
 ]
 ----
-Since the count of numeric values is even, the median is the mean of the two middle values (`3` and `3`), which is `3`.
+In this example, the median is the mean of the 2 middle values (`3` and `3`), which is `3`.
 ====
 
 .Find the median of distinct values
@@ -651,7 +625,8 @@ AS input;
   }
 ]
 ----
-Since the count of distinct numeric values is even, the median is the mean of the two middle values (`2` and `3`), which is `2.5`.
+In this example, the number of distinct numeric values is even.
+THerefore, the median is the mean of the 2 middle values (`2` and `3`), which is `2.5`.
 ====
 
 [[min,MIN()]]
@@ -659,7 +634,7 @@ Since the count of distinct numeric values is even, the median is the mean of th
 
 === Description
 
-Returns the minimum value in an expression.
+Returns the minimum value in an aggregated group.
 The function ignores `MISSING` and `NULL` values.
 
 When comparing values of different data types, the function uses {sqlpp} xref:n1ql-language-reference/datatypes.adoc#collation[collation rules] to determine precedence.
@@ -680,13 +655,13 @@ The function returns 1 of the following:
 
 === Examples
 
-.Find the minimum value in a numeric list
+.Find the minimum value from a group of numbers
 ====
 
 .Query
 [source,sqlpp]
 ----
-SELECT MIN(input) AS min_value
+SELECT MIN(input) AS min_value_num
 FROM [3, 1, 2, 1, MISSING, NULL]
 AS input;
 ----
@@ -696,18 +671,18 @@ AS input;
 ----
 [
   {
-    "min_value": 1
+    "min_value_num": 1
   }
 ]
 ----
 ====
 
-.Find the minimum value in a list with mixed types
+.Find the minimum value from a group with mixed types
 ====
 .Query
 [source,sqlpp]
 ----
-SELECT MIN(input) AS min_value
+SELECT MIN(input) AS min_value_all
 FROM [1, 2, 3, "airline", "2025-12-01T00:00:00Z", NULL]
 AS input; 
 ----
@@ -717,19 +692,19 @@ AS input;
 ----
 [
   {
-    "min_value": 1
+    "min_value_all": 1
   }
 ]
 ----
 The function returns `1` because numbers have a lower precedence than strings and dates.
 ====
 
-.Find the minimum value in a string list
+.Find the minimum value from a group of strings
 ====
 .Query
 [source,sqlpp]
 ----
-SELECT MIN(input) AS min_value
+SELECT MIN(input) AS min_value_string 
 FROM ["United", "Delta", "American", "Southwest"]
 AS input;
 ----  
@@ -738,7 +713,7 @@ AS input;
 ----
 [
   {
-    "min_value": "American"
+    "min_value_string": "American"
   }
 ]
 ----
@@ -750,16 +725,16 @@ When comparing string values, the function uses alphabetical order to determine 
 
 === Description
 
-Returns the <<eqn_samp_std_dev, corrected sample standard deviation>> of all numeric values in an expression.
+Returns the <<eqn_samp_std_dev, corrected sample standard deviation>> of all numeric values in an aggregated group.
 
-You can specify a quantifier to control which values to include in the calculation:
-* `ALL` - Includes every numeric value.
-By default, the function uses this quantifier.
-* `DISTINCT` - Includes only unique numeric values and ignores duplicates.
-
+You can use the `ALL` or `DISTINCT` quantifier to specify which values to include in the calculation.
 For more information, see <<aggregate-quantifier>>.
 
+NOTE: This function is similar to <<stddev_samp>>. 
+However, it returns `0` if there is only 1 matching value, while <<stddev_samp>> returns `NULL` in such cases.
+
 === Arguments
+
 See <<aggregate-syntax>>.
 
 === Return Value
@@ -768,17 +743,17 @@ The function returns 1 of the following:
 
 * A number that represents the corrected sample standard deviation.
 * `0` if the group contains only 1 numeric value.
-* NULL if there are no numeric values in the group.
+* `NULL` if there are no numeric values in the group.
 
 === Examples
 
-.Find the sample standard deviation of all values
+.Find the standard deviation of all values
 ====
 
 .Query
 [source,sqlpp]
 ----
-SELECT STDDEV(input) AS std_dev_all
+SELECT STDDEV(input) AS std_deviation_all
 FROM [1, 2, 3, 4, 4, MISSING, NULL, "abc"]
 AS input;
 ----
@@ -788,39 +763,18 @@ AS input;
 ----
 [
   {
-    "std_dev_all": 1.3038404810405297
+    "std_deviation_all": 1.3038404810405297
   }
 ]
 ----
 ====
 
-.Find the sample standard deviation when there is only one numeric value
+.Find the standard deviation of distinct values
 ====
 .Query
 [source,sqlpp]
 ----
-SELECT STDDEV(input) AS std_dev_single
-FROM [3, NULL, "abc"]
-AS input;
-----
-.Results
-[source,json]
-----
-[
-  {
-    "std_dev_single": 0
-  }
-]
-----
-There is only one numeric value in the input, so the standard deviation is `0`.
-====
-
-.Find the sample standard deviation of distinct values
-====
-.Query
-[source,sqlpp]
-----
-SELECT STDDEV(DISTINCT input) AS std_dev_distinct
+SELECT STDDEV(DISTINCT input) AS std_deviation_distinct
 FROM [1, 2, 2, 3, 4, 4, MISSING, NULL, "abc"]
 AS input; 
 ----
@@ -830,7 +784,27 @@ AS input;
 ----
 [
   {
-    "std_dev_distinct": 1.2909944487358056
+    "std_deviation_distinct": 1.2909944487358056
+  }
+]
+----
+====
+
+.Find the standard deviation of a single numeric value
+====
+.Query
+[source,sqlpp]
+----
+SELECT STDDEV(input) AS std_deviation_single
+FROM [3, NULL, "abc"]
+AS input;
+----
+.Results
+[source,json]
+----
+[
+  {
+    "std_deviation_single": 0
   }
 ]
 ----
@@ -841,14 +815,9 @@ AS input;
 
 === Description
 
-Returns the <<eqn_pop_std_dev,population standard deviation>> of all numeric values in an expression.
+Returns the <<eqn_pop_std_dev,population standard deviation>> of all numeric values in an aggregated group.
 
-You can specify a quantifier to control which values to include in the calculation:
-
-* `ALL` - Includes every numeric value.
-By default, the function uses this quantifier.
-* `DISTINCT` - Includes only unique numeric values and ignores duplicates.
-
+You can use the `ALL` or `DISTINCT` quantifier to specify which values to include in the calculation.
 For more information, see <<aggregate-quantifier>>.
 
 === Arguments
@@ -858,9 +827,9 @@ See <<aggregate-syntax>>.
 
 The function returns 1 of the following:
 
-* A number that represents the population standard deviation.
+* A number that represents the population standard deviation. 
 * `0` if the group contains only 1 numeric value.
-* NULL if there are no numeric values in the group.
+* `NULL` if there are no numeric values in the group.
 
 === Examples
 
@@ -869,7 +838,7 @@ The function returns 1 of the following:
 .Query
 [source,sqlpp]
 ----
-SELECT STDDEV_POP(input) AS pop_std_dev
+SELECT STDDEV_POP(input) AS pop_deviation_all
 FROM [1, 2, 3, 4, 4, MISSING, NULL, "abc"]
 AS input;
 ----
@@ -879,7 +848,7 @@ AS input;
 ----
 [
   {
-    "pop_std_dev": 1.16619037896906
+    "pop_deviation_all": 1.16619037896906
   }
 ]
 ----
@@ -890,7 +859,7 @@ AS input;
 .Query
 [source,sqlpp]
 ----
-SELECT STDDEV_POP(DISTINCT input) AS pop_std_dev_distinct
+SELECT STDDEV_POP(DISTINCT input) AS pop_deviation_distinct
 FROM [1, 2, 2, 3, 4, 4, MISSING, NULL, "abc"]
 AS input; 
 ----
@@ -900,7 +869,7 @@ AS input;
 ----
 [
   {
-    "pop_std_dev_distinct": 1.118033988749895
+    "pop_deviation_distinct": 1.118033988749895
   }
 ]
 ----
@@ -911,10 +880,13 @@ AS input;
 
 === Description
 
-Returns the <<eqn_samp_std_dev, corrected sample standard deviation>> of all numeric values in an expression.
+Returns the <<eqn_samp_std_dev, corrected sample standard deviation>> of all numeric values in an aggregated group.
 
-The function is similar to <<stddev>>, but it returns `NULL` if there is only one matching element. 
+You can use the `ALL` or `DISTINCT` quantifier to specify which values to include in the calculation.
+For more information, see <<aggregate-quantifier>>.
 
+NOTE: This function is similar to <<stddev>>.
+However, it returns `NULL` if there is only 1 matching value, while <<stddev>> returns `0` in such cases.
 
 === Arguments
 
@@ -924,12 +896,54 @@ See <<aggregate-syntax>>.
 
 The function returns 1 of the following:
 
-* A number that represents the corrected sample standard deviation.
-* NULL if there are fewer than 2 numeric values in the group.
+* A number that represents the sample standard deviation.
+* `NULL` if there are fewer than 2 numeric values in the group.
 
 === Example
 
-.Find the sample standard deviation
+.Find the sample standard deviation of all values
+====
+.Query
+[source,sqlpp]
+----
+SELECT STDDEV_SAMP(input) AS std_deviation_all
+FROM [1, 2, 3, 4, 4, MISSING, NULL, "abc"]
+AS input;
+----
+
+.Results
+[source,json]
+----
+[
+  {
+    "std_deviation_all": 1.3038404810405297
+  }
+]
+----
+====
+
+.Find the sample standard deviation of distinct values
+====
+.Query
+[source,sqlpp]
+----
+SELECT STDDEV_SAMP(DISTINCT input) AS std_deviation_distinct
+FROM [1, 2, 2, 3, 4, 4, MISSING, NULL, "abc"]
+AS input;
+----  
+
+.Results
+[source,json]
+----
+[
+  {
+    "std_deviation_distinct": 1.2909944487358056
+  }
+]
+----
+====
+
+.Find the sample standard deviation of a single numeric value
 ====
 .Query
 [source,sqlpp]
@@ -948,7 +962,6 @@ AS input;
   }
 ]
 ----
-There is only one numeric value in the group, so the function returns NULL.
 ====
 
 [[sum,SUM()]]
@@ -956,13 +969,9 @@ There is only one numeric value in the group, so the function returns NULL.
 
 === Description
 
-Returns the arithmetic sum of all number values in an expression. 
+Returns the arithmetic sum of all number values in an aggregated group. 
 
-You can specify a quantifier to control which values to include in the calculation:
-* `ALL` - Includes every number value.
-By default, the function uses this quantifier.
-* `DISTINCT` - Includes only unique number values and ignores duplicates.
-
+You can use the `ALL` or `DISTINCT` quantifier to specify which values to include in the calculation.
 For more information, see <<aggregate-quantifier>>.
 
 === Arguments
@@ -973,17 +982,17 @@ See <<aggregate-syntax>>.
 
 The function returns 1 of the following:
 
-* A number that represents the arithmetic sum.
-* NULL if there are no number values in the group.
+* A number that represents the sum.
+* `NULL` if there are no numeric values in the group.
 
 === Examples
 
-.Find the sum total of all numbers
+.Find the sum of all numbers
 ====
 .Query
 [source,sqlpp]
 ----
-SELECT SUM(input) AS total_sum
+SELECT SUM(input) AS sum_all
 FROM [1, 2, 3, 4, 4, MISSING, NULL, "abc"]
 AS input;
 ----
@@ -993,18 +1002,18 @@ AS input;
 ----
 [
   {
-    "total_sum": 14
+    "sum_all": 14
   }
 ]
 ----
 ====
 
-.Find the sum total of distinct numbers
+.Find the sum of distinct numbers
 ====
 .Query
 [source,sqlpp]
 ----
-SELECT SUM(DISTINCT input) AS total_sum
+SELECT SUM(DISTINCT input) AS sum_distinct
 FROM [1, 2, 3, 4, 4, MISSING, NULL, "abc"]
 AS input;
 ----
@@ -1014,7 +1023,7 @@ AS input;
 ----
 [
   {
-    "total_sum": 10
+    "sum_distinct": 10
   }
 ]
 ----
@@ -1025,17 +1034,13 @@ AS input;
 
 === Description
 
-Returns the unbiased sample variance (the square of the <<eqn_samp_std_dev,corrected sample standard deviation>>) of all numeric values in an expression.
+Returns the unbiased sample variance (the square of the <<eqn_samp_std_dev,corrected sample standard deviation>>) of all numeric values in an aggregated group.
 
-You can specify a quantifier to control which values to include in the calculation:
-* `ALL` - Includes every numeric value.
-By default, the function uses this quantifier.
-* `DISTINCT` - Includes only unique numeric values and ignores duplicates.
-
+You can use the `ALL` or `DISTINCT` quantifier to specify which values to include in the calculation.
 For more information, see <<aggregate-quantifier>>.
 
-NOTE: This function is similar to <<variance_samp>>, but it returns `0` if there is only one matching element.
-Whereas `VARIANCE_SAMP()` returns `NULL` in that case.
+NOTE: This function is similar to <<variance_samp>>. 
+However, it returns `0` if there is only 1 matching value, while <<variance_samp>> returns `NULL` in such cases.
 
 === Arguments
 
@@ -1047,7 +1052,7 @@ The function returns 1 of the following:
 
 * A number that represents the unbiased sample variance.
 * `0` if the group contains only 1 numeric value.
-* NULL if there are no numeric values in the group.
+* `NULL` if there are no numeric values in the group.
 
 === Examples
 
@@ -1056,7 +1061,7 @@ The function returns 1 of the following:
 .Query
 [source,sqlpp]
 ----
-SELECT VARIANCE(input) AS variance
+SELECT VARIANCE(input) AS variance_all
 FROM [1, 2, 3, 4, 4, MISSING, NULL, "abc"]
 AS input;
 ----
@@ -1066,7 +1071,28 @@ AS input;
 ----
 [
   {
-    "variance": 1.7
+    "variance_all": 1.7
+  }
+]
+----
+====
+
+.Find the sample variance of distinct values
+====
+.Query
+[source,sqlpp]
+----
+SELECT VARIANCE(DISTINCT input) AS variance_distinct
+FROM [1, 2, 3, 4, 4, MISSING, NULL, "abc"]
+AS input;
+----
+
+.Results
+[source,json]
+----
+[
+  {
+    "variance_distinct": 1.6666666666666667
   }
 ]
 ----
@@ -1091,28 +1117,6 @@ AS input;
   }
 ]
 ----
-There is only matching value in the input, so the variance is `0`.
-====
-
-.Find the sampling variance of distinct values
-====
-.Query
-[source,sqlpp]
-----
-SELECT VARIANCE(DISTINCT input) AS variance
-FROM [1, 2, 3, 4, 4, MISSING, NULL, "abc"]
-AS input;
-----
-
-.Results
-[source,json]
-----
-[
-  {
-    "variance": 1.6666666666666667
-  }
-]
-----
 ====
 
 [[variance_pop,VARIANCE_POP()]]
@@ -1122,13 +1126,9 @@ This function has a synonym <<var_pop>>.
 
 === Description
 
-Returns the population variance (the square of the <<eqn_pop_std_dev,population standard deviation>>) of all numeric values in an expression.
+Returns the population variance (the square of the <<eqn_pop_std_dev,population standard deviation>>) of all numeric values in an aggregated group.
 
-You can specify a quantifier to control which values to include in the calculation:
-* `ALL` - Includes every numeric value.
-By default, the function uses this quantifier.
-* `DISTINCT` - Includes only unique numeric values and ignores duplicates.
-
+You can use the `ALL` or `DISTINCT` quantifier to specify which values to include in the calculation.
 For more information, see <<aggregate-quantifier>>.
 
 === Arguments
@@ -1140,7 +1140,7 @@ See <<aggregate-syntax>>.
 The function returns 1 of the following:
 
 * A number that represents the population variance.
-* NULL if there are no numeric values in the group.
+* `NULL` if there are no numeric values in the group.
 
 === Examples
 
@@ -1186,6 +1186,27 @@ AS input;
 ----
 ====
 
+.Find the population variance of a single numeric value
+====
+.Query
+[source,sqlpp]
+----  
+SELECT VARIANCE_POP(input) AS pop_variance_single
+FROM [3, NULL, "abc"]
+AS input;
+----
+
+.Results
+[source,json]
+----  
+[
+  {
+    "pop_variance_single": null
+  }
+]
+----
+====
+
 [[variance_samp,VARIANCE_SAMP()]]
 == [[variance_samp_distinct]]VARIANCE_SAMP( {startsb} ALL | DISTINCT {endsb} `expression`)
 
@@ -1193,17 +1214,13 @@ This function has a synonym <<var_samp>>.
 
 === Description
 
-Returns the unbiased sample variance (the square of the <<eqn_samp_std_dev,corrected sample standard deviation>>) of all numeric values in an expression.
+Returns the unbiased sample variance (the square of the <<eqn_samp_std_dev,corrected sample standard deviation>>) of all numeric values in an aggregated group.
 
-You can specify a quantifier to control which values to include in the calculation:
-* `ALL` - Includes every numeric value.
-By default, the function uses this quantifier.
-* `DISTINCT` - Includes only unique numeric values and ignores duplicates.
-
+You can use the `ALL` or `DISTINCT` quantifier to specify which values to include in the calculation.
 For more information, see <<aggregate-quantifier>>.
 
-NOTE: This function is similar to <<variance>>, but it returns `NULL` when there is only one matching element.
-Whereas `VARIANCE()` returns `0` in that case.
+NOTE: This function is similar to <<variance>>. 
+However, it returns `NULL` if there is only 1 matching value, while <<variance>> returns `0` in such cases.
 
 === Arguments
 
@@ -1212,17 +1229,18 @@ See <<aggregate-syntax>>.
 === Return Value
 
 The function returns 1 of the following:
-* A number that represents the unbiased sample variance.
-* NULL if there is fewer than 2 numeric values in the group.
+
+* A number that represents the sample variance.
+* `NULL` if there is fewer than 2 numeric values in the group.
 
 === Examples
 
-.Find the sample standard deviation of all values
+.Find the sample standard variance of all values
 ====
 .Query
 [source,sqlpp]
 ----
-SELECT VARIANCE_SAMP(input) AS variance_samp
+SELECT VARIANCE_SAMP(input) AS variance_all
 FROM [1, 2, 3, 4, 4, MISSING, NULL, "abc"]
 AS input;
 ----
@@ -1232,7 +1250,28 @@ AS input;
 ----
 [
   {
-    "variance_samp": 1.7
+    "variance_all": 1.7
+  }
+]
+----
+====
+
+.Find the sample variance of distinct values
+====
+.Query
+[source,sqlpp]
+----
+SELECT VARIANCE_SAMP(DISTINCT input) AS variance_distinct
+FROM [1, 2, 3, 4, 4, MISSING, NULL, "abc"]
+AS input;
+----    
+
+.Results
+[source,json]
+----
+[
+  {
+    "variance_distinct": 1.6666666666666667
   }
 ]
 ----
@@ -1273,7 +1312,7 @@ Synonym of <<variance_samp>>.
 
 [[eqn_samp_std_dev]]
 .Corrected Sample Standard Deviation
-The corrected sample standard deviation is calculated according to the following formula.
+Formula for calculating the corrected sample standard deviation: 
 
 [stem]
 ++++
@@ -1282,7 +1321,7 @@ s = sqrt(1/(n-1) sum_(i=1)^n (x_i - barx)^2)
 
 [[eqn_pop_std_dev]]
 .Population Standard Deviation
-The population standard deviation is calculated according to the following formula.
+Formula for calculating the population standard deviation: 
 
 [stem]
 ++++

--- a/modules/n1ql/pages/n1ql-language-reference/aggregatefun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/aggregatefun.adoc
@@ -36,6 +36,7 @@ In Couchbase Server Enterprise Edition, aggregate functions can also be used as 
 
 include::partial$n1ql-language-reference/window-intro.adoc[tag=syntax]
 
+[[agg-func-syntax]]
 == Syntax
 
 This section describes the generic syntax of aggregate functions.
@@ -120,10 +121,21 @@ All other aggregate functions return NULL.
 [[array_agg,ARRAY_AGG()]]
 == [[array_agg_distinct]]ARRAY_AGG( {startsb} ALL | DISTINCT {endsb} `expression`)
 
-=== Return Value
-With the `ALL` quantifier, or no quantifier, returns an array of the non-MISSING values in the group, including NULL values.
+=== Description
 
-With the `DISTINCT` quantifier, returns an array of the distinct non-MISSING values in the group, including NULL values.
+The `ARRAY_AGG()` function takes all the non-MISSING values of the specified expression and returns them as an array.
+
+You can use the `ALL` or `DISTINCT` quantifier to specify whether to include all values or only distinct values in the resulting array.
+
+=== Arguments
+
+See <<agg-func-syntax>>.
+
+=== Return Value
+
+With the `ALL` quantifier, or no quantifier, returns an array of the non-MISSING values, including NULL values.
+
+With the `DISTINCT` quantifier, returns an array of the distinct non-MISSING values, including NULL values.
 
 === Examples
 include::ROOT:partial$query-context.adoc[tag=section]

--- a/modules/n1ql/pages/n1ql-language-reference/aggregatefun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/aggregatefun.adoc
@@ -129,75 +129,76 @@ The function ignores MISSING values, but includes NULL values in the resulting a
 You can use the following quantifiers to control the values in the resulting array: 
 
 * `ALL` - includes every non-MISSING value.  
-This is the default behavior.
+By default, the function uses this quantifier.
 * `DISTINCT` - includes only distinct values and removes duplicates.
 
 For more information about quantifiers, see <<aggregate-quantifier>>.
 
 === Arguments
 
-expression:: [Required] 
-A valid {expression}[expression] that contains the values to aggregate.
-
-NOTE: You can also add optional clauses like FILTER and OVER to this function. 
-For more information, see <<aggregate-syntax>>.
+See <<aggregate-syntax>>.
 
 === Return Value
 
-An array of aggregated values. 
+The function returns 1 of the following:
 
-The function returns NULL if all values in the group are either MISSING or empty.
+* An array of aggregated values. 
+* NULL if all values in the group are either MISSING or empty.
 
 === Examples
 
-.List all airlines into an array
+.Aggregate all values into an array
 ====
 .Query
 [source,sqlpp]
 ----
-SELECT ARRAY_AGG(airline) AS result
-FROM ["United", "Delta", "United", 
-      "Southwest", NULL, MISSING] 
-AS airline;
+SELECT ARRAY_AGG(input) AS agg_all
+FROM [1, 2, 2, 3, "abc", MISSING, NULL] 
+AS input;
 ----
 
 .Results
 [source,json]
 ----
-[{
-    "result": [
-        null,
-        "Delta",
-        "Southwest",
-        "United",
-        "United"
+[
+  {
+    "agg_all": [
+      null,
+      1,
+      2,
+      2,
+      3,
+      "abc"
     ]
-}]
+  }
+]
 ----
 ====
 
-.List unique airlines into an array
+.Aggregate distinct values into an array
 ====
 .Query
 [source,sqlpp]
 ----
-SELECT ARRAY_AGG( DISTINCT airline) AS result
-FROM ["United", "Delta", "United", 
-      "Southwest", NULL, MISSING] 
-AS airline;
+SELECT ARRAY_AGG(DISTINCT input) AS agg_distinct
+FROM [1, 2, 2, 3, "abc", MISSING, NULL] 
+AS input;
 ----
 
 .Results
 [source,json]
 ----
-[{
-    "result": [
-        null,
-        "Delta",
-        "Southwest",
-        "United"
+[
+  {
+    "agg_distinct": [
+      null,
+      1,
+      2,
+      3,
+      "abc"
     ]
-}]
+  }
+]
 ----
 ====
 
@@ -208,7 +209,7 @@ This function has a synonym <<mean>>.
 
 === Description
 
-This function computes the arithmetic mean (average) of all numeric values in an expression.
+Returns the arithmetic mean (average) of all numeric values in an expression.
 
 You can use the ALL or DISTINCT quantifiers to control the values used in the calculation.
 By default, the function uses the ALL quantifier and includes every non-MISSING value. 
@@ -217,55 +218,56 @@ For more information about these quantifiers, see <<aggregate-quantifier>>.
 
 ==== Arguments
 
-ALL | DISTINCT:: [Optional] Specifies whether to include all values or only distinct values in the calculation.
-
-expression:: [Required]
-A valid {expression}[expression] that contains values to aggregate.
-
-NOTE: You can also add optional clauses like FILTER and OVER as arguments to this function. 
-For more information, see <<aggregate-syntax>>.
+See <<aggregate-syntax>>.
 
 === Return Value
 
-The function returns a number that represents the arithmetic mean.
+The function returns 1 of the following:
+
+* A number that represents the arithmetic mean.
+* NULL if there are no numeric values in the group.
+
 It returns NULL if all values in the group are MISSING, non-numeric, or NULL.
 
 === Examples
-include::ROOT:partial$query-context.adoc[tag=section]
 
+.Find the average of all numbers in a mixed array
 ====
-Find the average altitude of airports in the `airport` keyspace:
-
 .Query
 [source,sqlpp]
 ----
-include::example$functions/avg.n1ql[]
+SELECT AVG(input) AS avg_number
+FROM [1, 1, 2, 2, 3, MISSING, NULL, "abc"]
+AS input;
 ----
 
 .Results
 [source,json]
 ----
-include::example$functions/avg.jsonc[]
+[{
+    "avg_number": 1.8
+}]
 ----
 ====
 
+.Find the average of distinct numbers in a mixed array
 ====
-Find the average number of stops per route vs. the average of distinct numbers of stops:
-
 .Query
 [source,sqlpp]
 ----
-include::example$functions/avg-all.n1ql[]
+SELECT AVG(DISTINCT input) AS avg_distinct_number
+FROM [1, 1, 2, 2, 3, MISSING, NULL, "abc"]
+AS input;
 ----
 
-Results in 0.0002 since nearly all routes have 0 stops.
-
+.Results
 [source,sqlpp]
 ----
-include::example$functions/avg-distinct.n1ql[]
+[{
+    "avg_distinct_number": 2
+}]
 ----
-
-Results in 0.5 since all routes have only 1 or 0 stops.
+The calculation considers only the distinct numeric values and the average is (1 + 2 + 3) / 3 = 2.
 ====
 
 [[count_all,COUNT(*)]]
@@ -273,25 +275,33 @@ Results in 0.5 since all routes have only 1 or 0 stops.
 
 === Description
 
-This function counts all input rows for the group, regardless of value.
+Returns the count of all input rows in a group. footnote:count[{doc-count}]
+
+The wildcard (`*`) indicates all rows are to be counted, including rows with NULL and MISSING values.
+
+TIP: To count only non-NULL and non-MISSING values in an expression, use <<count, COUNT(`expression`)>>.
 
 === Arguments
 
-*:: [Required] A wildcard that specifies counting all input rows.
+This function does not take any arguments. 
 
 === Return Value
-Returns count of all the input rows for the group, regardless of value. footnote:count[{doc-count}]
+
+A number that represents the count of all objects. 
+
+The function returns `0` if the group is empty. 
 
 === Example
-include::ROOT:partial$query-context.adoc[tag=section]
 
+.Count all values in a mixed array
 ====
-Find the number of documents in the `landmark` keyspace:
 
 .Query
 [source,sqlpp]
 ----
-SELECT COUNT(*) AS CountAll FROM landmark;
+SELECT COUNT(*) AS count_all
+FROM [1, 1, 2, 2, 3, MISSING, NULL, "abc"]
+AS input;
 ----
 
 .Results
@@ -299,7 +309,7 @@ SELECT COUNT(*) AS CountAll FROM landmark;
 ----
 [
   {
-    "CountAll": 4495
+    "count_all": 8
   }
 ]
 ----
@@ -308,21 +318,36 @@ SELECT COUNT(*) AS CountAll FROM landmark;
 [[count,COUNT()]]
 == [[count_distinct]]COUNT( {startsb} ALL | DISTINCT {endsb} `expression`)
 
-=== Return Value
-With the `ALL` quantifier, or no quantifier, returns count of all the non-NULL and non-MISSING values in the group. footnote:count[]
+=== Description
 
-With the `DISTINCT` quantifier, returns count of all the distinct non-NULL and non-MISSING values in the group.
+Returns the count of non-NULL and non-MISSING values in an expression. footnote:count[]
+
+You can specify a quantifier to control which values to count: 
+
+* `ALL` - Counts every value in the expression.
+By default, the function uses this quantifier.
+* `DISTINCT` - Counts only unique values and ignores duplicates.
+
+In both cases, the function ignores MISSING and NULL values.
+
+TIP: To count all values including NULL and MISSING, use <<count_all, COUNT(*)>>.
+
+=== Return Value
+
+A number that represents the count of values.
+
+The function returns `0` if all values are MISSING, NULL, or empty.
 
 === Examples
-include::ROOT:partial$query-context.adoc[tag=section]
 
+.Count all values 
 ====
-Find the number of documents with an airline route stop in the `route` keyspace regardless of its value:
-
 .Query
 [source,sqlpp]
 ----
-SELECT COUNT(stops) AS CountOfStops FROM route;
+SELECT COUNT(input) AS count_all
+FROM [1, 1, 2, 2, 3, MISSING, NULL, "abc"]
+AS input;
 ----
 
 .Results
@@ -330,20 +355,20 @@ SELECT COUNT(stops) AS CountOfStops FROM route;
 ----
 [
   {
-    "CountOfStops": 24024
+    "count_all": 6
   }
 ]
 ----
 ====
 
+.Count unique values
 ====
-Find the number of unique values of airline route stops in the `route` keyspace:
-
 .Query
 [source,sqlpp]
 ----
-SELECT COUNT(DISTINCT stops) AS CountOfDistinctStops
-FROM route;
+SELECT COUNT(DISTINCT input) AS count_all
+FROM [1, 1, 2, 2, 3, MISSING, NULL, "abc"]
+AS input;
 ----
 
 .Results
@@ -351,35 +376,45 @@ FROM route;
 ----
 [
   {
-    "CountOfSDistinctStops": 2 <1>
+    "count_all": 4
   }
 ]
 ----
-
-<1> Results in 2 because there are only 0 or 1 stops.
 ====
 
 [[countn,COUNTN()]]
 == COUNTN( {startsb} ALL {vbar} DISTINCT {endsb} `expression` )
 
-=== Return Value
-With the `ALL` quantifier, or no quantifier, returns a count of all the numeric values in the group. footnote:count[]
+=== Description
 
-With the `DISTINCT` quantifier, returns a count of all the distinct numeric values in the group.
+Returns the count of numeric values in an expression. footnote:count[]
+
+You can specify a quantifier to control which numeric values to include: 
+
+* `ALL` - Counts every numeric value.
+By default, the function uses this quantifier.
+* `DISTINCT` - Counts only unique numeric values and ignores duplicates.
+
+=== Arguments
+
+See <<aggregate-syntax>>.
+
+=== Return Value
+
+A number that represents the count of numeric values.
+
+The function returns `0` if there are no numeric values.
 
 === Examples
-====
-The count of numeric values in a mixed group.
 
+.Count all numeric values 
+====
+.Query
 [source,sqlpp]
 ----
-SELECT COUNTN(list.val) AS CountOfNumbers
-FROM [
-  {"val":1},
-  {"val":1},
-  {"val":2},
-  {"val":"abc"}
-] AS list;
+SELECT COUNTN(input) AS count_all
+FROM [ 1, 1, 2, 2, 3, "abc", MISSING, NULL] 
+AS input;
 ----
 
 .Results
@@ -387,24 +422,21 @@ FROM [
 ----
 [
   {
-    "CountOfNumbers": 3
+    "count_all": 5
   }
 ]
 ----
 ====
 
-====
-The count of unique numeric values in a mixed group.
+.Count distinct numeric values 
+==== 
 
+.Query
 [source,sqlpp]
 ----
-SELECT COUNTN(DISTINCT list.val) AS CountOfNumbers
-FROM [
-  {"val":1},
-  {"val":1},
-  {"val":2},
-  {"val":"abc"}
-] AS list;
+SELECT COUNTN(DISTINCT input) AS count_distinct
+FROM [ 1, 1, 2, 2, 3, "abc", MISSING, NULL] 
+AS input;
 ----
 
 .Results
@@ -412,7 +444,7 @@ FROM [
 ----
 [
   {
-    "CountOfNumbers": 2
+    "count_distinct": 3
   }
 ]
 ----


### PR DESCRIPTION
Jira: DOC-2423

Updated the Aggregate Functions page to align with the [function template](https://github.com/couchbaselabs/docs-tooling/blob/main/templates/reference/function.adoc), mainly focusing on standardizing descriptions and examples. 

All examples have been tested locally to ensure they work.

Preview: [Aggregate Functions](https://preview.docs-test.couchbase.com/docs-devex-DOC-2423-aggregate-functions/server/current/n1ql/n1ql-language-reference/aggregatefun.html)