### PR TITLE
[DOC-14047]: Feedback on Covering Indexes | Couchbase Docs

### DIFF
--- a/modules/indexes/partials/diagrams/query-execution.puml
+++ b/modules/indexes/partials/diagrams/query-execution.puml
@@ -3,7 +3,7 @@
 skinparam maxMessageSize 125
 skinparam roundcorner 5
 skinparam responseMessageBelowArrow true
-skinparam sequenceMessageAlign direction
+skinparam sequenceMessageAlign right
 skinparam ParticipantPadding 10
 skinparam BoxPadding 60
 skinparam box {


### PR DESCRIPTION

The NPE problem is caused by the inclusion of the line:

`skinparam sequenceMessageAlign direction`

This is a known bug in PlantUML:

https://github.com/plantuml/plantuml/issues/2477

which has been fixed, but Kroki needs to have its PlantUML module upgraded to implement the fix.

In the meantime, the line has been changed to align the text to the `right` which seems to work.

> [!NOTE]
> As a side note, `skinparam` has been deprecated from PlantUML. We should be using CSS where possible. 

----

Preview URL:
https://preview.docs-test.couchbase.com/docs-devex-DOC-14047--8.0--Feedback-on-Covering-Indexes/server/current/indexes/covering-indexes.html

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.