### PR TITLE
[DOC-10029] Update valid characters for GSI index names

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
@@ -89,9 +89,9 @@ image::n1ql-language-reference/create-index.png["Syntax diagram: see source code
 [horizontal#index-name, reftext="index-name"]
 index-name:: (Required) A unique name that identifies the index.
 +
-Valid GSI index names can contain any of the following characters: `A-Z` `a-z` `0-9` `&num;` `&lowbar;`, and must start with a letter, [`A-Z` `a-z`].
+Valid GSI index names can contain any of the following characters: `A-Z` `a-z` `0-9` `&num;` `&lowbar;`, `-`, and must start with a letter, [`A-Z` `a-z`].
 The minimum length of an index name is 1 character and there is no maximum length set for an index name.
-When querying, if the index name contains a `&num;` or `&lowbar;` character, you must enclose the index name within backticks.
+When querying, if the index name contains a `&num;` or `-` character, you must enclose the index name within backticks.
 
 keyspace-ref:: (Required) Specifies the keyspace where the index is created.
 See <<keyspace-ref>>.


### PR DESCRIPTION
Jira: DOC-10029

Updates the `CREATE INDEX` page to correct the valid characters listed for GSI index names. 