### PR TITLE
[DOC-11724] Update the metrics (execution time) parameter 

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/n1ql-auditing.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/n1ql-auditing.adoc
@@ -130,7 +130,10 @@ The syslog format will allow for integration with third party SIEM tools, such a
 | `success`
 
 | `metrics`
-| The elapsed time (ms), execution time (ms), result count, and result size (MB).
+| The elapsed time (ms), execution time, result count, and result size (MB).
+
+The execution time can be in milliseconds (ms), microseconds (µs), or nanoseconds (ns), depending on the duration of the query.
+To determine the unit, check the suffix of each value.
 | `"elapsedTime":"7.599684ms",`
 
 `"executionTime":"7.507755ms",`


### PR DESCRIPTION
Updates the `metrics` parameter description to reflect that `executionTime` can be reported in milliseconds, microseconds, or nanoseconds. 

Jira: DOC-11724
Doc Preview: [Audit Log Format > metrics](https://preview.docs-test.couchbase.com/docs-devex-DOC-11724-execution-time-unit/server/current/n1ql/n1ql-language-reference/n1ql-auditing.html#audit-log-format)
