### PR TITLE
[DOC-13222]: Feedback on Reserved Words | Couchbase Docs

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/reservedwords.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/reservedwords.adoc
@@ -33,282 +33,268 @@ CREATE INDEX myindex ON default(`index`) USING GSI;
 
 The following keywords are reserved and cannot be used as unescaped identifiers:
 
-[cols=6*]
-|===
-| _INDEX_CONDITION
-| _INDEX_KEY
-| xref:n1ql-language-reference/advise.adoc[ADVISE]
-| xref:n1ql-language-reference/selectclause.adoc#all[ALL]
-| ALTER
-| ANALYZE
 
-| xref:n1ql-language-reference/logicalops.adoc#logical-op-and[AND]
-| xref:n1ql-language-reference/collectionops.adoc#collection-op-any[ANY]
-| xref:n1ql-language-reference/collectionops.adoc#array[ARRAY]
-| xref:n1ql-language-reference/from.adoc#section_ax5_2nx_1db[AS]
-| ASC
-| AT
+++++
+<style>
+.card-row.six-column-row .column {
+  flex-basis: 10%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+  margin-top: 10px
 
-| BEGIN
-| xref:n1ql-language-reference/comparisonops.adoc#between[BETWEEN]
-| xref:n1ql-language-reference/datatypes.adoc#datatype-binary[BINARY]
-| xref:n1ql-language-reference/datatypes.adoc#datatype-boolean[BOOLEAN]
-| BREAK
-| BUCKET
+}
+</style>
+<div class="card-row six-column-row">
 
-| BUILD
-| BY
-| CACHE
-| CALL
-| xref:n1ql-language-reference/conditionalops.adoc[CASE]
-| CAST
+++++
 
-| CLUSTER
-| COLLATE
-| COLLECTION
-| COMMIT
-| xref:n1ql:n1ql-language-reference/set-transaction.adoc[COMMITTED]
-| CONNECT
+[.column]
+_INDEX_CONDITION +
+_INDEX_KEY +
+xref:n1ql-language-reference/advise.adoc[ADVISE] +
+xref:n1ql-language-reference/selectclause.adoc#all[ALL] +
+ALTER +
+ANALYZE +
+xref:n1ql-language-reference/logicalops.adoc#logical-op-and[AND] +
+xref:n1ql-language-reference/collectionops.adoc#collection-op-any[ANY] +
+xref:n1ql-language-reference/collectionops.adoc#array[ARRAY] +
+xref:n1ql-language-reference/from.adoc#section_ax5_2nx_1db[AS] +
+ASC +
+AT +
+BEGIN +
+xref:n1ql-language-reference/comparisonops.adoc#between[BETWEEN] +
+xref:n1ql-language-reference/datatypes.adoc#datatype-binary[BINARY] +
+xref:n1ql-language-reference/datatypes.adoc#datatype-boolean[BOOLEAN] +
+BREAK +
+BUCKET +
+BUILD +
+BY +
+CACHE +
+CALL +
+xref:n1ql-language-reference/conditionalops.adoc[CASE] +
+CAST +
+CLUSTER +
+COLLATE +
+COLLECTION +
+COMMIT +
+xref:n1ql:n1ql-language-reference/set-transaction.adoc[COMMITTED] +
+CONNECT +
+CONTINUE +
+CORRELATED +
+COVER +
+xref:n1ql-language-reference/createindex.adoc[CREATE] +
+xref:n1ql-language-reference/window.adoc#window-frame-extent[CURRENT] +
+CYCLE +
+DATABASE +
 
-| CONTINUE
-| CORRELATED
-| COVER
-| xref:n1ql-language-reference/createindex.adoc[CREATE]
-| xref:n1ql-language-reference/window.adoc#window-frame-extent[CURRENT]
-| CYCLE
+[.column]
+DATASET +
+DATASTORE +
+DECLARE +
+DECREMENT +
+DEFAULT +
+xref:n1ql-language-reference/delete.adoc[DELETE] +
+DERIVED +
+DESC +
+DESCRIBE +
+xref:n1ql-language-reference/selectclause.adoc#distinct[DISTINCT] +
+DO +
+xref:n1ql-language-reference/dropindex.adoc[DROP] +
+EACH +
+ELEMENT +
+ELSE +
+END +
+ESCAPE +
+xref:n1ql-language-reference/collectionops.adoc#collection-op-every[EVERY] +
+xref:n1ql-language-reference/union.adoc[EXCEPT] +
+xref:n1ql-language-reference/selectclause.adoc#sec_ExcludeClause[EXCLUDE] +
+xref:n1ql-language-reference/execute.adoc[EXECUTE] +
+xref:n1ql-language-reference/collectionops.adoc#exists[EXISTS] +
+xref:n1ql-language-reference/explain.adoc[EXPLAIN] +
+FALSE +
+FETCH +
+FILTER +
+xref:n1ql-language-reference/collectionops.adoc#first[FIRST] +
+FLATTEN +
+FLATTEN_KEYS +
+FLUSH +
+xref:n1ql-language-reference/window.adoc#window-frame-extent[FOLLOWING] +
+FOR +
+FORCE +
+xref:n1ql-language-reference/from.adoc[FROM] +
+xref:n1ql-language-reference/hints.adoc#index-type[FTS] +
+xref:n1ql-language-reference/createfunction.adoc[FUNCTION] +
+GOLANG +
 
