### PR TITLE
[DOC-14220] Update timezone information

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/datefun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/datefun.adoc
@@ -27,7 +27,14 @@ All {sqlpp} functions which accept a timezone as an argument also accept `UTC`.
 
 Many applications operate across multiple different time zones and may not necessarily use `UTC`.
 Therefore, it is important for the database to be able to handle and manipulate dates in these time zones in a consistent manner.
-Many date functions take the time zone as an additional argument.
+
+Many date functions take the time zone as an additional argument and use data from the https://www.iana.org/time-zones[IANA Time Zone Database]. 
+Most operating systems provide this database through the `tzdata` package.
+On some platforms, legacy time zones (for example, `US/Central`) may require an additional package, such as `tzdata-legacy`.
+
+If these packages are missing or outdated, date functions may fail with unknown or missing time zone errors.
+To resolve such issues, install or update the necessary packages using your operating system's package manager. 
+For detailed instructions, refer to your operating system's documentation.
 
 NOTE: Timezones are case sensitive, `Europe/London` is not the same as `europe/london`.
 
@@ -65,7 +72,7 @@ Below are a few examples of commonly used timezones and their offsets:
 | +05:30
 |====
 
-For a complete list of supported timezones, see https://www.iana.org/time-zones[the Timezone Database]
+For a complete list of supported timezones, see https://www.iana.org/time-zones[the Timezone Database].
 
 === Local System Timezone
 


### PR DESCRIPTION
PR to clarify that date functions use the IANA Time Zone Database and that outdated packages can cause time zone errors. 

Jira: DOC-14220
Doc preview: [IANA Timezone](https://preview.docs-test.couchbase.com/docs-devex-DOC-14220-timezone-info/server/current/n1ql/n1ql-language-reference/datefun.html#iana-timezones)