### PR TITLE
[DOC-12004] Add a note about `completed_requests` eviction order behavior

### DIFF
--- a/modules/n1ql/pages/n1ql-manage/monitoring-n1ql-query.adoc
+++ b/modules/n1ql/pages/n1ql-manage/monitoring-n1ql-query.adoc
@@ -835,6 +835,10 @@ curl $BASE_URL/admin/settings -u $USER:$PASSWORD \
   -d '{"completed-limit":1000}'
 ----
 
+NOTE: To optimize performance, the completed requests catalog uses a generic cache that does not guarantee a strict eviction order.
+When the catalog reaches the specified limit, it evicts requests based on when they complete, and not when they start. 
+As a result, it may remove a request with a later start time (`requestTime`) that completes quickly before it removes a long-running request with an earlier start time that completes later.
+
 [[sys-history]]
 == Stream Completed Requests
 


### PR DESCRIPTION
Added a note to the `completed-limit` section explaining how `completed_requests` manages eviction when the limit is reached.

- Jira: DOC-12004
- Doc preview: [Completed Limit](https://preview.docs-test.couchbase.com/docs-devex-DOC-12004-completed-limit/server/current/n1ql/n1ql-manage/monitoring-n1ql-query.html#completed-limit)
- [Preview credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords#Preview-docs-for-internal-Couchbase-reviews)