-| DATABASE
-| DATASET
-| DATASTORE
-| DECLARE
-| DECREMENT
-| DEFAULT
+[.column]
+xref:n1ql-language-reference/grant.adoc[GRANT] +
+xref:n1ql-language-reference/groupby.adoc[GROUP] +
+xref:n1ql-language-reference/window.adoc#window-frame-clause[GROUPS] +
+xref:n1ql-language-reference/hints.adoc#index-type[GSI] +
+xref:n1ql-language-reference/join.adoc#use-hash-hint[HASH] +
+HAVING +
+IF +
+IGNORE +
+ILIKE +
+xref:n1ql-language-reference/collectionops.adoc#collection-op-in[IN] +
+INCLUDE +
+INCREMENT +
+INDEX +
+xref:n1ql-language-reference/infer.adoc[INFER] +
+INLINE +
+INNER +
+xref:n1ql-language-reference/insert.adoc[INSERT] +
+xref:n1ql-language-reference/union.adoc[INTERSECT] +
+INTO +
+xref:n1ql-language-reference/comparisonops.adoc#is[IS] +
+xref:n1ql:n1ql-language-reference/set-transaction.adoc[ISOLATION] +
+xref:n1ql-language-reference/createfunction.adoc[JAVASCRIPT] +
+xref:n1ql-language-reference/join.adoc[JOIN] +
+KEY +
+KEYS +
+KEYSPACE +
+KNOWN +
+xref:n1ql-language-reference/createfunction.adoc[LANGUAGE] +
+LAST +
+LATERAL +
+LEFT +
+xref:n1ql-language-reference/let.adoc[LET] +
+LETTING +
+xref:n1ql:n1ql-language-reference/set-transaction.adoc[LEVEL] +
+xref:n1ql-language-reference/comparisonops.adoc#like[LIKE] +
+xref:n1ql-language-reference/limit.adoc[LIMIT] +
+LSM +
 
-| xref:n1ql-language-reference/delete.adoc[DELETE]
-| DERIVED
-| DESC
-| DESCRIBE
-| xref:n1ql-language-reference/selectclause.adoc#distinct[DISTINCT]
-| DO
+[.column]
+MAP +
+MAPPING +
+MATCHED +
+MATERIALIZED +
+MAXVALUE +
+xref:n1ql-language-reference/merge.adoc[MERGE] +
+MINUS +
+MINVALUE +
+xref:n1ql-language-reference/comparisonops.adoc#null-and-missing[MISSING] +
+NAMESPACE +
+NAMESPACE_ID +
+xref:n1ql-language-reference/nest.adoc[NEST] +
+NEXT +
+NEXTVAL +
+xref:n1ql-language-reference/join.adoc#use-nl-hint[NL] +
+xref:n1ql-language-reference/window.adoc#window-frame-exclusion[NO] +
+xref:n1ql-language-reference/logicalops.adoc#logical-op-not[NOT] +
+NOT_A_TOKEN +
+xref:n1ql-language-reference/windowfun.adoc#fn-window-nth-value[NTH_VALUE] +
+xref:n1ql-language-reference/comparisonops.adoc#null-and-missing[NULL] +
+xref:n1ql-language-reference/window.adoc#nulls-treatment[NULLS] +
+NUMBER +
+OBJECT +
+xref:n1ql-language-reference/offset.adoc[OFFSET] +
+ON +
+OPTION +
+xref:n1ql-language-reference/insert.adoc#insert-values[OPTIONS] +
+xref:n1ql-language-reference/logicalops.adoc#or-operator[OR] +
+xref:n1ql-language-reference/orderby.adoc[ORDER] +
+xref:n1ql-language-reference/window.adoc#window-frame-exclusion[OTHERS] +
+OUTER +
+xref:n1ql-language-reference/window.adoc[OVER] +
+PARSE +
+PARTITION +
+PASSWORD +
+PATH +
+POOL +
 
-| xref:n1ql-language-reference/dropindex.adoc[DROP]
-| EACH
-| ELEMENT
-| ELSE
-| END
-| ESCAPE
+[.column]
+xref:n1ql-language-reference/window.adoc#window-frame-extent[PRECEDING] +
+xref:n1ql-language-reference/prepare.adoc[PREPARE] +
+PREV +
+PREVIOUS +
+PREVVAL +
+PRIMARY +
+PRIVATE +
+PRIVILEGE +
+xref:n1ql-language-reference/join.adoc#use-hash-hint[PROBE] +
+PROCEDURE +
+PUBLIC +
+xref:n1ql-language-reference/window.adoc#window-frame-clause[RANGE] +
+RAW +
+READ +
+REALM +
+RECURSIVE +
+REDUCE +
+RENAME +
+REPLACE +
+xref:n1ql-language-reference/window.adoc#nulls-treatment[RESPECT] +
+RESTART +
+RESTRICT +
+RETURN +
+RETURNING +
+xref:n1ql-language-reference/revoke.adoc[REVOKE] +
+RIGHT +
+ROLE +
+ROLES +
+xref:n1ql:n1ql-language-reference/rollback-transaction.adoc[ROLLBACK] +
+xref:n1ql-language-reference/window.adoc#window-frame-extent[ROW] +
+xref:n1ql-language-reference/window.adoc#window-frame-clause[ROWS] +
+SATISFIES +
+xref:n1ql:n1ql-language-reference/savepoint.adoc[SAVEPOINT] +
+SCHEMA +
+SCOPE +
+xref:n1ql-language-reference/selectclause.adoc[SELECT] +
+SELF +
 
