### PR TITLE
Changed database instances to cluster in 2 files

### DIFF
--- a/modules/eventing/pages/eventing-Terminologies.adoc
+++ b/modules/eventing/pages/eventing-Terminologies.adoc
@@ -283,7 +283,7 @@ The Function name must:
 |Deployment Feed Boundary
 |The Feed Boundary determines if the Eventing Function's activities need to include documents that already exist.
 
-When you set the Feed Boundary to `Everything`, the Function deploys all mutations available in your cluster.
+When you set the Feed Boundary to `Everything`, the Function processes all mutations available in your cluster.
 When you set the Feed Boundary to `From Now`, the Function only processes instances of data mutation that happen after the Function's deployment.
 
 The Feed Boundary also works as a checkpoint for paused Functions.

--- a/modules/eventing/pages/eventing-Terminologies.adoc
+++ b/modules/eventing/pages/eventing-Terminologies.adoc
@@ -103,7 +103,7 @@ All states in the execution stack are short-lived.
 Couchbase does not store every version a document permanently.
 When a handler receives the mutation history of documents from Eventing, it sees a truncated history of each document.
 
-NOTE: Because the current state of a document is always available in the database, the final state of a document is always present in the mutation history.
+NOTE: Because the current state of a document is always available in the cluster, the final state of a document is always present in the mutation history.
 
 To ensure high performance, the KV data engine deduplicates multiple mutations made to an individual document in succession.
 Handlers might not see all intermediate states of a document when it mutates quickly, but they do see its final state.
@@ -283,7 +283,7 @@ The Function name must:
 |Deployment Feed Boundary
 |The Feed Boundary determines if the Eventing Function's activities need to include documents that already exist.
 
-When you set the Feed Boundary to `Everything`, the Function deploys all mutations available in your database.
+When you set the Feed Boundary to `Everything`, the Function deploys all mutations available in your cluster.
 When you set the Feed Boundary to `From Now`, the Function only processes instances of data mutation that happen after the Function's deployment.
 
 The Feed Boundary also works as a checkpoint for paused Functions.

--- a/modules/eventing/pages/eventing-advanced-keyspace-accessors.adoc
+++ b/modules/eventing/pages/eventing-advanced-keyspace-accessors.adoc
@@ -411,7 +411,7 @@ function OnUpdate(doc, meta) {
 
 The TOUCH operation lets you modify the expiration time of a document without the need to access that document first.
 
-You can use this operation if your application does not need to access the database when handling a user session.
+You can use this operation if your application does not need to access the cluster when handling a user session.
 
 ==== Example
 ====


### PR DESCRIPTION
[DOC-12101](https://jira.issues.couchbase.com/browse/DOC-12101)

Replaced the term **database** to **cluster** as we only use database when talking generally about the concept of a database. Made changes to 2 files: the **Eventing Terminology** and **Advanced Keyspace Accessors** chapters. 

Docs preview for **Eventing Terminology** --> https://preview.docs-test.couchbase.com/docs-devex-DOC-12101_Eventing_Replace_Database_with_Cluster/server/current/eventing/eventing-Terminologies.html

and

Docs preview for **Advanced Keyspace Accessors**  --> https://preview.docs-test.couchbase.com/docs-devex-DOC-12101_Eventing_Replace_Database_with_Cluster/server/current/eventing/eventing-advanced-keyspace-accessors.html

[Preview credentials](https://couchbasecloud.atlassian.net/wiki/x/dYF_dQ#Preview-docs-for-internal-review)

[DOC-12101]: https://couchbasecloud.atlassian.net/browse/DOC-12101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