### PR TITLE
[DOC-12772] Update INSERT Statement - Expiration Values

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/insert.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/insert.adoc
@@ -233,9 +233,17 @@ options::
 Only the listed attributes have any effect; the statement ignores the others.
 
 expiration:::
-An integer, or an expression resolving to an integer, representing the {document-expiration}[document expiration] in seconds.
+An integer, or an expression resolving to an integer, representing the {document-expiration}[document expiration].
 +
-If the document expiration is not specified, it defaults to `0`, meaning the document expiration is the same as the {bucket-expiration}[bucket or collection expiration].
+--
+* If the expiration time is less than 30 days, specify value in seconds. 
+For example, `60*60*24*14` sets the document to expire in 14 days. 
+* If the expiration time is 30 days or more, specify the value as a Unix timestamp. 
+* If no expiration is specified, the value defaults to `0`. 
+In this case, the document expiration matches the {bucket-expiration}[bucket or collection expiration].
+--
++
+WARNING: Setting an incorrect expiration may cause documents to expire earlier than intended, resulting in data loss. 
 
 xattrs:::
 An object containing top-level extended attribute (XATTR) names and their corresponding JSON values. 

--- a/modules/n1ql/pages/n1ql-language-reference/insert.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/insert.adoc
@@ -236,7 +236,7 @@ expiration:::
 An integer, or an expression resolving to an integer, representing the {document-expiration}[document expiration].
 +
 --
-* If the expiration time is less than 30 days, specify value in seconds. 
+* If the expiration time is less than 30 days, specify the value in seconds. 
 For example, `60*60*24*14` sets the document to expire in 14 days. 
 * If the expiration time is 30 days or more, specify the value as a Unix timestamp. 
 * If no expiration is specified, the value defaults to `0`. 


### PR DESCRIPTION
Updates the INSERT statement to clarify expiration values.
(Didn't update the similar part in UPSERT because the doc points to INSERT for details.)

Jira: DOC-12772
Preview: [INSERT > VALUES Clause > Options](https://preview.docs-test.couchbase.com/docs-devex-DOC-12772-insert-upsert-ttl/server/current/n1ql/n1ql-language-reference/insert.html#values-clause)
