### PR TITLE
[AV-110625] Add Mention of Preset Document FIlter Examples

### DIFF
--- a/modules/search/pages/set-type-identifier.adoc
+++ b/modules/search/pages/set-type-identifier.adoc
@@ -131,8 +131,13 @@ For more information about the properties for each document filter type, see:
 * xref:search-index-params.adoc#disjunct_filter[Disjunct Document Filters]
 
 +
-TIP: Do not add the name of your document filter to your filter definition when defining a custom document filter through the {page-ui-name}.
+[TIP]
+====
+Do not add the name of your document filter to your filter definition when defining a custom document filter through the {page-ui-name}.
 Define the document filter as an unnamed object with the specific properties you need for your document filter type.
+
+You can also click a *Preset Example* to automatically add the necessary fields for each filter type to your editor.
+====
 
 +
 . Click btn:[Save].


### PR DESCRIPTION
Small change to add a mention of the new preset examples that were added to the Capella Search UI: 

<img width="1147" height="638" alt="image" src="https://github.com/user-attachments/assets/2cdfa302-016c-42da-8a81-66a2b9c1813f" />
