### PR TITLE
[DOC-14250] Fix incorrect unit description for `elapsedTime` in Audit Logs - Capella

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/n1ql-auditing.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/n1ql-auditing.adoc
@@ -133,10 +133,20 @@ endif::flag-devex-rest-api[]
 | `success`
 
 | `metrics`
-| The elapsed time (ms), execution time, result count, and result size (MB).
+| The elapsed time, execution time, result count, and result size (MB).
 
-The execution time can be in milliseconds (ms), microseconds (µs), or nanoseconds (ns), depending on the duration of the query.
-To determine the unit, check the suffix of each value.
+The elapsed time and execution time use a duration string format, which includes a numeric value and a unit suffix.
+The unit varies depending on the duration of the query.
+
+Valid units are:
+
+* `ms` - milliseconds
+* `µs` - microseconds
+* `ns` - nanoseconds
+* `s` - seconds
+* `m` - minutes
+* `h` - hours
+
 | `"elapsedTime":"7.599684ms",`
 
 `"executionTime":"7.507755ms",`


### PR DESCRIPTION
Porting the approved changes from https://github.com/couchbaselabs/docs-devex/pull/632 into the capella branch. 