-| xref:n1ql-language-reference/collectionops.adoc#collection-op-every[EVERY]
-| xref:n1ql-language-reference/union.adoc[EXCEPT]
-| xref:n1ql-language-reference/selectclause.adoc#sec_ExcludeClause[EXCLUDE]
-| xref:n1ql-language-reference/execute.adoc[EXECUTE]
-| xref:n1ql-language-reference/collectionops.adoc#exists[EXISTS]
-| xref:n1ql-language-reference/explain.adoc[EXPLAIN]
+[.column]
+SEQUENCE +
+SEMI +
+SET +
+SHOW +
+SOME +
+START +
+STATISTICS +
+STRING
+SYSTEM +
+THEN +
+xref:n1ql-language-reference/window.adoc#window-frame-exclusion[TIES] +
+TO +
+xref:n1ql:n1ql-language-reference/begin-transaction.adoc[TRAN] +
+xref:n1ql:n1ql-language-reference/begin-transaction.adoc[TRANSACTION] +
+TRIGGER +
+TRUE +
+TRUNCATE +
+xref:n1ql-language-reference/window.adoc#window-frame-extent[UNBOUNDED] +
+UNDER +
+xref:n1ql-language-reference/union.adoc[UNION] +
+UNIQUE +
+UNKNOWN +
+xref:n1ql-language-reference/unnest.adoc[UNNEST] +
+xref:n1ql-language-reference/update.adoc#unset-clause[UNSET] +
+xref:n1ql-language-reference/update.adoc[UPDATE] +
+xref:n1ql-language-reference/upsert.adoc[UPSERT] +
+xref:n1ql-language-reference/hints.adoc[USE] +
+USER +
+USERS +
+USING +
+VALIDATE +
+VALUE +
+VALUED +
+VALUES +
+VECTOR +
+VIA +
+VIEW +
 
-| FALSE
-| FETCH
-| FILTER
-| xref:n1ql-language-reference/collectionops.adoc#first[FIRST]
-| FLATTEN
-| FLATTEN_KEYS
+[.column]
+WHEN +
+xref:n1ql-language-reference/where.adoc[WHERE] +
+WHILE +
+xref:n1ql-language-reference/window.adoc[WINDOW] +
+xref:n1ql-language-reference/with.adoc[WITH] +
+xref:n1ql-language-reference/collectionops.adoc#collection-op-within[WITHIN] +
+xref:n1ql:n1ql-language-reference/begin-transaction.adoc[WORK] +
+XOR +
 
-| FLUSH
-| xref:n1ql-language-reference/window.adoc#window-frame-extent[FOLLOWING]
-| FOR
-| FORCE
-| xref:n1ql-language-reference/from.adoc[FROM]
-| xref:n1ql-language-reference/hints.adoc#index-type[FTS]
+++++
+</div>
+++++
 
