### PR TITLE
[DOC-13923] Clarify Behaviour When Field Names Contain Periods

### DIFF
--- a/modules/search/examples/about-mappings.jsonc
+++ b/modules/search/examples/about-mappings.jsonc
@@ -1,0 +1,56 @@
+{
+  "type": "shorthair",
+  "name": "British Shorthair",
+  "category": "shorthaired",
+  "origin": {
+    "country": "United Kingdom",
+    "region": "Great Britain"
+  },
+  "physicalCharacteristics": {
+    "coatLength": "short",
+    "coatTexture": "dense",
+    "commonColors": [
+      "blue",
+      "black",
+      "white",
+      "cream",
+      "silver"
+    ],
+    "eyeColors": [
+      "copper",
+      "gold",
+      "blue",
+      "green"
+    ],
+    "averageWeightKg": {
+      "male": 6.5,
+      "female": 5.0
+    }
+  },
+  "temperament": [
+    "calm",
+    "affectionate",
+    "independent",
+    "gentle"
+  ],
+  "energyLevel": "moderate",
+  "intelligence": "high",
+  "lifespanYears": {
+    "min": 12,
+    "max": 17
+  },
+  "careRequirements": {
+    "groomingFrequency": "weekly",
+    "sheddingLevel": "moderate",
+    "healthNotes": [
+      "prone to obesity if overfed",
+      "can be predisposed to hypertrophic cardiomyopathy"
+    ]
+  },
+  "goodWith": {
+    "children": true,
+    "otherCats": true,
+    "dogs": true
+  },
+  "description": "The British Shorthair is a sturdy, round-faced cat known for its plush coat and easygoing personality. It is affectionate without being overly demanding and adapts well to indoor living."
+}

