### PR TITLE
[DOC-14124]: Query service’s documentation backend seems to have some problem

### DIFF
--- a/modules/indexes/pages/groupby-aggregate-performance.adoc
+++ b/modules/indexes/pages/groupby-aggregate-performance.adoc
@@ -77,7 +77,6 @@ Note that the query engine does not fetch any data from the data service (KV ser
 
 skinparam maxMessageSize 150
 skinparam responseMessageBelowArrow true
-skinparam sequenceMessageAlign direction
 
 ' title Query Execution with Grouping and Aggregation Pushdown
 
@@ -112,7 +111,6 @@ For reference, this is how the same query would be executed without grouping and
 
 skinparam maxMessageSize 150
 skinparam responseMessageBelowArrow true
-skinparam sequenceMessageAlign direction
 
 ' title Query Execution without Grouping and Aggregation Pushdown
 


### PR DESCRIPTION

Fixed a null pointer error caused by the PlantUML diagrams.

preview
----

https://preview.docs-test.couchbase.com/docs-devex-DOC-14124--release-8.0--Query-services-documentation-backend-seems-to-have-some-problem/server/current/indexes/groupby-aggregate-performance.html