### PR TITLE
[DOC-12023] Add a note about the maxTTL setting

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/createcollection.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createcollection.adoc
@@ -106,7 +106,7 @@ Overrides the maximum time-to-live set by the bucket.
 `-1`: By default, items in the collection never expire.
 Overrides the maximum time-to-live set by the bucket.
 
-NOTE: The `maxTTL` attribute is an Enterprise Edition setting.
+NOTE: `maxTTL` is an Enterprise Edition setting.
 While the attribute is available in Community Edition, it only supports the value `0`.
 Setting `maxTTL` to any other value in Community Edition results in an error.
 

--- a/modules/n1ql/pages/n1ql-language-reference/createcollection.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createcollection.adoc
@@ -93,7 +93,9 @@ Only the `maxTTL` attribute is valid; any other attributes generate an error.
 
 |**maxTTL** +
 __required__
-|The maximum time-to-live for any item in the collection.
+|[.status]#Enterprise Edition# 
+
+The maximum time-to-live for any item in the collection.
 May have any of the following values.
 
 `0` or unspecified: The collection inherits the maximum time-to-live setting from the bucket which contains it.
@@ -103,6 +105,10 @@ Overrides the maximum time-to-live set by the bucket.
 
 `-1`: By default, items in the collection never expire.
 Overrides the maximum time-to-live set by the bucket.
+
+NOTE: The `maxTTL` attribute is an Enterprise Edition setting.
+While the attribute is available in Community Edition, it only supports the value `0`.
+Setting `maxTTL` to any other value in Community Edition results in an error.
 
 |integer
 |===


### PR DESCRIPTION
Adding a note to say that `maxTTL` is an Enterprise Edition setting in `CREATE COLLECTION`. 

Jira: DOC-12023
Preview: [CREATE COLLECTION > maxTTL](https://preview.docs-test.couchbase.com/docs-devex-DOC-12023-maxttl-setting/server/current/n1ql/n1ql-language-reference/createcollection.html#with)

