### PR TITLE
[NO ISSUE] Fix typo in the UPDATE DDL page

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/update.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/update.adoc
@@ -158,12 +158,12 @@ If you assign an alias to the keyspace reference, the `AS` keyword may be omitte
 [[use-clause]]
 === USE Clause
 
-You can use a `USE` clause to provide hints for the delete target.
+You can use a `USE` clause to provide hints for the update target.
 
 The clause supports the following hints: 
 
-* `USE KEYS`: Specifies the keys of the data items to delete.
-* `USE INDEX`: Specifies the index to use for the delete operation.
+* `USE KEYS`: Specifies the keys of the data items to update.
+* `USE INDEX`: Specifies the index to use for the update operation.
 
 For more information, see {use-clause}[USE Clause].
 


### PR DESCRIPTION
Replaced the term _delete_ with _update_  in the USE Clause section of the UPDATE page. 