--- a/modules/search/pages/about-mappings.adoc
+++ b/modules/search/pages/about-mappings.adoc
@@ -1,0 +1,137 @@
+= About Mapping Collections, Objects and Fields
+:page-topic-type: concept
+:description: The Search Service has distinct mapping types for collections, objects, and fields in a Search index.
+
+[abstract]
+{description}
+
+Mappings control the specific documents and fields that you can return in a xref:search:run-searches.adoc[Search query].
+
+You can create the following types of mappings: 
+
+* <<collections,>>
+* <<objects,>>
+* <<fields,>>
+* <<xattrs,>>
+
+When you create a new mapping, you need to choose whether you want a <<static-vs-dynamic,Static or Dynamic Mapping>>.
+
+[#collections]
+== Collection Mappings
+
+The mapping for a collection is also called a type mapping.
+
+A type mapping includes or excludes specific documents in a collection from an index.
+A document must match the collection and document type set by a type mapping to be included in a Search index.
+
+You can also choose to control the type of a document by xref:search:set-type-identifier.adoc[setting a type identifier].
+A type identifier is an optional configuration that tells the Search Service how to interpret a document's type.
+Only documents that pass the filter from your type identifier can be included in your Search index under a specific type mapping, and potentially returned in search results.
+
+Type mappings can be <<static,>> or <<dynamic,>>.
+Add <<objects,>> and <<fields,>> to make a collection type mapping a static mapping.
+
+For more information about how to create a type mapping, see xref:search:create-type-mapping.adoc[].
+
+=== Collection Type Mapping Names
+
+The Search Service uses periods (`.`) to separate collection names from xref:search:customize-index.adoc#type-identifiers[type identifiers]. 
+If you add a period to the name of your collection type mapping, the Search Service would interpret anything after the period as a filter value. 
+
+For example, if you wanted to include the following document in your Search index, with a `type` value of `shorthair`: 
+
+[source,json]
+----
+include::example$about-mappings.jsonc[]
+----
+
+If you used a collection type mapping called `cat.breeds` and used the default *JSON type field* type identifier, the Search Service would only include documents that had a value of `breeds` in their `type` field.
+That means that the British Shorthair document would not match the type mapping, and would not be included in the Search index. 
+
+[#objects]
+== Object Mappings 
+
+Use an object mapping to add a nested JSON object from your documents to your Search index.
+
+For example, you would use an object mapping to add the `origin` object and its child fields to your Search index: 
+
+[source,json]
+----
+include::example$about-mappings.jsonc[lines=1..8]
+----
+
+Like <<collections,>>, object mappings can be <<static,static>> or <<dynamic,dynamic>>.
+You can add <<fields,>> to make an object mapping a static type mapping.
+
+=== Object Names
+
+Avoid using an object name that contains a period (`.`) in a Search index object mapping.
+
+The Search Service uses periods to maintain object and child field relationships after flattening. 
+For example, the `country` and `region` fields inside the `origin` object would be represented as `origin.country` and `origin.region` inside your Search index: 
+
+[source,json]
+----
+include::example$about-mappings.jsonc[lines=1..8]
+----
+
+If you created a mapping for a field called `origin.country` as well as a `country` field mapping inside the `origin` object, the Search Service creates a single field index for both fields.
+If you tried to query `origin.country` in a Search query with an analyzer, the Search Service would fail to pick the right analyzer for the `origin.country` field because of the 2 overlapping mappings.
+This can cause undesired or unexpected search results.
+
+To avoid issues with overlapping field and object names in a Search index, do not use periods (`.`) in your JSON document field or object names.
+
+[#fields]
+== Child Field Mappings
+
+Use a child field mapping to add a specific document field from your documents to your Search index. 
+
+A child field mapping can exist at the top-level of your document hierarchy and be created directly under a <<collections,collection type mapping>>, or it can exist as a nested field underneath an <<objects,object mapping>> or <<xattrs,XATTRs mapping>>.
+
+Use a child field mapping to turn a parent mapping into a static mapping.
+
+For example, you could create a child field mapping for the `type`, `name`, and `category` fields underneath the collection type mapping for this document.
+You could also create a child field mapping under the object mapping for the `origin` object for the `country` and `region` fields:
+
+[source,json]
+----
+include::example$about-mappings.jsonc[lines=1..8]
+----
+
+Just like <<object-names,>>, to avoid undesired results in your Search queries, avoid using periods (`.`) in your child field names.
+See <<object-names,>> for examples and an explanation. 
+
+[#xattrs]
+== XATTRs Mappings
+
+IMPORTANT: You can only use XATTRs mappings in the Advanced Mode editor.
+
+Extended Attributes (XATTRs) mappings add fields and metadata from your document's XATTRs and let you query them inside a Search index.
+
+XATTRs mappings can be <<static,static>> or <<dynamic,dynamic>>, based on whether you add <<fields,>>.
+
+Just like <<object-names,>> and <<fields,>>, to avoid undesired results in your Search queries, avoid using periods (`.`) in the names of fields in your document metadata.
+See <<object-names,>> for examples and an explanation. 
+
+[#static-vs-dynamic]
+== Choosing a Static or Dynamic Mapping
+
+Each mapping type can be either *static* or *dynamic*: 
+
+[[static]]Static mappings:: When your data fields are stable and unlikely to change, use a static type mapping to add and define only specific fields from a matching document type to an index.
+If you're unsure about your document structure and how it might change, use <<dynamic,>>, instead.
++
+For example, you could create a static type mapping to only include the contents of the `description` field from the `cats` collection in your Search index, as a text field with an `en` analyzer.
++
+Add <<fields,>> to a <<collections,collection type mapping>>, <<objects,object mapping>>, or <<xattrs,XATTRs mapping>> to make it static.
+
+[[dynamic]]Dynamic mappings:: When you do not know the structure of your data fields ahead of time, use a dynamic type mapping to add all available fields from a matching document type, collection, or JSON object to an index.
+If your document structure is more stable and unlikely to change, use <<static,>> to get the best results from the Search Service. 
++
+For example, you could create a dynamic type mapping to include all documents from a `cats` collection in your Search index, or include all fields under the `careRequirements` object from a document schema.
+
+
+== See Also
+
+* xref:set-type-identifier.adoc[]
+* xref:create-type-mapping.adoc[]

--- a/modules/search/pages/create-type-mapping.adoc
+++ b/modules/search/pages/create-type-mapping.adoc
@@ -9,8 +9,8 @@
 [abstract]
 {description}
 
-You can create xref:customize-index.adoc#static[static type mappings], which include only specific fields from your documents, or xref:customize-index.adoc#dynamic[dynamic type mappings], which include all available fields.
-For more information about type mappings and mappings in the Search Service, see xref:customize-index.adoc#type-mappings[Type Mappings and Mappings].
+You can create xref:about-mappings.adoc#static[static type mappings], which include only specific fields from your documents, or xref:about-mappings.adoc#dynamic[dynamic type mappings], which include all available fields.
+For more information about type mappings and mappings in the Search Service, see xref:about-mappings.adoc[].
 
 Some mappings are only available in Advanced Mode.
 
@@ -53,7 +53,7 @@ To use the {page-ui-name} to create a new type mapping or mapping on a Search in
 [#collection]
 === Add a Collection Type Mapping 
 
-Add a collection type mapping to index all documents from a specific collection in your chosen bucket and scope.
+Add a xref:about-mappings.adoc#collections[collection type mapping] to index all documents from a specific collection in your chosen bucket and scope.
 
 To add an entire collection as a new type mapping: 
 
@@ -74,7 +74,7 @@ To add a document filter to a mapping, see xref:set-type-identifier.adoc[].
 
 NOTE: XATTRs mappings can only be created with *Advanced Mode*. 
 
-Add an XATTRs mapping to index document metadata from a specific collection. 
+Add an xref:about-mappings.adoc#xattrs[XATTRs mapping] to index document metadata from a specific collection. 
 
 To add Extended Attributes (XATTRs) document metadata as a new mapping: 
 
@@ -86,8 +86,8 @@ To add Extended Attributes (XATTRs) document metadata as a new mapping:
 [#object]
 === Add a JSON Object Mapping 
 
-Add a JSON object mapping to index a JSON object from your document schema.
-You can choose to index the fields inside the JSON object as <<field,field mappings>>, or keep your JSON object mapping as a xref:customize-index.adoc#dynamic[dynamic mapping].
+Add a xref:about-mappings.adoc#objects[JSON object mapping] to index a JSON object from your document schema.
+You can choose to index the fields inside the JSON object as <<field,field mappings>>, or keep your JSON object mapping as a xref:about-mappings.adoc#dynamic[dynamic mapping].
 
 To add an entire JSON object from your documents as a new mapping: 
 
@@ -97,10 +97,10 @@ To add an entire JSON object from your documents as a new mapping:
 . Click btn:[Add To Index].
 
 [#field]
-=== Add a Single Document Field Mapping 
+=== Add a Child Field Mapping 
 
-Add a single document field mapping to index a single document field from your document schema.
-Adding document field mappings turns any parent mappings into xref:customize-index.adoc#static[static type mappings].
+Add a xref:about-mappings.adoc#fields[child field mapping] to index a single document field from your document schema.
+Adding document field mappings turns any parent mappings into xref:about-mappings.adoc#static[static type mappings].
 
 To add only a single field from your documents as a new mapping:
 

--- a/modules/search/pages/customize-index.adoc
+++ b/modules/search/pages/customize-index.adoc
@@ -183,27 +183,7 @@ For more information about how to configure settings for the different types of 
 
 For more information about how to configure a type mapping in the Search index editor, see xref:create-type-mapping.adoc[].
 
-You can create 2 types of type mappings with the Search Service: 
-
-* <<dynamic,Dynamic Type Mappings>>
-* <<static,Static Type Mappings>>
-
-[#dynamic]
-=== Dynamic Type Mappings
-
-When you do not know the structure of your data fields ahead of time, use a dynamic type mapping to add all available fields from a matching document type to an index.
-For example, you could create a dynamic type mapping to include all documents from the `hotel` collection in your Search index, or include all fields under a JSON object from your document schema.
-
-Configure this type of mapping by selecting a collection or JSON object in the Search index editor when you xref:create-type-mapping.adoc[]. 
-
-[#static]
-=== Static Type Mappings
-
-When your data fields are stable and unlikely to change, use a static type mapping to add and define only specific fields from a matching document type to an index. 
-For example, you could create a static type mapping to only include the contents of the `city` field from the `hotel` collection in your Search index, as a text field with an `en` analyzer.
-
-Configure this type of mapping by selecting a field in your document schema in the Search index editor when you xref:create-type-mapping.adoc[].
-
+For more information about the different types of type mappings, see xref:about-mappings.adoc[].
 
 [#replica]
 == Replica and Partition Settings

--- a/modules/search/pages/field-data-types-reference.adoc
+++ b/modules/search/pages/field-data-types-reference.adoc
@@ -10,7 +10,7 @@
 When you xref:create-type-mapping.adoc[], you need to set the field's data type. 
 
 If you create a Search index and do not set a data type for a field, the Search Service automatically assigns a field data type.
-For example, if you created a xref:customize-index.adoc#type-mappings[dynamic type mapping], the Search Service automatically assigns data types to all fields in the type mapping.
+For example, if you created a xref:about-mappings.adoc#dynamic[dynamic type mapping], the Search Service automatically assigns data types to all fields in the type mapping.
 
 The following field data types are available: 
 

--- a/modules/search/pages/search-index-params.adoc
+++ b/modules/search/pages/search-index-params.adoc
@@ -1444,10 +1444,10 @@ For more information, see xref:clusters:data-service/manage-documents.adoc[].
 |dynamic |Boolean |Yes a|
 
 To index all fields under the specified scope and collection, JSON object, or all fields inside XATTRs, set `dynamic` to `true`.
-This creates a xref:customize-index.adoc#dynamic[dynamic type mapping].
+This creates a xref:about-mappings.adoc#dynamic[dynamic type mapping].
 
 To only index the fields you specify and enable the `properties` block, set `dynamic` to `false`.
-This creates a xref:customize-index.adoc#static[static type mapping].
+This creates a xref:about-mappings.adoc#static[static type mapping].
 
 |enabled |Boolean |Yes a| 
 

--- a/modules/search/pages/set-advanced-settings.adoc
+++ b/modules/search/pages/set-advanced-settings.adoc
@@ -52,7 +52,7 @@ For more information, see xref:set-type-identifier.adoc[].
 For more information, see xref:synonyms/synonyms-search.adoc[].
 .. Choose the scoring model you want to use with your Search index.
 For more information about scoring models, see xref:customize-index.adoc#scoring-model[Scoring Model].
-.. If you're using xref:customize-index.adoc#dynamic[dynamic type mappings], choose how to handle dynamic fields in your Search index:
+.. If you're using xref:about-mappings.adoc#dynamic[dynamic type mappings], choose how to handle dynamic fields in your Search index:
 ... To store the content of any fields added to a Search index from a dynamic type mapping, turn on *Store Dynamic Fields*. 
 ... To include fields or whole documents in your Search index that match a dynamic type mapping, turn on *Index Dynamic Fields*. 
 . Click btn:[Update Index].

--- a/modules/search/partials/nav.adoc
+++ b/modules/search/partials/nav.adoc
@@ -2,6 +2,7 @@
   ** xref:cloud:search:create-search-indexes.adoc[]
     *** xref:cloud:search:customize-index.adoc[]
     *** xref:cloud:search:create-search-index-ui.adoc[]
+      **** xref:cloud:search:about-mappings.adoc[]
       **** xref:cloud:search:create-type-mapping.adoc[]
         ***** xref:cloud:search:type-mapping-options.adoc[]
       **** xref:cloud:search:set-type-identifier.adoc[]


### PR DESCRIPTION
Capella version of https://github.com/couchbaselabs/docs-devex/pull/575

Ticket came in asking if we could clarify for users what happens when their field names contain periods and they try to use those with mappings in the Search Service.

Decided best course of action was a new page describing the mapping types in more details, with the impact periods have on each type.

Updated links and removed redundant info to support that.

Preview URL:
https://preview.docs-test.couchbase.com/docs-devex-DOC-13923-field-names-with-periods-capella/cloud/search/about-mappings.html

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.