### PR TITLE
[AV 125999] How to Export a Search Index (Server)

### DIFF
--- a/modules/search/pages/export-search-index.adoc
+++ b/modules/search/pages/export-search-index.adoc
@@ -1,0 +1,46 @@
+= Get a Search Index Definition from the Web Console
+:page-topic-type: guide
+:page-ui-name: {ui-name}
+:page-product-name: {product-name}
+:description: Use the Couchbase {page-ui-name} to copy and paste a JSON Search index definition for use in the REST API or another cluster.
+
+[abstract]
+{description}
+
+NOTE: You cannot export a Search index definition as a downloadable file.
+You can only copy the Search index definition from an existing index.
+
+== Prerequisites
+
+* You have the Search Service enabled on a node in your cluster.
+For more information about how to deploy a new node and Services on your cluster, see xref:server:manage:manage-nodes/node-management-overview.adoc[].
+
+* You have a bucket with scopes and collections in your cluster.
+For more information about how to create a bucket, see xref:server:manage:manage-buckets/create-bucket.adoc[].
+
+* Your user account has the xref:learn:security/roles.adoc#search-admin[`Search Admin`] role for the bucket where you want to export an index definition.  
+
+* You have created a Search index. 
++
+For more information about how to create a Search index, see xref:create-search-index-ui.adoc[] or xref:create-search-index-rest-api.adoc[].
+
+* You have logged in to the Couchbase {page-ui-name}. 
+
+== Procedure
+
+To copy a Search index definition from the {page-ui-name}:
+
+. Go to *Search*.
+. Click the name of the Search index definition you want to copy.
+. Expand *Show index definition JSON*.
+. Click btn:[Copy to Clipboard].
+
+TIP: When you xref:create-search-index-ui.adoc[create a Search index with the {page-ui-name}], you can also click btn:[copy to clipboard] on the *Index Definition Preview* to copy the Search index definition.
+
+== Next Steps
+
+You can paste the copied definition into a new `.json` file to import it into a new cluster, or use the definition with the xref:create-search-index-rest-api.adoc[Search REST API].
+
+To import your Search index definition into a new Couchbase Server cluster through the Web Console, see xref:server:search:import-search-index.adoc[].
+
+To import your Search index into a Couchbase Capella cluster, see xref:cloud:search:import-search-index.adoc[].

--- a/modules/search/partials/nav.adoc
+++ b/modules/search/partials/nav.adoc
@@ -11,6 +11,7 @@
         ***** xref:search:synonyms/create-synonym-collection-docs-quick.adoc[]
         ***** xref:search:synonyms/add-synonym-source-quick.adoc[]
     *** xref:search:import-search-index.adoc[]
+    *** xref:search:export-search-index.adoc[]
     *** xref:search:search-index-architecture.adoc[]
   ** xref:search:view-index-details.adoc[]
   ** xref:search:run-searches.adoc[]

--- a/preview/AV-125999-export-search-index-server.yml
+++ b/preview/AV-125999-export-search-index-server.yml
@@ -1,0 +1,11 @@
+sources:
+  docs-server:
+    branches: [release/8.0]
+  cb-swagger:
+    branches: [release/8.0]
+  docs-devex:
+    branches: [AV-125999-export-search-index-capella, AV-125999-export-search-index-server]
+  docs-capella:
+    branches: [main]
+override:
+  startPage: server:introduction:intro.adoc


### PR DESCRIPTION
New documentation on how to export a Search index from the Web Console. 

Making a new page for this in case they decide to create a single button click for this in the future, like on Capella, to keep the info clean and easy to find. 

Preview site: https://preview.docs-test.couchbase.com/docs-devex-AV-125999-export-search-index-server/server/current/search/export-search-index.html

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.