-| xref:n1ql-language-reference/createfunction.adoc[FUNCTION]
-| GOLANG
-| xref:n1ql-language-reference/grant.adoc[GRANT]
-| xref:n1ql-language-reference/groupby.adoc[GROUP]
-| xref:n1ql-language-reference/window.adoc#window-frame-clause[GROUPS]
-| xref:n1ql-language-reference/hints.adoc#index-type[GSI]
-
-| xref:n1ql-language-reference/join.adoc#use-hash-hint[HASH]
-| HAVING
-| IF
-| IGNORE
-| ILIKE
-| xref:n1ql-language-reference/collectionops.adoc#collection-op-in[IN]
-
-| INCLUDE
-| INCREMENT
-| INDEX
-| xref:n1ql-language-reference/infer.adoc[INFER]
-| INLINE
-| INNER
-
-| xref:n1ql-language-reference/insert.adoc[INSERT]
-| xref:n1ql-language-reference/union.adoc[INTERSECT]
-| INTO
-| xref:n1ql-language-reference/comparisonops.adoc#is[IS]
-| xref:n1ql:n1ql-language-reference/set-transaction.adoc[ISOLATION]
-| xref:n1ql-language-reference/createfunction.adoc[JAVASCRIPT]
-
-| xref:n1ql-language-reference/join.adoc[JOIN]
-| KEY
-| KEYS
-| KEYSPACE
-| KNOWN
-| xref:n1ql-language-reference/createfunction.adoc[LANGUAGE]
-
-| LAST
-| LATERAL
-| LEFT
-| xref:n1ql-language-reference/let.adoc[LET]
-| LETTING
-| xref:n1ql:n1ql-language-reference/set-transaction.adoc[LEVEL]
-
-| xref:n1ql-language-reference/comparisonops.adoc#like[LIKE]
-| xref:n1ql-language-reference/limit.adoc[LIMIT]
-| LSM
-| MAP
-| MAPPING
-| MATCHED
-
-| MATERIALIZED
-| MAXVALUE
-| xref:n1ql-language-reference/merge.adoc[MERGE]
-| MINUS
-| MINVALUE
-| xref:n1ql-language-reference/comparisonops.adoc#null-and-missing[MISSING]
-
-| NAMESPACE
-| NAMESPACE_ID
-| xref:n1ql-language-reference/nest.adoc[NEST]
-| NEXT
-| NEXTVAL
-| xref:n1ql-language-reference/join.adoc#use-nl-hint[NL]
-
-| xref:n1ql-language-reference/window.adoc#window-frame-exclusion[NO]
-| xref:n1ql-language-reference/logicalops.adoc#logical-op-not[NOT]
-| NOT_A_TOKEN
-| xref:n1ql-language-reference/windowfun.adoc#fn-window-nth-value[NTH_VALUE]
-| xref:n1ql-language-reference/comparisonops.adoc#null-and-missing[NULL]
-| xref:n1ql-language-reference/window.adoc#nulls-treatment[NULLS]
-
-| NUMBER
-| OBJECT
-| xref:n1ql-language-reference/offset.adoc[OFFSET]
-| ON
-| OPTION
-| xref:n1ql-language-reference/insert.adoc#insert-values[OPTIONS]
-
-| xref:n1ql-language-reference/logicalops.adoc#or-operator[OR]
-| xref:n1ql-language-reference/orderby.adoc[ORDER]
-| xref:n1ql-language-reference/window.adoc#window-frame-exclusion[OTHERS]
-| OUTER
-| xref:n1ql-language-reference/window.adoc[OVER]
-| PARSE
-
-| PARTITION
-| PASSWORD
-| PATH
-| POOL
-| xref:n1ql-language-reference/window.adoc#window-frame-extent[PRECEDING]
-| xref:n1ql-language-reference/prepare.adoc[PREPARE]
-
-| PREV
-| PREVIOUS
-| PREVVAL
-| PRIMARY
-| PRIVATE
-| PRIVILEGE
-
-| xref:n1ql-language-reference/join.adoc#use-hash-hint[PROBE]
-| PROCEDURE
-| PUBLIC
-| xref:n1ql-language-reference/window.adoc#window-frame-clause[RANGE]
-| RAW
-| READ
-
-| REALM
-| RECURSIVE
-| REDUCE
-| RENAME
-| REPLACE
-| xref:n1ql-language-reference/window.adoc#nulls-treatment[RESPECT]
-
-| RESTART
-| RESTRICT
-| RETURN
-| RETURNING
-| xref:n1ql-language-reference/revoke.adoc[REVOKE]
-| RIGHT
-
-| ROLE
-| ROLES
-| xref:n1ql:n1ql-language-reference/rollback-transaction.adoc[ROLLBACK]
-| xref:n1ql-language-reference/window.adoc#window-frame-extent[ROW]
-| xref:n1ql-language-reference/window.adoc#window-frame-clause[ROWS]
-| SATISFIES
-
-| xref:n1ql:n1ql-language-reference/savepoint.adoc[SAVEPOINT]
-| SCHEMA
-| SCOPE
-| xref:n1ql-language-reference/selectclause.adoc[SELECT]
-| SELF
-| SEQUENCE
-
-| SEMI
-| SET
-| SHOW
-| SOME
-| START
-| STATISTICS
-
-| STRING
-| SYSTEM
-| THEN
-| xref:n1ql-language-reference/window.adoc#window-frame-exclusion[TIES]
-| TO
-| xref:n1ql:n1ql-language-reference/begin-transaction.adoc[TRAN]
-
-| xref:n1ql:n1ql-language-reference/begin-transaction.adoc[TRANSACTION]
-| TRIGGER
-| TRUE
-| TRUNCATE
-| xref:n1ql-language-reference/window.adoc#window-frame-extent[UNBOUNDED]
-| UNDER
-
-| xref:n1ql-language-reference/union.adoc[UNION]
-| UNIQUE
-| UNKNOWN
-| xref:n1ql-language-reference/unnest.adoc[UNNEST]
-| xref:n1ql-language-reference/update.adoc#unset-clause[UNSET]
-| xref:n1ql-language-reference/update.adoc[UPDATE]
-
-| xref:n1ql-language-reference/upsert.adoc[UPSERT]
-| xref:n1ql-language-reference/hints.adoc[USE]
-| USER
-| USERS
-| USING
-| VALIDATE
-
-| VALUE
-| VALUED
-| VALUES
-| VECTOR
-| VIA
-| VIEW
-
-| WHEN
-| xref:n1ql-language-reference/where.adoc[WHERE]
-| WHILE
-| xref:n1ql-language-reference/window.adoc[WINDOW]
-| xref:n1ql-language-reference/with.adoc[WITH]
-| xref:n1ql-language-reference/collectionops.adoc#collection-op-within[WITHIN]
-
-| xref:n1ql:n1ql-language-reference/begin-transaction.adoc[WORK]
-| XOR
-|
-|
-|
-|
-
-|===
-
-NOTE: The word `AI` is not a reserved word, even though you can use it in combination with the `USING` keyword as part of the xref:n1ql-language-reference/using-ai.adoc[USING AI] statement.
+NOTE: The word `AI` is not a reserved word, even though you can use it in combination with the `USING` keyword as part of the xref:n1ql-language-reference/using-ai.adoc[USING AI] statement. +
 You do not have to escape the word `AI` inside backticks when using it by itself as an identifier.

--- a/modules/n1ql/pages/n1ql-language-reference/reservedwords.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/reservedwords.adoc
@@ -33,7 +33,6 @@ CREATE INDEX myindex ON default(`index`) USING GSI;
 
 The following keywords are reserved and cannot be used as unescaped identifiers:
 
