### PR TITLE
[DOC-13202] Additional details for 'name' parameter in PREPARE

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
@@ -124,16 +124,26 @@ See <<ex-prepare-positions>>.
 [[result]]
 == Result
 
-A JSON object is returned that contains the following properties:
+A JSON object that contains the following properties:
 
 name:: The full name of the prepared statement.
-This has the format `[host:port]local-name-or-UUID`, and consists of:
 +
-* The host and port of the node where the prepared statement was created, in square brackets, followed by
-* The local name that you specified for the prepared statement, or a UUID that was generated from the statement text.
-
+The name uses the format `[host:port]local-name-or-UUID`, and consists of:
 +
-The host and port can be used when executing to retrieve the prepared statement from the node where it was created.
+--
+* The host and port of the node where you created the prepared statement, enclosed in square brackets. 
+* The local name you specified for the prepared statement, or a UUID that the Query Service generated from the statement text.
+--
++
+You can use this name to execute the prepared statement without resending the full statement text.
++
+When you execute a prepared statement by name:
++
+--
+* The Query Service first checks whether the executing node contains the prepared statement in its local cache.
+* If not found, the service uses the host information in the name to retrieve the prepared statement from the node where you originally created it.
+* If the service cannot find the statement on the original node either, it returns an error. 
+--
 
 operator:: The execution plan of the statement being prepared.
 

--- a/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
@@ -127,22 +127,20 @@ See <<ex-prepare-positions>>.
 A JSON object that contains the following properties:
 
 name:: The full name of the prepared statement.
-+
-The name uses the format `[host:port]local-name-or-UUID`, and consists of:
+This has the format `[host:port]local-name-or-UUID`, and consists of:
 +
 --
 * The host and port of the node where you created the prepared statement, enclosed in square brackets. 
-* The local name you specified for the prepared statement, or a UUID that the Query Service generated from the statement text.
+* The local name you specified for the prepared statement, or a UUID that was generated from the statement text.
 --
 +
-You can use this name to execute the prepared statement without resending the full statement text.
-+
-When you execute a prepared statement by name:
+You can use this name to execute a prepared statement without resending the entire statement text.
+When executing a prepared statement by its name:
 +
 --
-* The Query Service first checks whether the executing node contains the prepared statement in its local cache.
+* The Query Service first checks whether the executing node contains the prepared statement.
 * If not found, the service uses the host information in the name to retrieve the prepared statement from the node where you originally created it.
-* If the service cannot find the statement on the original node either, it returns an error. 
+* If the service cannot find the prepared statement on the original node either, it returns an error. 
 --
 
 operator:: The execution plan of the statement being prepared.


### PR DESCRIPTION
Updated the PREPARE statement to include additional information about the `name` parameter. 

- Jira: DOC-13202
- Preview: [PREPARE > Result ](https://preview.docs-test.couchbase.com/docs-devex-DOC-13202-prepare-statement/server/current/n1ql/n1ql-language-reference/prepare.html#result)
- [Preview credentials for review](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords#Preview-docs-for-internal-Couchbase-reviews)