-
 ++++
 <style>
 .card-row.six-column-row .column {
@@ -49,248 +48,255 @@ The following keywords are reserved and cannot be used as unescaped identifiers:
 ++++
 
 [.column]
-_INDEX_CONDITION +
-_INDEX_KEY +
-xref:n1ql-language-reference/advise.adoc[ADVISE] +
-xref:n1ql-language-reference/selectclause.adoc#all[ALL] +
-ALTER +
-ANALYZE +
-xref:n1ql-language-reference/logicalops.adoc#logical-op-and[AND] +
-xref:n1ql-language-reference/collectionops.adoc#collection-op-any[ANY] +
-xref:n1ql-language-reference/collectionops.adoc#array[ARRAY] +
-xref:n1ql-language-reference/from.adoc#section_ax5_2nx_1db[AS] +
-ASC +
-AT +
-BEGIN +
-xref:n1ql-language-reference/comparisonops.adoc#between[BETWEEN] +
-xref:n1ql-language-reference/datatypes.adoc#datatype-binary[BINARY] +
-xref:n1ql-language-reference/datatypes.adoc#datatype-boolean[BOOLEAN] +
-BREAK +
-BUCKET +
-BUILD +
-BY +
-CACHE +
-CALL +
-xref:n1ql-language-reference/conditionalops.adoc[CASE] +
-CAST +
-CLUSTER +
-COLLATE +
-COLLECTION +
-COMMIT +
-xref:n1ql:n1ql-language-reference/set-transaction.adoc[COMMITTED] +
-CONNECT +
-CONTINUE +
-CORRELATED +
-COVER +
-xref:n1ql-language-reference/createindex.adoc[CREATE] +
-xref:n1ql-language-reference/window.adoc#window-frame-extent[CURRENT] +
-CYCLE +
-DATABASE +
+[%hardbreaks]
+_INDEX_CONDITION 
+_INDEX_KEY 
+xref:n1ql-language-reference/advise.adoc[ADVISE] 
+xref:n1ql-language-reference/selectclause.adoc#all[ALL] 
+ALTER 
+ANALYZE 
+xref:n1ql-language-reference/logicalops.adoc#logical-op-and[AND] 
+xref:n1ql-language-reference/collectionops.adoc#collection-op-any[ANY] 
+xref:n1ql-language-reference/collectionops.adoc#array[ARRAY] 
+xref:n1ql-language-reference/from.adoc#section_ax5_2nx_1db[AS] 
+ASC 
+AT 
+BEGIN 
+xref:n1ql-language-reference/comparisonops.adoc#between[BETWEEN] 
+xref:n1ql-language-reference/datatypes.adoc#datatype-binary[BINARY] 
+xref:n1ql-language-reference/datatypes.adoc#datatype-boolean[BOOLEAN] 
+BREAK 
+BUCKET 
+BUILD 
+BY 
+CACHE 
+CALL 
+xref:n1ql-language-reference/conditionalops.adoc[CASE] 
+CAST 
+CLUSTER 
+COLLATE 
+COLLECTION 
+COMMIT 
+xref:n1ql:n1ql-language-reference/set-transaction.adoc[COMMITTED] 
+CONNECT 
+CONTINUE 
+CORRELATED 
+COVER 
+xref:n1ql-language-reference/createindex.adoc[CREATE] 
+xref:n1ql-language-reference/window.adoc#window-frame-extent[CURRENT] 
+CYCLE 
+DATABASE
 
 [.column]
-DATASET +
-DATASTORE +
-DECLARE +
-DECREMENT +
-DEFAULT +
-xref:n1ql-language-reference/delete.adoc[DELETE] +
-DERIVED +
-DESC +
-DESCRIBE +
-xref:n1ql-language-reference/selectclause.adoc#distinct[DISTINCT] +
-DO +
-xref:n1ql-language-reference/dropindex.adoc[DROP] +
-EACH +
-ELEMENT +
-ELSE +
-END +
-ESCAPE +
-xref:n1ql-language-reference/collectionops.adoc#collection-op-every[EVERY] +
-xref:n1ql-language-reference/union.adoc[EXCEPT] +
-xref:n1ql-language-reference/selectclause.adoc#sec_ExcludeClause[EXCLUDE] +
-xref:n1ql-language-reference/execute.adoc[EXECUTE] +
-xref:n1ql-language-reference/collectionops.adoc#exists[EXISTS] +
-xref:n1ql-language-reference/explain.adoc[EXPLAIN] +
-FALSE +
-FETCH +
-FILTER +
-xref:n1ql-language-reference/collectionops.adoc#first[FIRST] +
-FLATTEN +
-FLATTEN_KEYS +
-FLUSH +
-xref:n1ql-language-reference/window.adoc#window-frame-extent[FOLLOWING] +
-FOR +
-FORCE +
-xref:n1ql-language-reference/from.adoc[FROM] +
-xref:n1ql-language-reference/hints.adoc#index-type[FTS] +
-xref:n1ql-language-reference/createfunction.adoc[FUNCTION] +
-GOLANG +
+[%hardbreaks]
+DATASET 
+DATASTORE 
+DECLARE 
+DECREMENT 
+DEFAULT 
+xref:n1ql-language-reference/delete.adoc[DELETE]
+DERIVED
+DESC
+DESCRIBE 
+xref:n1ql-language-reference/selectclause.adoc#distinct[DISTINCT] 
+DO 
+xref:n1ql-language-reference/dropindex.adoc[DROP] 
+EACH 
+ELEMENT 
+ELSE 
+END 
+ESCAPE 
+xref:n1ql-language-reference/collectionops.adoc#collection-op-every[EVERY] 
+xref:n1ql-language-reference/union.adoc[EXCEPT] 
+xref:n1ql-language-reference/selectclause.adoc#sec_ExcludeClause[EXCLUDE] 
+xref:n1ql-language-reference/execute.adoc[EXECUTE] 
+xref:n1ql-language-reference/collectionops.adoc#exists[EXISTS] 
+xref:n1ql-language-reference/explain.adoc[EXPLAIN] 
+FALSE 
+FETCH 
+FILTER 
+xref:n1ql-language-reference/collectionops.adoc#first[FIRST] 
+FLATTEN 
+FLATTEN_KEYS 
+FLUSH 
+xref:n1ql-language-reference/window.adoc#window-frame-extent[FOLLOWING] 
+FOR 
+FORCE 
+xref:n1ql-language-reference/from.adoc[FROM] 
+xref:n1ql-language-reference/hints.adoc#index-type[FTS] 
+xref:n1ql-language-reference/createfunction.adoc[FUNCTION] 
+GOLANG 
 
 [.column]
-xref:n1ql-language-reference/grant.adoc[GRANT] +
-xref:n1ql-language-reference/groupby.adoc[GROUP] +
-xref:n1ql-language-reference/window.adoc#window-frame-clause[GROUPS] +
-xref:n1ql-language-reference/hints.adoc#index-type[GSI] +
-xref:n1ql-language-reference/join.adoc#use-hash-hint[HASH] +
-HAVING +
-IF +
-IGNORE +
-ILIKE +
-xref:n1ql-language-reference/collectionops.adoc#collection-op-in[IN] +
-INCLUDE +
-INCREMENT +
-INDEX +
-xref:n1ql-language-reference/infer.adoc[INFER] +
-INLINE +
-INNER +
-xref:n1ql-language-reference/insert.adoc[INSERT] +
-xref:n1ql-language-reference/union.adoc[INTERSECT] +
-INTO +
-xref:n1ql-language-reference/comparisonops.adoc#is[IS] +
-xref:n1ql:n1ql-language-reference/set-transaction.adoc[ISOLATION] +
-xref:n1ql-language-reference/createfunction.adoc[JAVASCRIPT] +
-xref:n1ql-language-reference/join.adoc[JOIN] +
-KEY +
-KEYS +
-KEYSPACE +
-KNOWN +
-xref:n1ql-language-reference/createfunction.adoc[LANGUAGE] +
-LAST +
-LATERAL +
-LEFT +
-xref:n1ql-language-reference/let.adoc[LET] +
-LETTING +
-xref:n1ql:n1ql-language-reference/set-transaction.adoc[LEVEL] +
-xref:n1ql-language-reference/comparisonops.adoc#like[LIKE] +
-xref:n1ql-language-reference/limit.adoc[LIMIT] +
-LSM +
+[%hardbreaks]
+xref:n1ql-language-reference/grant.adoc[GRANT] 
+xref:n1ql-language-reference/groupby.adoc[GROUP] 
+xref:n1ql-language-reference/window.adoc#window-frame-clause[GROUPS] 
+xref:n1ql-language-reference/hints.adoc#index-type[GSI] 
+xref:n1ql-language-reference/join.adoc#use-hash-hint[HASH] 
+HAVING 
+IF 
+IGNORE 
+ILIKE 
+xref:n1ql-language-reference/collectionops.adoc#collection-op-in[IN] 
+INCLUDE 
+INCREMENT 
+INDEX 
+xref:n1ql-language-reference/infer.adoc[INFER] 
+INLINE 
+INNER 
+xref:n1ql-language-reference/insert.adoc[INSERT] 
+xref:n1ql-language-reference/union.adoc[INTERSECT] 
+INTO 
+xref:n1ql-language-reference/comparisonops.adoc#is[IS] 
+xref:n1ql:n1ql-language-reference/set-transaction.adoc[ISOLATION] 
+xref:n1ql-language-reference/createfunction.adoc[JAVASCRIPT] 
+xref:n1ql-language-reference/join.adoc[JOIN] 
+KEY 
+KEYS 
+KEYSPACE 
+KNOWN 
+xref:n1ql-language-reference/createfunction.adoc[LANGUAGE] 
+LAST 
+LATERAL 
+LEFT 
+xref:n1ql-language-reference/let.adoc[LET] 
+LETTING 
+xref:n1ql:n1ql-language-reference/set-transaction.adoc[LEVEL] 
+xref:n1ql-language-reference/comparisonops.adoc#like[LIKE] 
+xref:n1ql-language-reference/limit.adoc[LIMIT] 
+LSM 
 
 [.column]
-MAP +
-MAPPING +
-MATCHED +
-MATERIALIZED +
-MAXVALUE +
-xref:n1ql-language-reference/merge.adoc[MERGE] +
-MINUS +
-MINVALUE +
-xref:n1ql-language-reference/comparisonops.adoc#null-and-missing[MISSING] +
-NAMESPACE +
-NAMESPACE_ID +
-xref:n1ql-language-reference/nest.adoc[NEST] +
-NEXT +
-NEXTVAL +
-xref:n1ql-language-reference/join.adoc#use-nl-hint[NL] +
-xref:n1ql-language-reference/window.adoc#window-frame-exclusion[NO] +
-xref:n1ql-language-reference/logicalops.adoc#logical-op-not[NOT] +
-NOT_A_TOKEN +
-xref:n1ql-language-reference/windowfun.adoc#fn-window-nth-value[NTH_VALUE] +
-xref:n1ql-language-reference/comparisonops.adoc#null-and-missing[NULL] +
-xref:n1ql-language-reference/window.adoc#nulls-treatment[NULLS] +
-NUMBER +
-OBJECT +
-xref:n1ql-language-reference/offset.adoc[OFFSET] +
-ON +
-OPTION +
-xref:n1ql-language-reference/insert.adoc#insert-values[OPTIONS] +
-xref:n1ql-language-reference/logicalops.adoc#or-operator[OR] +
-xref:n1ql-language-reference/orderby.adoc[ORDER] +
-xref:n1ql-language-reference/window.adoc#window-frame-exclusion[OTHERS] +
-OUTER +
-xref:n1ql-language-reference/window.adoc[OVER] +
-PARSE +
-PARTITION +
-PASSWORD +
-PATH +
-POOL +
+[%hardbreaks]
+MAP 
+MAPPING 
+MATCHED 
+MATERIALIZED 
+MAXVALUE 
+xref:n1ql-language-reference/merge.adoc[MERGE] 
+MINUS 
+MINVALUE 
+xref:n1ql-language-reference/comparisonops.adoc#null-and-missing[MISSING] 
+NAMESPACE 
+NAMESPACE_ID 
+xref:n1ql-language-reference/nest.adoc[NEST] 
+NEXT 
+NEXTVAL 
+xref:n1ql-language-reference/join.adoc#use-nl-hint[NL] 
+xref:n1ql-language-reference/window.adoc#window-frame-exclusion[NO] 
+xref:n1ql-language-reference/logicalops.adoc#logical-op-not[NOT] 
+NOT_A_TOKEN 
+xref:n1ql-language-reference/windowfun.adoc#fn-window-nth-value[NTH_VALUE] 
+xref:n1ql-language-reference/comparisonops.adoc#null-and-missing[NULL] 
+xref:n1ql-language-reference/window.adoc#nulls-treatment[NULLS] 
+NUMBER 
+OBJECT 
+xref:n1ql-language-reference/offset.adoc[OFFSET] 
+ON 
+OPTION 
+xref:n1ql-language-reference/insert.adoc#insert-values[OPTIONS] 
+xref:n1ql-language-reference/logicalops.adoc#or-operator[OR] 
+xref:n1ql-language-reference/orderby.adoc[ORDER] 
+xref:n1ql-language-reference/window.adoc#window-frame-exclusion[OTHERS] 
+OUTER 
+xref:n1ql-language-reference/window.adoc[OVER] 
+PARSE 
+PARTITION 
+PASSWORD 
+PATH 
+POOL 
 
 [.column]
-xref:n1ql-language-reference/window.adoc#window-frame-extent[PRECEDING] +
-xref:n1ql-language-reference/prepare.adoc[PREPARE] +
-PREV +
-PREVIOUS +
-PREVVAL +
-PRIMARY +
-PRIVATE +
-PRIVILEGE +
-xref:n1ql-language-reference/join.adoc#use-hash-hint[PROBE] +
-PROCEDURE +
-PUBLIC +
-xref:n1ql-language-reference/window.adoc#window-frame-clause[RANGE] +
-RAW +
-READ +
-REALM +
-RECURSIVE +
-REDUCE +
-RENAME +
-REPLACE +
-xref:n1ql-language-reference/window.adoc#nulls-treatment[RESPECT] +
-RESTART +
-RESTRICT +
-RETURN +
-RETURNING +
-xref:n1ql-language-reference/revoke.adoc[REVOKE] +
-RIGHT +
-ROLE +
-ROLES +
-xref:n1ql:n1ql-language-reference/rollback-transaction.adoc[ROLLBACK] +
-xref:n1ql-language-reference/window.adoc#window-frame-extent[ROW] +
-xref:n1ql-language-reference/window.adoc#window-frame-clause[ROWS] +
-SATISFIES +
-xref:n1ql:n1ql-language-reference/savepoint.adoc[SAVEPOINT] +
-SCHEMA +
-SCOPE +
-xref:n1ql-language-reference/selectclause.adoc[SELECT] +
-SELF +
+[%hardbreaks]
+xref:n1ql-language-reference/window.adoc#window-frame-extent[PRECEDING] 
+xref:n1ql-language-reference/prepare.adoc[PREPARE] 
+PREV 
+PREVIOUS 
+PREVVAL 
+PRIMARY 
+PRIVATE 
+PRIVILEGE 
+xref:n1ql-language-reference/join.adoc#use-hash-hint[PROBE] 
+PROCEDURE 
+PUBLIC 
+xref:n1ql-language-reference/window.adoc#window-frame-clause[RANGE] 
+RAW 
+READ 
+REALM 
+RECURSIVE 
+REDUCE 
+RENAME 
+REPLACE 
+xref:n1ql-language-reference/window.adoc#nulls-treatment[RESPECT] 
+RESTART 
+RESTRICT 
+RETURN 
+RETURNING 
+xref:n1ql-language-reference/revoke.adoc[REVOKE] 
+RIGHT 
+ROLE 
+ROLES 
+xref:n1ql:n1ql-language-reference/rollback-transaction.adoc[ROLLBACK] 
+xref:n1ql-language-reference/window.adoc#window-frame-extent[ROW] 
+xref:n1ql-language-reference/window.adoc#window-frame-clause[ROWS] 
+SATISFIES 
+xref:n1ql:n1ql-language-reference/savepoint.adoc[SAVEPOINT] 
+SCHEMA 
+SCOPE 
+xref:n1ql-language-reference/selectclause.adoc[SELECT] 
+SELF 
 
 [.column]
-SEQUENCE +
-SEMI +
-SET +
-SHOW +
-SOME +
-START +
-STATISTICS +
+[%hardbreaks]
+SEQUENCE 
+SEMI 
+SET 
+SHOW 
+SOME 
+START 
+STATISTICS 
 STRING
-SYSTEM +
-THEN +
-xref:n1ql-language-reference/window.adoc#window-frame-exclusion[TIES] +
-TO +
-xref:n1ql:n1ql-language-reference/begin-transaction.adoc[TRAN] +
-xref:n1ql:n1ql-language-reference/begin-transaction.adoc[TRANSACTION] +
-TRIGGER +
-TRUE +
-TRUNCATE +
-xref:n1ql-language-reference/window.adoc#window-frame-extent[UNBOUNDED] +
-UNDER +
-xref:n1ql-language-reference/union.adoc[UNION] +
-UNIQUE +
-UNKNOWN +
-xref:n1ql-language-reference/unnest.adoc[UNNEST] +
-xref:n1ql-language-reference/update.adoc#unset-clause[UNSET] +
-xref:n1ql-language-reference/update.adoc[UPDATE] +
-xref:n1ql-language-reference/upsert.adoc[UPSERT] +
-xref:n1ql-language-reference/hints.adoc[USE] +
-USER +
-USERS +
-USING +
-VALIDATE +
-VALUE +
-VALUED +
-VALUES +
-VECTOR +
-VIA +
-VIEW +
+SYSTEM 
+THEN 
+xref:n1ql-language-reference/window.adoc#window-frame-exclusion[TIES] 
+TO 
+xref:n1ql:n1ql-language-reference/begin-transaction.adoc[TRAN] 
+xref:n1ql:n1ql-language-reference/begin-transaction.adoc[TRANSACTION] 
+TRIGGER 
+TRUE 
+TRUNCATE 
+xref:n1ql-language-reference/window.adoc#window-frame-extent[UNBOUNDED] 
+UNDER 
+xref:n1ql-language-reference/union.adoc[UNION] 
+UNIQUE 
+UNKNOWN 
+xref:n1ql-language-reference/unnest.adoc[UNNEST] 
+xref:n1ql-language-reference/update.adoc#unset-clause[UNSET] 
+xref:n1ql-language-reference/update.adoc[UPDATE] 
+xref:n1ql-language-reference/upsert.adoc[UPSERT] 
+xref:n1ql-language-reference/hints.adoc[USE] 
+USER 
+USERS 
+USING 
+VALIDATE 
+VALUE 
+VALUED 
+VALUES 
+VECTOR 
+VIA 
+VIEW 
 
 [.column]
-WHEN +
-xref:n1ql-language-reference/where.adoc[WHERE] +
-WHILE +
-xref:n1ql-language-reference/window.adoc[WINDOW] +
-xref:n1ql-language-reference/with.adoc[WITH] +
-xref:n1ql-language-reference/collectionops.adoc#collection-op-within[WITHIN] +
-xref:n1ql:n1ql-language-reference/begin-transaction.adoc[WORK] +
-XOR +
+[%hardbreaks]
+WHEN 
+xref:n1ql-language-reference/where.adoc[WHERE] 
+WHILE 
+xref:n1ql-language-reference/window.adoc[WINDOW] 
+xref:n1ql-language-reference/with.adoc[WITH] 
+xref:n1ql-language-reference/collectionops.adoc#collection-op-within[WITHIN] 
+xref:n1ql:n1ql-language-reference/begin-transaction.adoc[WORK] 
+XOR 
 
 ++++
 </div>

--- a/modules/n1ql/pages/n1ql-language-reference/reservedwords.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/reservedwords.adoc
@@ -39,8 +39,8 @@ The following keywords are reserved and cannot be used as unescaped identifiers:
   flex-basis: 10%;
   padding-right: 1rem;
   padding-left: 1rem;
-  margin-top: 10px
-
+  margin-top: 10px;
+  white-space: nowrap;
 }
 </style>
 <div class="card-row six-column-row">


### PR DESCRIPTION

Changed the layout of the reserved words list. 

They're now listed in columns flowing top to bottom.

Hakim should review as he might know of a better way to do this, without embedding CSS code on the AsciiDoc page.

Preview URL:
https://preview.docs-test.couchbase.com/docs-devex-DOC-13222/release/8.0/Feedback-on-Reserved-Words--Couchbase-Docs/server/current/n1ql/n1ql-language-reference/reservedwords.html

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.