### PR TITLE
[DOC-14261] Update Object and Number Functions

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/numericfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/numericfun.adoc
@@ -1,17 +1,24 @@
 = Number Functions
 :description: Number functions perform various mathematical calculations and transformations on numeric data.
 :page-topic-type: reference
+:example-caption!:
 
 [abstract]
 {description}
 
-== ABS(`expression`)
+== ABS
 
 Returns the absolute value of a numeric expression.
 
 The absolute value is the non-negative value of a number without regard to its sign. 
 
-=== Arguments
+=== Syntax
+
+....
+ABS(expression)
+....
+
+==== Arguments
 
 expression:: [Required] A valid numeric expression.
 
@@ -50,11 +57,16 @@ SELECT ABS(-15) AS absValue_1,
 ----
 ====
 
-== ACOS(`expression`)
+== ACOS
 
 Returns the arccosine (inverse cosine) value of a numeric expression, in radians. 
 
-=== Arguments
+=== Syntax
+....
+ACOS(expression)
+....
+
+==== Arguments
 
 expression:: [Required] A valid numeric expression.
 
@@ -94,11 +106,17 @@ SELECT ACOS(0.5) AS acosValue_1,
 ----
 ====
 
-== ASIN(`expression`)
+== ASIN
 
 Returns the arcsine (inverse sine) value of a numeric expression, in radians.
 
-=== Arguments
+=== Syntax
+
+....
+ASIN(expression)
+....
+
+==== Arguments
 
 expression:: [Required] A valid numeric expression.
 
@@ -138,11 +156,17 @@ SELECT ASIN(0.5) AS asinValue_1,
 ----
 ====
 
-== ATAN(`expression`)
+== ATAN
 
 Returns the arctangent (inverse tangent) value of a numeric expression, in radians.
 
-=== Arguments
+=== Syntax
+
+....
+ATAN(expression)
+....
+
+==== Arguments
 
 expression:: [Required] A valid numeric expression.
 
@@ -180,11 +204,17 @@ SELECT ATAN(1) AS atanValue_1,
 ----
 ====
 
-== ATAN2(`expression1`, `expression2`)
+== ATAN2
 
 Returns the arctangent (inverse tangent) value of 2 numeric expressions (`expression1`/`expression2`), in radians.
 
-=== Arguments
+=== Syntax
+
+....
+ATAN2(expression1, expression2)
+....
+
+==== Arguments
 
 expression1:: [Required] A valid numeric expression representing the y-coordinate.
 expression2:: [Required] A valid numeric expression representing the x-coordinate.
@@ -223,11 +253,17 @@ SELECT ATAN2(1, 1) AS atan2Value_1,
 ----
 ====
 
-== CEIL(`expression`)
+== CEIL
 
 Returns the smallest integer that's greater than or equal to the specified numeric expression.
 
-=== Arguments
+=== Syntax
+
+....
+CEIL(expression)
+....
+
+==== Arguments
 
 expression:: [Required] A valid numeric expression.
 
@@ -265,11 +301,17 @@ SELECT CEIL(6.3) AS ceilValue_1,
 ----
 ====
 
-== COS(`expression`)
+== COS
 
 Returns the cosine value of a numeric expression.
 
-=== Arguments
+=== Syntax
+
+....
+COS(expression)
+....
+
+==== Arguments
 
 expression:: [Required] A valid numeric expression.
 
@@ -307,11 +349,17 @@ SELECT COS(0) AS cosValue_1,
 ----
 ====
 
-== DEGREES(`expression`)
+== DEGREES
 
 Converts a numeric expression from radians to degrees.
 
-=== Arguments
+=== Syntax
+
+....
+DEGREES(expression)
+....
+
+==== Arguments
 
 expression:: [Required] A valid numeric expression (in radians).
 
@@ -351,11 +399,17 @@ SELECT DEGREES(PI()/2) AS degreesValue_1,
 ====
 
 
-== E()
+== E
 
 Returns the base of the natural logarithm `e`, which is approximately 2.71828.
 
-=== Arguments
+=== Syntax
+
+....
+E()
+....
+
+==== Arguments
 
 This function does not take any arguments.
 
@@ -385,11 +439,17 @@ SELECT E() AS eValue;
 ====
 
 
-== EXP(`expression`)
+== EXP
 
 Returns the value of <<e, e>> raised to the power of the given numeric expression.
 
-=== Arguments
+=== Syntax
+
+....
+EXP(expression)
+....
+
+==== Arguments
 
 expression:: [Required] A valid numeric expression.
 
@@ -427,11 +487,17 @@ SELECT EXP(10) AS expValue_1,
 ----
 ====
 
-== FLOOR(`expression`)
+== FLOOR
 
 Returns the largest integer that's less than or equal to the specified numeric expression.
 
-=== Arguments
+=== Syntax
+
+....
+FLOOR(expression)
+....
+
+==== Arguments
 
 expression:: [Required] A valid numeric expression.
 
@@ -469,13 +535,19 @@ SELECT FLOOR(6.7) AS floorValue_1,
 ====
 
 [[imod]]
-== IMOD(`expression1`, `expression2`)
+== IMOD
 
 Returns the remainder of the division of 1 number by another, but returns only integer values.
 
 NOTE: If you want the result to include both integer and floating-point numbers, use the <<mod, MOD function>> instead.
 
-=== Arguments
+=== Syntax
+
+....
+IMOD(expression1, expression2)
+....
+
+==== Arguments
 
 expression1:: [Required] A valid numeric expression representing the dividend.
 expression2:: [Required] A valid numeric expression representing the divisor.
@@ -516,11 +588,17 @@ SELECT IMOD(10.5, 3) AS imodValue_1,
 ----
 ====
 
-== INF()
+== INF
 
 Returns the special value `"Infinity"` that represents positive infinity.
 
-=== Arguments
+=== Syntax
+
+....
+INF()
+....
+
+==== Arguments
 
 This function does not take any arguments.
 
@@ -549,11 +627,17 @@ SELECT INF() AS infValue;
 ----
 ====
 
-== -INF()
+== -INF
 
 Returns the special value `"-Infinity"` that represents negative infinity.
 
-=== Arguments
+=== Syntax
+
+....
+-INF()
+....
+
+==== Arguments
 
 This function does not take any arguments.
 
@@ -582,11 +666,17 @@ SELECT -INF() AS negInfValue;
 ----
 ====
 
-== LN(`expression`)
+== LN
 
 Returns the natural logarithm (base e) of a numeric expression.
 
-=== Arguments
+=== Syntax
+
+....
+LN(expression)
+....
+
+==== Arguments
 
 expression:: [Required] A valid numeric expression.
 
@@ -628,11 +718,17 @@ SELECT LN(10) AS lnValue_1,
 ----
 ====
 
-== LOG(`expression`)
+== LOG
 
 Returns the base 10 logarithm of a numeric expression.
 
-=== Arguments
+=== Syntax
+
+....
+LOG(expression)
+....
+
+==== Arguments
 
 expression:: [Required] A valid numeric expression.
 
@@ -675,14 +771,20 @@ SELECT LOG(100) AS logValue_1,
 ====
 
 [[mod]]
-== MOD(`expression1`, `expression2`)
+== MOD
 
 Returns the remainder of the division of 1 number by another.
 
 NOTE: This function can return both integer and floating-point numbers.
 If you want the result to include only integer values, use the <<imod, IMOD function>> instead.
 
-=== Arguments
+=== Syntax
+
+....
+MOD(expression1, expression2)
+....
+
+==== Arguments
 
 expression1:: [Required] A valid numeric expression representing the dividend.
 expression2:: [Required] A valid numeric expression representing the divisor.
@@ -723,11 +825,17 @@ SELECT MOD(10.5, 3) AS modValue_1,
 ----
 ====
 
-== NAN()
+== NAN
 
 Returns the special value `"NaN"` (Not a Number) that represents an undefined value in numeric calculations.
 
-=== Arguments
+=== Syntax
+
+....
+NAN()
+....
+
+==== Arguments
 
 This function does not take any arguments.
 
@@ -756,11 +864,17 @@ SELECT NAN() AS nanValue;
 ----
 ====
 
-== PI()
+== PI
 
 Returns the mathematical constant π (pi), which is approximately 3.14159.
 
-=== Arguments
+=== Syntax
+
+....
+PI()
+....
+
+==== Arguments
 
 This function does not take any arguments.
 
@@ -789,11 +903,17 @@ SELECT PI() AS piValue;
 ----
 ====
 
-== POWER(`expression1`, `expression2`)
+== POWER
 
 Returns the value of `expression1` raised to the power of `expression2`.
 
-=== Arguments
+=== Syntax
+
+....
+POWER(expression1, expression2)
+....
+
+==== Arguments
 
 expression1:: [Required] A valid numeric expression representing the base.
 expression2:: [Required] A valid numeric expression representing the exponent.
@@ -832,11 +952,17 @@ SELECT POWER(2, 3) AS powerValue_1,
 ----
 ====
 
-== RADIANS(`expression`)
+== RADIANS
 
 Converts a numeric expression from degrees to radians.
 
-=== Arguments
+=== Syntax
+
+....
+RADIANS(expression)
+....
+
+==== Arguments
 
 expression:: [Required] A valid numeric expression (in degrees).
 
@@ -874,7 +1000,7 @@ SELECT RADIANS(90) AS radiansValue_1,
 ----
 ====
 
-== RANDOM([ `expression` ])
+== RANDOM
 
 Returns a pseudo-random number between `0` (inclusive) and `1` (exclusive).
 
@@ -882,7 +1008,13 @@ You can optionally specify a numeric expression as a seed value.
 If specified, the random number generator uses this value to initialize itself.
 Using the same seed value always produces the same sequence of random numbers.
 
-=== Arguments
+=== Syntax
+
+....
+RANDOM([expression])
+....
+
+==== Arguments
 
 expression:: [Optional] A valid numeric expression to use as a seed value.
 
@@ -916,25 +1048,29 @@ SELECT RANDOM() AS randomValue_1,
 ====
 
 [[round]]
-== ROUND(`expression` [, `digits` ])
+== ROUND
 
 Rounds a numeric expression to the nearest integer or to a specified number of decimal places.
 
-You can specify the number of places to round to using the optional `digits` parameter.
-
-* If `digits` is a positive integer, rounds to the specified number of places to the right of the decimal point.
-* If `digits` is `0` or not provided, rounds to the nearest whole integer.
-* If `digits` is a negative integer, rounds digits to the left of the decimal point.
-For example, `-1` rounds to the nearest 10, `-2` to the nearest 100, and so on.
-
 TIP: If you want to truncate a number without rounding, use the <<trunc, TRUNC function>>.
 
-=== Arguments
+=== Syntax
+
+....
+ROUND(expression [, digits])
+....
+
+==== Arguments
 
 expression:: [Required] A valid numeric expression.
 
 digits:: [Optional] An integer representing the number of decimal places to round to.
 The default value is `0`.
+
+* If `digits` is a positive integer, the function rounds the number to the specified number of decimal places to the right of the decimal point.
+* If `digits` is `0` or not provided, the function rounds the number to the nearest whole integer.
+* If `digits` is a negative integer, the function rounds digits to the left of the decimal point.
+For example, `-1` rounds to the nearest 10, `-2` rounds to the nearest 100, and so on.
 
 === Return Value
 
@@ -970,7 +1106,7 @@ SELECT ROUND(12.3456) AS roundValue_1,
 ----
 ====
 
-== SIGN(`expression`)
+== SIGN
 
 Returns the sign of a numeric expression.
 
@@ -980,6 +1116,12 @@ Instead, it returns a numeric representation of the sign.
 * `-1` if the input value is negative.
 * `0` if the input value is zero.
 * `1` if the input value is positive.
+
+=== Syntax
+
+....
+SIGN(expression)
+....
 
 === Arguments
 
@@ -1021,11 +1163,17 @@ SELECT SIGN(10) AS signValue_1,
 ----
 ====
 
-== SIN(`expression`)
+== SIN
 
 Returns the sine value of a numeric expression.
 
-=== Arguments
+=== Syntax
+
+....
+SIN(expression)
+....
+
+==== Arguments
 
 expression:: [Required] A valid numeric expression.
 
@@ -1063,11 +1211,17 @@ SELECT SIN(0) AS sinValue_1,
 ----
 ====
 
-== SQRT(`expression`)
+== SQRT
 
 Returns the square root of a numeric expression.
 
-=== Arguments
+=== Syntax
+
+....
+SQRT(expression)
+....
+
+==== Arguments
 
 expression:: [Required] A valid numeric expression.
 
@@ -1106,11 +1260,17 @@ SELECT SQRT(16) AS sqrtValue_1,
 ----
 ====
 
-== TAN(`expression`)
+== TAN
 
 Returns the tangent value of a numeric expression.
 
-=== Arguments
+=== Syntax
+
+....
+TAN(expression)
+....
+
+==== Arguments
 
 expression:: [Required] A valid numeric expression.
 
@@ -1149,23 +1309,27 @@ SELECT TAN(0) AS tanValue_1,
 ====
 
 [[trunc]]
-== TRUNC(`expression` [, `digits` ])
+== TRUNC
 
 Truncates a numeric expression to a specified number of decimal places.
 Unlike the <<round, ROUND function>>, this function simply removes digits without adjusting the remaining value.
 
-You can specify the number of places to truncate to using the optional `digits` parameter.
+=== Syntax
 
-* If `digits` is a positive integer, truncates to the specified number of places to the right of the decimal point.
-* If `digits` is `0` or not provided, truncates the expression to the nearest whole integer.
-* If `digits` is a negative integer, truncates digits to the left of the decimal point.
-For example, `-1` truncates to the nearest 10, `-2` to the nearest 100, and so on. 
+....
+TRUNC(expression [, digits])
+....
 
-=== Arguments
+==== Arguments
 
 expression:: [Required] A valid numeric expression.
 digits:: [Optional] An integer representing the number of decimal places to truncate to.
 The default value is `0`.
+
+* If `digits` is a positive integer, the function truncates the number to the specified number of decimal places to the right of the decimal point.
+* If `digits` is `0` or not provided, the function truncates the number to the nearest whole integer.
+* If `digits` is a negative integer, the function truncates digits to the left of the decimal point.
+For example, `-1` truncates to the nearest 10, `-2` truncates to the nearest 100, and so on.
 
 === Return Value
 

--- a/modules/n1ql/pages/n1ql-language-reference/objectfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/objectfun.adoc
@@ -1,14 +1,15 @@
 = Object Functions
-:description: You can use object functions to evaluate objects, perform computations on attributes in an object, and to return a new object based on a transformation.
+:description: Object functions evaluate objects, perform computations on attributes in an object, and return a new object based on a transformation.
 :page-topic-type: reference
 :example-caption!:
 
+[abstract]
 {description}
 
 [[fn-obj-add,OBJECT_ADD()]]
 == OBJECT_ADD
 
-This function adds new attributes and values to a given object.
+Adds new attributes and values to a given object.
 
 === Syntax
 
@@ -18,18 +19,18 @@ OBJECT_ADD(object, new_attr_key, new_attr_value)
 
 ==== Arguments
 
-object:: An expression representing the object that you want to add to.
-new_attr_key:: The name of the attribute to add.
-new_attr_value:: The value of the attribute to add.
+object:: An expression representing the object to update.
+new_attr_key:: The name of the attribute to add to the object.
+new_attr_value:: The value to assign to the new attribute.
 
 === Return Value
 
 The updated object.
 
 * This function does not perform key substitution.
-* If you add a duplicate attribute (that is, if the key is found), it returns an error or NULL object.
-* If `new_attr_key` or `new_attr_value` is MISSING, or if `new_attr_key` is NULL, it returns the `object` unmodified.
-* If object` is not an object or NULL, it returns a NULL value object.
+* If `new_attr_key` already exists in the object, the function returns an error or a `NULL` object.
+* If `new_attr_key` or `new_attr_value` is `MISSING`, or if `new_attr_key` is `NULL`, the function returns the `object` unmodified.
+* If `object` is not an object or is `NULL`, the function returns a `NULL` object.
 
 === Example
 
@@ -73,27 +74,29 @@ SELECT route[0].schedule[0] AS original,
 [[fn-obj-concat,OBJECT_CONCAT()]]
 == OBJECT_CONCAT
 
-This function concatenates the input objects and returns a new object.
-It requires a minimum of two input objects.
+Concatenates two or more input objects into a single new object.
 
 NOTE: All input objects must be plain objects; arrays of objects are not supported.
-If you need to concatenate arrays of objects, use <<fn-obj-concat2,OBJECT_CONCAT2()>> instead.
+If you need to concatenate arrays of objects, use the <<fn-obj-concat2,OBJECT_CONCAT2>> function instead.
 
 === Syntax
 
 ....
-OBJECT_CONCAT(expr, expr, ...)
+OBJECT_CONCAT(expr1, expr2, ...)
 ....
 
 ==== Arguments
 
-expr:: An expression representing an object. 
-There must be at least two expressions, and all must be plain objects (not arrays).
+expr1, expr2, ...:: Expressions representing the objects to concatenate.
+You must provide at least two expressions. 
+All input objects must be plain objects and cannot be arrays of objects.
 
 === Return Value
 
 An object constructed by concatenating all the input objects.
-If any of the input objects contain the same attribute name, the attribute from the last relevant object in the input list is copied to the output; similarly-named attributes from earlier objects in the input list are ignored.
+
+If multiple input objects contain the same attribute name, the function copies the attribute from the last relevant object in the argument list to the output object. 
+The same-named attributes from earlier objects in the list are ignored.
 
 === Examples
 
@@ -132,25 +135,27 @@ SELECT OBJECT_CONCAT({"flight": "AF198"},
 [[fn-obj-concat2,OBJECT_CONCAT2()]]
 == OBJECT_CONCAT2
 
-This function concatenates multiple input objects into a single new object, and requires at least two input objects to work. 
+Concatenates multiple input objects into a single new object, and requires at least two input objects to work. 
 Unlike <<fn-obj-concat>>, this function supports both plain objects and arrays of objects as arguments. 
 
 === Syntax
 
 ....
-OBJECT_CONCAT2(expr, expr, ...)
+OBJECT_CONCAT2(expr1, expr2, ...)
 ....
 
 ==== Arguments
 
-expr:: An expression representing an object or an array of objects. 
-There must be at least two expressions.
-The first argument must be a plain object and cannot be an array. 
+expr1, expr2, ...:: Expressions representing the objects to concatenate.
+You must provide at least two expressions.
+These can be plain objects or arrays of objects, but the first argument must be a plain object and cannot be an array. 
 
 === Return Value
 
 An object constructed by concatenating all the input objects.
-If any of the input objects contain the same attribute name, the attribute from the last relevant object in the input list is copied to the output; similarly-named attributes from earlier objects in the input list are ignored.
+
+If multiple input objects contain the same attribute name, the function copies the attribute from the last relevant object in the argument list to the output object. 
+The same-named attributes from earlier objects in the list are ignored.
 
 === Example
 
@@ -188,8 +193,8 @@ SELECT OBJECT_CONCAT2(
 [[fn-obj-field,OBJECT_FIELD()]]
 == OBJECT_FIELD
 
-This function returns the value of the specified field within the given object.
-A field in this context may be any attribute or element, nested at any level within the object.
+Extracts and returns the value of a specified field from a given object.
+The field can be an attribute or element, nested at any level within the object.
 
 === Syntax
 
@@ -199,7 +204,7 @@ OBJECT_FIELD(expr, field)
 
 ==== Arguments
 
-expr:: An expression representing an object.
+expr:: An expression representing the object to query.
 
 field:: A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the path to a field within the object.
 +
@@ -209,11 +214,10 @@ If any attribute names within the field path contain special characters, they mu
 === Return Value
 
 The value of the specified field.
-If the object does not exist, or the field cannot be found within the object at the specified location, the function returns NULL.
+
+If the object does not exist, or the field cannot be found within the object at the specified location, the function returns `NULL`.
 
 === Example
-
-include::ROOT:partial$query-context.adoc[tag=section]
 
 [[obj-field-ex1,OBJECT_FIELD() Example 1]]
 .Top-Level Fields
@@ -223,12 +227,25 @@ This example returns the complete values of the specified attributes at the top 
 .Query
 [source,sqlpp]
 ----
-SELECT OBJECT_FIELD(hotel, "public_likes") AS `array`,
-       OBJECT_FIELD(hotel, "vacancy") AS `boolean`,
-       OBJECT_FIELD(hotel, "id") AS `number`,
-       OBJECT_FIELD(hotel, "geo") AS `object`,
-       OBJECT_FIELD(hotel, "name") AS `string`
-FROM hotel
+WITH flight AS ([
+  {
+    "flight_no": 198,
+    "airline": "Air France",
+    "on_time": true,
+    "passengers": ["Julius Tromp I", "Corrine Hill", "Jaeden McKenzie"],
+    "departure": {
+      "airport": "CDG",
+      "time": "10:13:00",
+      "geo": {"lat": 49.0097, "lon": 2.5479}
+    }
+  }
+])
+SELECT
+  OBJECT_FIELD(flight[0], "passengers") AS `array`,
+  OBJECT_FIELD(flight[0], "on_time")    AS `boolean`,
+  OBJECT_FIELD(flight[0], "flight_no")  AS `number`,
+  OBJECT_FIELD(flight[0], "departure.geo") AS `object`,
+  OBJECT_FIELD(flight[0], "airline")    AS `string`
 LIMIT 1;
 ----
 
@@ -238,23 +255,17 @@ LIMIT 1;
 [
   {
     "array": [
-      "Julius Tromp I",
-      "Corrine Hilll",
-      "Jaeden McKenzie",
-      "Vallie Ryan",
-      "Brian Kilback",
-      "Lilian McLaughlin",
-      "Ms. Moses Feeney",
-      "Elnora Trantow"
+        "Julius Tromp I",
+        "Corrine Hill",
+        "Jaeden McKenzie"
     ],
     "boolean": true,
-    "number": 10025,
+    "number": 198,
     "object": {
-      "accuracy": "RANGE_INTERPOLATED",
-      "lat": 51.35785,
-      "lon": 0.55818
+        "lat": 49.0097,
+        "lon": 2.5479
     },
-    "string": "Medway Youth Hostel"
+    "string": "Air France"
   }
 ]
 ----
@@ -269,12 +280,29 @@ In the path to the nested object attribute, the final attribute name is escaped,
 .Query
 [source,sqlpp]
 ----
+WITH flight AS ([
+  {
+    "flight_no": 198,
+    "airline": "Air France",
+    "feedback": [
+      {
+        "author": "Barton Marks",
+        "comment": "Smooth flight",
+        "ratings": { "Comfort": 4 }
+      },
+      {
+        "author": "Corrine Hill",
+        "comment": "Good facilities",
+        "ratings": { "In-flight service (e.g., wifi)": 5, 
+                   "Comfort": 4 }
+      }
+    ]
+  }
+])
 SELECT
-  OBJECT_FIELD(hotel, "reviews[1]")
-    AS array_element,
-  OBJECT_FIELD(hotel, "reviews[1].ratings.`Business service (e.g., internet access)`")
-    AS object_attribute
-FROM hotel
+  OBJECT_FIELD(flight[0], "feedback[1]") AS array_element,
+  OBJECT_FIELD(flight[0], "feedback[1].ratings.`In-flight service (e.g., wifi)`") 
+  AS object_attribute
 LIMIT 1;
 ----
 
@@ -284,21 +312,14 @@ LIMIT 1;
 [
   {
     "array_element": {
-      "author": "Barton Marks",
-      "content": "We found the hotel de la Monnaie through Interval ...",
-      "date": "2015-03-02 19:56:13 +0300",
+      "author": "Corrine Hill",
+      "comment": "Good facilities",
       "ratings": {
-        "Business service (e.g., internet access)": 4,
-        "Check in / front desk": 4,
-        "Cleanliness": 4,
-        "Location": 4,
-        "Overall": 4,
-        "Rooms": 3,
-        "Service": 3,
-        "Value": 5
+        "Comfort": 4,
+        "In-flight service (e.g., wifi)": 5
       }
     },
-    "object_attribute": 4
+    "object_attribute": 5
   }
 ]
 ----
@@ -308,7 +329,7 @@ LIMIT 1;
 [[fn-obj-filter,OBJECT_FILTER()]]
 == OBJECT_FILTER
 
-This function extracts and returns nested fields from an input object that match a specified pattern, while retaining their original hierarchical path structure in the output. 
+Extracts and returns nested fields from an input object that match a specified pattern, while retaining their original hierarchical path structure in the output. 
 This is particularly useful when working with complex objects, as it allows you to filter fields based on patterns using either regular expressions or exact matches.
 
 === Syntax
@@ -413,30 +434,31 @@ Non-matching fields are excluded from the output.
 .Query
 [source,sqlpp]
 ----
-SELECT OBJECT_FILTER(t, {"pattern":"Business service"})  
-FROM `travel-sample`.`inventory`.`hotel` t 
-WHERE type = 'hotel' 
-LIMIT 2;
+WITH hotel AS ([
+  {
+    "id": 1,
+    "type": "hotel",
+    "reviews": [
+      { "ratings": { "Business service": 4, "Service": 3 } }
+    ]
+  }
+])
+SELECT OBJECT_FILTER(hotel[0], {"pattern":"Business service"}) AS filtered
+LIMIT 1;
 ----
+
 .Result
 [source,json]
 ----
-[
-  {
-    "$1": {
-      "reviews": [
-        {
-          "ratings": {
-            "Business service (e.g., internet access)": 4
-          }
-        }
-      ]
+[{
+    "filtered": {
+        "reviews": [{
+            "ratings": {
+                "Business service": 4
+            }
+        }]
     }
-  },
-  {
-    "$1": null
-  }
-]
+}]
 ----
 ====
 
@@ -447,27 +469,33 @@ You can use <<fn-obj-paths,OBJECT_PATHS()>> to generate the full path to a field
 .Query
 [source,sqlpp]
 ----
-SELECT OBJECT_FILTER(t, { "pattern": "reviews[1].ratings.Service", "regex": false }) 
-FROM `travel-sample`.`inventory`.`hotel` t 
-WHERE type = 'hotel' 
+WITH hotels AS ([
+  {
+    "id": 1,
+    "type": "hotel",
+    "reviews": [
+      { "ratings": { "Service": 2 } },
+      { "ratings": { "Service": 3 } }
+    ]
+  }
+])
+SELECT OBJECT_FILTER(h, {"pattern":"reviews[1].ratings.Service", "regex": false}) AS filtered
+FROM hotels AS h
+WHERE h.type = "hotel"
 LIMIT 1;
 ----
 .Result
 [source,json]
 ----
-[
-  {
-    "$1": {
-      "reviews": [
-        {
-          "ratings": {
-            "Service": 3
-          }
-        }
-      ]
+[{
+    "filtered": {
+        "reviews": [{
+            "ratings": {
+                "Service": 3
+            }
+        }]
     }
-  }
-]
+}]
 ----
 ====
 
@@ -475,8 +503,8 @@ LIMIT 1;
 [[fn-obj-inner-pairs,OBJECT_INNER_PAIRS()]]
 == OBJECT_INNER_PAIRS
 
-This function returns an array of objects, containing the names and values of each attribute in the input object.
-It is particularly useful when iterating over multiple objects in an array, as it collates the values from similarly-named attributes into a single nested array.
+Returns an array of objects containing the names and values of each attribute in the input object.
+This function is particularly useful when iterating over multiple objects in an array, as it collates the values from similarly-named attributes into a single nested array.
 
 In this case, the function does not return a value from any object which does not contain the shared attribute name, rather like an INNER JOIN.
 For an illustration, refer to the examples below.
@@ -484,20 +512,20 @@ For an illustration, refer to the examples below.
 === Syntax
 
 ...
-OBJECT_INNER_PAIRS(expression)
+OBJECT_INNER_PAIRS(expr)
 ...
 
 ==== Arguments
 
-expression:: An expression representing an object.
+expr:: An expression representing an object.
 
 === Return Value
 
 An array of objects, each containing two attributes:
 
-name:: The name of an attribute in the source object.
+name:: The name of an attribute in the input object.
 
-val:: The value of an attribute in the source object; or an array, containing the collated values of similarly-named attributes in the source objects.
+val:: The value of an attribute in the input object; or an array, containing the collated values of similarly-named attributes in the input objects.
 
 The objects in the array are sorted by attribute name, in {sqlpp} collation order.
 
@@ -593,8 +621,8 @@ SELECT OBJECT_INNER_PAIRS(special_flights[*]) AS inner_pairs;
 [[fn-obj-inner-values,OBJECT_INNER_VALUES()]]
 == OBJECT_INNER_VALUES
 
-This function returns an array, containing the values of each attribute in the input object.
-It is particularly useful when iterating over multiple objects in an array, as it collates the values from similarly-named attributes into a single nested array.
+Returns an array containing the values of each attribute in the input object.
+This function is particularly useful when iterating over multiple objects in an array, as it collates the values from similarly-named attributes into a single nested array.
 
 In this case, the function does not return a value from any object which does not contain the shared attribute name, rather like an INNER JOIN.
 For an illustration, refer to the examples below.
@@ -602,12 +630,12 @@ For an illustration, refer to the examples below.
 === Syntax
 
 ....
-OBJECT_INNER_VALUES(expression)
+OBJECT_INNER_VALUES(expr)
 ....
 
 ==== Arguments
 
-expression:: An expression representing an object.
+expr:: An expression representing an object.
 
 === Return Value
 
@@ -685,26 +713,27 @@ SELECT OBJECT_INNER_VALUES(special_flights[*]) AS inner_values;
 [[fn-obj-length,OBJECT_LENGTH()]]
 == OBJECT_LENGTH
 
-This function returns the number of name-value pairs in the object.
+Returns the number of name-value pairs in an object.
 It only counts the top-level attributes and does not recurse into nested objects.
 
-Equivalent to xref:n1ql-language-reference/arrayfun.adoc#len[LEN()]. 
+This function is similar to xref:n1ql-language-reference/arrayfun.adoc#len[LEN()], but specifically operates on objects.
 
 === Syntax
 
 ....
-OBJECT_LENGTH(expression)
+OBJECT_LENGTH(expr)
 ....
 
 ==== Arguments
 
-expression:: An object or an expression that evaluates to an object.
+expr:: An expression representing an object.
 
 === Return Value
 
 An integer.
 
-If the input expression is not an object, the function returns `null`; if the input expression is `missing`, the function returns `missing`.
+If the input expression is not an object, the function returns `NULL`.
+If the input expression is `MISSING`, the function returns `MISSING`.
 
 === Example
 
@@ -730,18 +759,18 @@ SELECT OBJECT_LENGTH({"abc": 1, "def": 2, "ghi": {"uvw": 3, "xyz": 4}});
 [[fn-obj-names,OBJECT_NAMES()]]
 == OBJECT_NAMES
 
-This function returns an array, containing the names of each attribute in the input object.
-It is particularly useful when iterating over multiple objects in an array, as it collates similar attribute names.
+Returns an array containing the names of each attribute in the input object.
+This function is particularly useful when iterating over multiple objects in an array, as it collates similar attribute names.
 
 === Syntax
 
 ....
-OBJECT_NAMES(expression)
+OBJECT_NAMES(expr)
 ....
 
 ==== Arguments
 
-expression:: An expression representing an object.
+expr:: An expression representing an object.
 
 === Return Value
 
@@ -806,7 +835,7 @@ SELECT OBJECT_NAMES(special_flights[*]) AS names;
 [[fn-obj-pairs,OBJECT_PAIRS()]]
 == OBJECT_PAIRS
 
-This function returns an array of objects, containing the names and values of each attribute in the input object. 
+Returns an array of objects containing the names and values of each attribute in the input object. 
 It also provides an option to return attribute types instead of values. 
 
 The function is particularly useful when iterating over multiple objects in an array, as it collates the values from similarly-named attributes into a single nested array. 
@@ -1342,7 +1371,7 @@ Compare this example with <<obj-pairs-ex3>>.
 [[fn-obj-paths,OBJECT_PATHS()]]
 == OBJECT_PATHS
 
-This function returns the paths to all the fields within an object.
+Returns the paths to all the fields within an object.
 A field in this context may be any attribute or element, nested at any level within the object.
 
 === Syntax
@@ -1443,9 +1472,9 @@ An array containing the full path to every possible field within the source obje
 The result uses xref:n1ql-language-reference/nestedops.adoc[nested operators] to specify the path to all nested attributes or elements.
 If any attribute names within a field path contain special characters, they are escaped using backticks (`{backtick}{backtick}`).
 
-* If `object` is MISSING, the function returns a MISSING value.
-* If `object` is not an object, the function returns a NULL value.
-* If `options` is not an object, the function returns a NULL value.
+* If `object` is `MISSING`, the function returns a `MISSING` value.
+* If `object` is not an object, the function returns a `NULL` value.
+* If `options` is not an object, the function returns a `NULL` value.
 
 === Examples
 
@@ -1567,73 +1596,49 @@ SELECT
 ====
 
 [[obj-paths-ex4,OBJECT_PATHS() Example 4]]
-.Complex example
+.Extracting paths from nested fields
 ====
-include::ROOT:partial$query-context.adoc[tag=example]
 
 .Query
 [source,sqlpp]
 ----
-SELECT OBJECT_PATHS(hotel, {"composites": false, "arraysubscript": false}) AS paths
-FROM hotel
+WITH hotel AS ([
+  {
+    "id": 1,
+    "name": "Simple Inn",
+    "city": "Testville",
+    "geo": { "lat": 1.23, "lon": 4.56 },
+    "reviews": [
+      { "author": "Alice", "ratings": { "Service": 4 } },
+      { "author": "Bob",   "ratings": { "Service": 5 } }
+    ]
+  }
+])
+SELECT OBJECT_PATHS(hotel[0], {"composites": false, "arraysubscript": false}) AS paths
 LIMIT 1;
 ----
 
 .Result
 [source,json]
 ----
-[
-  {
+[{
     "paths": [
-      "address",
-      "alias",
-      "checkin",
-      "checkout",
-      "city",
-      "country",
-      "description",
-      "directions",
-      "email",
-      "fax",
-      "free_breakfast",
-      "free_internet",
-      "free_parking",
-      "geo.accuracy",
-      "geo.lat",
-      "geo.lon",
-      "id",
-      "name",
-      "pets_ok",
-      "phone",
-      "price",
-      "public_likes",
-      "reviews[*].author",
-      "reviews[*].content",
-      "reviews[*].date",
-      "reviews[*].ratings[*].Cleanliness",
-      "reviews[*].ratings[*].Location",
-      "reviews[*].ratings[*].Overall",
-      "reviews[*].ratings[*].Rooms",
-      "reviews[*].ratings[*].Service",
-      "reviews[*].ratings[*].Value",
-      "reviews[*].ratings[*].`Business service (e.g., internet access)`",
-      "reviews[*].ratings[*].`Check in / front desk`",
-      "state",
-      "title",
-      "tollfree",
-      "type",
-      "url",
-      "vacancy"
+        "city",
+        "geo.lat",
+        "geo.lon",
+        "id",
+        "name",
+        "reviews[*].author",
+        "reviews[*].ratings[*].Service"
     ]
-  }
-]
+}]
 ----
 ====
 
 [[fn-obj-put,OBJECT_PUT()]]
 == OBJECT_PUT
 
-This function adds new or updates existing attributes and values to a given object.
+Adds new attributes or updates existing attributes within a given object.
 
 === Syntax
 
@@ -1653,10 +1658,10 @@ attr_value:: The value of the attribute.
 
 The updated object.
 
-* If `attr_key` is found in the object, it replaces the corresponding attribute value by `attr_value`.
-* If `attr_value` is MISSING, it deletes the corresponding existing key (if any), like <<fn-obj-remove>>.
-* If `attr_key` is MISSING, it returns a MISSING value.
-* If `attr_key` is not an object, it returns a NULL value.
+* If `attr_key` exists in the object, the function replaces the corresponding attribute value with `attr_value`.
+* If `attr_value` is `MISSING`, the function deletes the corresponding existing key (if any), like <<fn-obj-remove>>.
+* If `attr_key` is `MISSING`, the function returns a `MISSING` value.
+* If `attr_key` is not an object, the function returns a `NULL` value.
 
 === Example
 
@@ -1764,7 +1769,7 @@ LIMIT 1;
 [[fn-obj-remove,OBJECT_REMOVE()]]
 == OBJECT_REMOVE
 
-This function removes the specified attribute and corresponding values from the given object.
+Removes the specified attribute and corresponding values from the given object.
 
 === Syntax
 
@@ -1911,7 +1916,7 @@ LIMIT 1;
 [[fn-obj-type,OBJECT_TYPES()]]
 == OBJECT_TYPES
 
-This function returns the data type of every field in the supplied object, as reported by the xref:n1ql-language-reference/typefun.adoc#fn-type-type[TYPE()] function.
+Returns the data type of every field in the supplied object, as reported by the xref:n1ql-language-reference/typefun.adoc#fn-type-type[TYPE()] function.
 
 === Syntax
 
@@ -1960,7 +1965,7 @@ SELECT OBJECT_TYPES({"flight": "AI444",
 [[fn-obj-types-nested,OBJECT_TYPES_NESTED()]]
 == OBJECT_TYPES_NESTED
 
-This function returns the data type of every non-composite field in the supplied object, as reported by the xref:n1ql-language-reference/typefun.adoc#fn-type-type[TYPE()] function.
+Returns the data type of every non-composite field in the supplied object, as reported by the xref:n1ql-language-reference/typefun.adoc#fn-type-type[TYPE()] function.
 Additionally, all composite type fields (ARRAYs and OBJECTs) are recursively processed in the same way, returning the data types of all nested values. 
 
 === Syntax
@@ -2021,7 +2026,7 @@ SELECT OBJECT_TYPES_NESTED({"flight":"AI444",
 [[fn-obj-unwrap,OBJECT_UNWRAP()]]
 == OBJECT_UNWRAP
 
-This function enables you to unwrap an object without knowing the name of the attribute.
+Enables you to unwrap an object without knowing the name of the attribute.
 
 === Syntax
 
@@ -2069,7 +2074,7 @@ SELECT OBJECT_UNWRAP({"name": "value"}) AS single,
 [[fn-obj-values,OBJECT_VALUES()]]
 == OBJECT_VALUES
 
-This function returns an array, containing the values of each attribute in the input object.
+Returns an array, containing the values of each attribute in the input object.
 It is particularly useful when iterating over multiple objects in an array, as it collates the values from similarly-named attributes into a single nested array.
 
 In this case, the function returns a null entry from any object which does not contain the shared attribute name, rather like an OUTER JOIN.

--- a/modules/n1ql/pages/n1ql-language-reference/objectfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/objectfun.adoc
@@ -6,13 +6,17 @@
 {description}
 
 [[fn-obj-add,OBJECT_ADD()]]
-== OBJECT_ADD(`object`, `new_attr_key`, `new_attr_value`)
-
-=== Description
+== OBJECT_ADD
 
 This function adds new attributes and values to a given object.
 
-=== Arguments
+=== Syntax
+
+....
+OBJECT_ADD(object, new_attr_key, new_attr_value)
+....
+
+==== Arguments
 
 object:: An expression representing the object that you want to add to.
 new_attr_key:: The name of the attribute to add.
@@ -24,25 +28,28 @@ The updated object.
 
 * This function does not perform key substitution.
 * If you add a duplicate attribute (that is, if the key is found), it returns an error or NULL object.
-* If [.var]`new_attr_key` or [.var]`new_attr_value` is MISSING, or if [.var]`new_attr_key` is NULL, it returns the [.var]`object` unmodified.
-* If [.var]`object` is not an object or NULL, it returns a NULL value object.
+* If `new_attr_key` or `new_attr_value` is MISSING, or if `new_attr_key` is NULL, it returns the `object` unmodified.
+* If object` is not an object or NULL, it returns a NULL value object.
 
-=== Examples
-
-include::ROOT:partial$query-context.adoc[tag=section]
+=== Example
 
 [[obj-add-ex,OBJECT_ADD() Example]]
 ====
 .Query
 [source,sqlpp]
 ----
-SELECT schedule[0] AS original,
-       OBJECT_ADD(schedule[0], "day_new", 1) AS output
-FROM route
-LIMIT 1;
+WITH route AS ([{
+  "id": "R1",
+  "schedule": [
+    {"day": 0, "flight": "AF198", "utc": "10:13:00"},
+    {"day": 2, "flight": "AF200", "utc": "15:30:00"}
+  ]
+}])
+SELECT route[0].schedule[0] AS original,
+       OBJECT_ADD(route[0].schedule[0], "day_new", 1) AS output;
 ----
 
-.Results
+.Result
 [source,json]
 ----
 [
@@ -64,16 +71,24 @@ LIMIT 1;
 ====
 
 [[fn-obj-concat,OBJECT_CONCAT()]]
-== OBJECT_CONCAT(`expr`, `expr` ...)
-
-=== Description
+== OBJECT_CONCAT
 
 This function concatenates the input objects and returns a new object.
 It requires a minimum of two input objects.
 
-=== Arguments
+NOTE: All input objects must be plain objects; arrays of objects are not supported.
+If you need to concatenate arrays of objects, use <<fn-obj-concat2,OBJECT_CONCAT2()>> instead.
 
-expr:: An expression representing an object.
+=== Syntax
+
+....
+OBJECT_CONCAT(expr, expr, ...)
+....
+
+==== Arguments
+
+expr:: An expression representing an object. 
+There must be at least two expressions, and all must be plain objects (not arrays).
 
 === Return Value
 
@@ -95,7 +110,7 @@ SELECT OBJECT_CONCAT({"flight": "AF198"},
 );       
 ----
 
-.Results
+.Result
 [source,json]
 ----
 [
@@ -115,17 +130,21 @@ SELECT OBJECT_CONCAT({"flight": "AF198"},
 ====
 
 [[fn-obj-concat2,OBJECT_CONCAT2()]]
-== OBJECT_CONCAT2(`expr`, `expr` ...)
-
-=== Description
+== OBJECT_CONCAT2
 
 This function concatenates multiple input objects into a single new object, and requires at least two input objects to work. 
 Unlike <<fn-obj-concat>>, this function supports both plain objects and arrays of objects as arguments. 
 
+=== Syntax
 
-=== Arguments
+....
+OBJECT_CONCAT2(expr, expr, ...)
+....
+
+==== Arguments
 
 expr:: An expression representing an object or an array of objects. 
+There must be at least two expressions.
 The first argument must be a plain object and cannot be an array. 
 
 === Return Value
@@ -133,7 +152,7 @@ The first argument must be a plain object and cannot be an array.
 An object constructed by concatenating all the input objects.
 If any of the input objects contain the same attribute name, the attribute from the last relevant object in the input list is copied to the output; similarly-named attributes from earlier objects in the input list are ignored.
 
-=== Examples
+=== Example
 
 [[obj-concat2-ex,OBJECT_CONCAT2() Example]]
 ====
@@ -150,7 +169,7 @@ SELECT OBJECT_CONCAT2(
 );
 ----
 
-.Results
+.Result
 [source,json]
 ----
 [
@@ -167,14 +186,18 @@ SELECT OBJECT_CONCAT2(
 ====
 
 [[fn-obj-field,OBJECT_FIELD()]]
-== OBJECT_FIELD(`object`, `field`)
-
-=== Description
+== OBJECT_FIELD
 
 This function returns the value of the specified field within the given object.
 A field in this context may be any attribute or element, nested at any level within the object.
 
-=== Arguments
+=== Syntax
+
+....
+OBJECT_FIELD(expr, field)
+....
+
+==== Arguments
 
 expr:: An expression representing an object.
 
@@ -188,7 +211,7 @@ If any attribute names within the field path contain special characters, they mu
 The value of the specified field.
 If the object does not exist, or the field cannot be found within the object at the specified location, the function returns NULL.
 
-=== Examples
+=== Example
 
 include::ROOT:partial$query-context.adoc[tag=section]
 
@@ -209,7 +232,7 @@ FROM hotel
 LIMIT 1;
 ----
 
-.Results
+.Result
 [source,json]
 ----
 [
@@ -255,7 +278,7 @@ FROM hotel
 LIMIT 1;
 ----
 
-.Results
+.Result
 [source,json]
 ----
 [
@@ -283,18 +306,23 @@ LIMIT 1;
 
 
 [[fn-obj-filter,OBJECT_FILTER()]]
-== OBJECT_FILTER(`expression` [, `options`])
+== OBJECT_FILTER
 
-=== Description
 This function extracts and returns nested fields from an input object that match a specified pattern, while retaining their original hierarchical path structure in the output. 
 This is particularly useful when working with complex objects, as it allows you to filter fields based on patterns using either regular expressions or exact matches.
 
-=== Arguments
+=== Syntax
+
+....
+OBJECT_FILTER(expression [, options])
+....
+
+==== Arguments
 expression:: An expression representing an object.
 
 options:: [Optional] A JSON object specifying options for the function.
 
-=== Options
+==== Options
 
 [options="header", cols="1a,3a,1a"]
 |===
@@ -390,7 +418,7 @@ FROM `travel-sample`.`inventory`.`hotel` t
 WHERE type = 'hotel' 
 LIMIT 2;
 ----
-.Results
+.Result
 [source,json]
 ----
 [
@@ -424,7 +452,7 @@ FROM `travel-sample`.`inventory`.`hotel` t
 WHERE type = 'hotel' 
 LIMIT 1;
 ----
-.Results
+.Result
 [source,json]
 ----
 [
@@ -445,9 +473,7 @@ LIMIT 1;
 
 
 [[fn-obj-inner-pairs,OBJECT_INNER_PAIRS()]]
-== OBJECT_INNER_PAIRS(`expression`)
-
-=== Description
+== OBJECT_INNER_PAIRS
 
 This function returns an array of objects, containing the names and values of each attribute in the input object.
 It is particularly useful when iterating over multiple objects in an array, as it collates the values from similarly-named attributes into a single nested array.
@@ -455,7 +481,13 @@ It is particularly useful when iterating over multiple objects in an array, as i
 In this case, the function does not return a value from any object which does not contain the shared attribute name, rather like an INNER JOIN.
 For an illustration, refer to the examples below.
 
-=== Arguments
+=== Syntax
+
+...
+OBJECT_INNER_PAIRS(expression)
+...
+
+==== Arguments
 
 expression:: An expression representing an object.
 
@@ -481,7 +513,7 @@ SELECT OBJECT_INNER_PAIRS({"flight": "AI444", "utc": "4:44:44", "codename": "gre
     AS inner_pairs;
 ----
 
-.Results
+.Result
 [source,json]
 ----
 [
@@ -519,7 +551,7 @@ WITH special_flights AS ([{"flight": "AI444", "utc": "4:44:44", "codename": "gre
 SELECT OBJECT_INNER_PAIRS(special_flights[*]) AS inner_pairs;
 ----
 
-.Results
+.Result
 [source,json]
 ----
 [
@@ -559,9 +591,7 @@ SELECT OBJECT_INNER_PAIRS(special_flights[*]) AS inner_pairs;
 ====
 
 [[fn-obj-inner-values,OBJECT_INNER_VALUES()]]
-== OBJECT_INNER_VALUES(`expression`)
-
-=== Description
+== OBJECT_INNER_VALUES
 
 This function returns an array, containing the values of each attribute in the input object.
 It is particularly useful when iterating over multiple objects in an array, as it collates the values from similarly-named attributes into a single nested array.
@@ -569,7 +599,13 @@ It is particularly useful when iterating over multiple objects in an array, as i
 In this case, the function does not return a value from any object which does not contain the shared attribute name, rather like an INNER JOIN.
 For an illustration, refer to the examples below.
 
-=== Arguments
+=== Syntax
+
+....
+OBJECT_INNER_VALUES(expression)
+....
+
+==== Arguments
 
 expression:: An expression representing an object.
 
@@ -590,7 +626,7 @@ SELECT OBJECT_INNER_VALUES({"flight": "AI444", "utc": "4:44:44", "codename": "gr
     AS inner_values;
 ----
 
-.Results
+.Result
 [source,json]
 ----
 [
@@ -619,7 +655,7 @@ WITH special_flights AS ([{"flight": "AI444", "utc": "4:44:44", "codename": "gre
 SELECT OBJECT_INNER_VALUES(special_flights[*]) AS inner_values;
 ----
 
-.Results
+.Result
 [source,json]
 ----
 [
@@ -647,16 +683,20 @@ SELECT OBJECT_INNER_VALUES(special_flights[*]) AS inner_values;
 ====
 
 [[fn-obj-length,OBJECT_LENGTH()]]
-== OBJECT_LENGTH(`expression`)
-
-_Equivalent_: xref:n1ql-language-reference/metafun.adoc#len[LEN()]
-
-=== Description
+== OBJECT_LENGTH
 
 This function returns the number of name-value pairs in the object.
 It only counts the top-level attributes and does not recurse into nested objects.
 
-=== Arguments
+Equivalent to xref:n1ql-language-reference/arrayfun.adoc#len[LEN()]. 
+
+=== Syntax
+
+....
+OBJECT_LENGTH(expression)
+....
+
+==== Arguments
 
 expression:: An object or an expression that evaluates to an object.
 
@@ -666,7 +706,7 @@ An integer.
 
 If the input expression is not an object, the function returns `null`; if the input expression is `missing`, the function returns `missing`.
 
-=== Examples
+=== Example
 
 [[obj-length-ex,OBJECT_LENGTH() Example]]
 ====
@@ -676,7 +716,7 @@ If the input expression is not an object, the function returns `null`; if the in
 SELECT OBJECT_LENGTH({"abc": 1, "def": 2, "ghi": {"uvw": 3, "xyz": 4}});
 ----
 
-.Results
+.Result
 [source,json]
 ----
 [
@@ -688,14 +728,20 @@ SELECT OBJECT_LENGTH({"abc": 1, "def": 2, "ghi": {"uvw": 3, "xyz": 4}});
 ====
 
 [[fn-obj-names,OBJECT_NAMES()]]
-== OBJECT_NAMES(`expression`)
+== OBJECT_NAMES
 
 === Description
 
 This function returns an array, containing the names of each attribute in the input object.
 It is particularly useful when iterating over multiple objects in an array, as it collates similar attribute names.
 
-=== Arguments
+=== Syntax
+
+....
+OBJECT_NAMES(expression)
+....
+
+==== Arguments
 
 expression:: An expression representing an object.
 
@@ -716,7 +762,7 @@ SELECT OBJECT_NAMES({"flight": "AI444", "utc": "4:44:44", "codename": "green"})
     AS names;
 ----
 
-.Results
+.Result
 [source,json]
 ----
 [
@@ -743,7 +789,7 @@ WITH special_flights AS ([{"flight": "AI444", "utc": "4:44:44", "codename": "gre
 SELECT OBJECT_NAMES(special_flights[*]) AS names;
 ----
 
-.Results
+.Result
 [source,json]
 ----
 [
@@ -836,7 +882,7 @@ SELECT OBJECT_PAIRS({"flight": "AI444", "utc": "4:44:44", "codename": "green"})
     AS outer_pairs;
 ----
 
-.Results
+.Result
 [source,json]
 ----
 [
@@ -870,7 +916,7 @@ SELECT OBJECT_PAIRS({"flight": "AI444", "utc": "4:44:44", "codename": "green"},{
     AS outer_pairs;
 ----
 
-.Results
+.Result
 [source,json]
 ----
 [
@@ -908,7 +954,7 @@ WITH special_flights AS ([{"flight": "AI444", "utc": "4:44:44", "codename": "gre
 SELECT OBJECT_PAIRS(special_flights[*]) AS outer_pairs;
 ----
 
-.Results
+.Result
 [source,json]
 ----
 [
@@ -1113,7 +1159,7 @@ SELECT OBJECT_PAIRS_NESTED(input) AS nested_pairs,
                                    AS filtered_fields_regex;
 ----
 
-.Results
+.Result
 [source,json]
 ----
 [
@@ -1193,7 +1239,7 @@ WITH special_flights AS ([{"flight": "AI444", "utc": "4:44:44", "codename": "gre
 SELECT OBJECT_PAIRS_NESTED(special_flights[*], {"composites": true}) AS nested_pairs;
 ----
 
-.Results
+.Result
 [source,json]
 ----
 [
@@ -1406,7 +1452,7 @@ SELECT OBJECT_PATHS(input, {"composites": true}) AS composite,
        OBJECT_PATHS(input, {"composites": false}) AS non_composite;
 ----
 
-.Results
+.Result
 [source,json]
 ----
 [
@@ -1443,7 +1489,7 @@ SELECT
     AS no_subscripts_unique;
 ----
 
-.Results
+.Result
 [source,json]
 ----
 [
@@ -1489,7 +1535,7 @@ SELECT
     AS exact_field_name; 
 ----
 
-.Results
+.Result
 [source,json]
 ----
 [
@@ -1523,7 +1569,7 @@ FROM hotel
 LIMIT 1;
 ----
 
-.Results
+.Result
 [source,json]
 ----
 [
@@ -1593,10 +1639,10 @@ attr_value:: The value of the attribute.
 
 The updated object.
 
-* If [.var]`attr_key` is found in the object, it replaces the corresponding attribute value by [.var]`attr_value`.
-* If [.var]`attr_value` is MISSING, it deletes the corresponding existing key (if any), like <<fn-obj-remove>>.
-* If [.var]`attr_key` is MISSING, it returns a MISSING value.
-* If [.var]`attr_key` is not an object, it returns a NULL value.
+* If `attr_key` is found in the object, it replaces the corresponding attribute value by `attr_value`.
+* If `attr_value` is MISSING, it deletes the corresponding existing key (if any), like <<fn-obj-remove>>.
+* If `attr_key` is MISSING, it returns a MISSING value.
+* If `attr_key` is not an object, it returns a NULL value.
 
 === Examples
 
@@ -1613,7 +1659,7 @@ FROM route
 LIMIT 1;
 ----
 
-.Results
+.Result
 [source,json]
 ----
 [
@@ -1669,7 +1715,7 @@ FROM airline AS t
 LIMIT 1;
 ----
 
-.Results
+.Result
 [source,json]
 ----
 [
@@ -1714,8 +1760,8 @@ attr_key:: The name of the attribute to remove.
 
 The input object without the removed attribute.
 
-* If the [.var]`attr_key` is MISSING, it returns a MISSING value.
-* If the [.var]`attr_key` is not an object, it returns a NULL value.
+* If the `attr_key` is MISSING, it returns a MISSING value.
+* If the `attr_key` is not an object, it returns a NULL value.
 
 === Examples
 
@@ -1732,7 +1778,7 @@ FROM route
 LIMIT 1;
 ----
 
-.Results
+.Result
 [source,json]
 ----
 [
@@ -1759,7 +1805,7 @@ LIMIT 1;
 SELECT OBJECT_REMOVE({"abc": 1, "def": 2, "ghi": 3}, "def");
 ----
 
-.Results
+.Result
 [source,json]
 ----
 [
@@ -1808,7 +1854,7 @@ FROM airline AS t
 LIMIT 1;
 ----
 
-.Results
+.Result
 [source,json]
 ----
 [
@@ -1865,7 +1911,7 @@ SELECT OBJECT_TYPES({"flight": "AI444",
     AS object_types;
 ----
 
-.Results
+.Result
 [source,json]
 ----
 [
@@ -1914,7 +1960,7 @@ SELECT OBJECT_TYPES_NESTED({"flight":"AI444",
     AS object_types_nested;
 ----
 
-.Results
+.Result
 [source,json]
 ----
 [
@@ -1968,7 +2014,7 @@ SELECT OBJECT_UNWRAP({"name": "value"}) AS single,
        OBJECT_UNWRAP("some-string") AS `string`;
 ----
 
-.Results
+.Result
 [source,json]
 ----
 [
@@ -2016,7 +2062,7 @@ SELECT OBJECT_VALUES({"flight": "AI444", "utc": "4:44:44", "codename": "green"})
     AS outer_values;
 ----
 
-.Results
+.Result
 [source,json]
 ----
 [
@@ -2045,7 +2091,7 @@ WITH special_flights AS ([{"flight": "AI444", "utc": "4:44:44", "codename": "gre
 SELECT OBJECT_VALUES(special_flights[*]) AS outer_values;
 ----
 
-.Results
+.Result
 [source,json]
 ----
 [

--- a/modules/n1ql/pages/n1ql-language-reference/objectfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/objectfun.adoc
@@ -705,7 +705,7 @@ SELECT OBJECT_INNER_VALUES(special_flights[*]) AS inner_values;
 Returns the number of name-value pairs in an object.
 It only counts the top-level attributes and does not recurse into nested objects.
 
-This function is similar to xref:n1ql-language-reference/arrayfun.adoc#len[LEN()], but specifically operates on objects.
+The xref:n1ql-language-reference/metafun.adoc#len[LEN()] function is equivalent to OBJECT_LENGTH() when working with objects.
 
 === Syntax
 
@@ -1355,7 +1355,7 @@ SELECT OBJECT_PAIRS_NESTED(special_flights[*], {"composites": true}) AS nested_p
 ]
 ----
 
-Compare this example with the <<obj-pairs-ex3, OBJECT_PAIRS() example>>.
+Compare this example with <<obj-pairs-ex3>>.
 ====
 
 [[fn-obj-paths,OBJECT_PATHS()]]

--- a/modules/n1ql/pages/n1ql-language-reference/objectfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/objectfun.adoc
@@ -730,8 +730,6 @@ SELECT OBJECT_LENGTH({"abc": 1, "def": 2, "ghi": {"uvw": 3, "xyz": 4}});
 [[fn-obj-names,OBJECT_NAMES()]]
 == OBJECT_NAMES
 
-=== Description
-
 This function returns an array, containing the names of each attribute in the input object.
 It is particularly useful when iterating over multiple objects in an array, as it collates similar attribute names.
 
@@ -806,11 +804,7 @@ SELECT OBJECT_NAMES(special_flights[*]) AS names;
 ====
 
 [[fn-obj-pairs,OBJECT_PAIRS()]]
-== OBJECT_PAIRS(`expression` [, `options` ])
-
-_Alias_: *OBJECT_OUTER_PAIRS(`expression` [, `options` ])*
-
-=== Description
+== OBJECT_PAIRS
 
 This function returns an array of objects, containing the names and values of each attribute in the input object. 
 It also provides an option to return attribute types instead of values. 
@@ -820,7 +814,15 @@ However, if an object does not contain a shared attribute name, it returns a nul
 
 For an illustration, refer to the examples below.
 
-=== Arguments
+This function has an alias `OBJECT_OUTER_PAIRS`. 
+
+=== Syntax
+
+....
+OBJECT_PAIRS(expression [, options])
+....
+
+==== Arguments
 
 expression:: An expression representing an object.
 
@@ -828,7 +830,7 @@ options:: [Optional]
 A JSON object specifying options for the function.
 
 
-=== Options
+==== Options
 
 [options="header", cols="1a,3a,1a"]
 |===
@@ -1000,9 +1002,7 @@ SELECT OBJECT_PAIRS(special_flights[*]) AS outer_pairs;
 
 
 [[fn-obj-pairs-nested,OBJECT_PAIRS_NESTED()]]
-== OBJECT_PAIRS_NESTED(`object` [, `options`])
-
-=== Description
+== OBJECT_PAIRS_NESTED
 
 Similar to <<fn-obj-pairs>>, this function returns an array of objects, containing the names and values of each field in the input object. 
 It also provides an option to return field types instead of values. 
@@ -1013,13 +1013,19 @@ However, if an object does not contain a shared field name, it returns a null en
 
 For an illustration, refer to the examples below.
 
-=== Arguments
+=== Syntax
+
+....
+OBJECT_PAIRS_NESTED(object [, options])
+....
+
+==== Arguments
 
 object:: An expression representing an object.
 
 options:: [Optional] A JSON object specifying options for the function. 
 
-=== Options
+==== Options
 
 [options="header", cols="1a,3a,1a"]
 |===
@@ -1334,20 +1340,24 @@ Compare this example with <<obj-pairs-ex3>>.
 ====
 
 [[fn-obj-paths,OBJECT_PATHS()]]
-== OBJECT_PATHS(`object` [, `options`] )
-
-=== Description
+== OBJECT_PATHS
 
 This function returns the paths to all the fields within an object.
 A field in this context may be any attribute or element, nested at any level within the object.
 
-=== Arguments
+=== Syntax
+
+....
+OBJECT_PATHS(object [, options])
+....
+
+==== Arguments
 
 object:: An expression representing an object.
 
 options:: [Optional] An object containing the following possible parameters. 
 
-=== Options
+==== Options
 
 [options="header", cols="1a,3a,1a"]
 |===
@@ -1621,13 +1631,17 @@ LIMIT 1;
 ====
 
 [[fn-obj-put,OBJECT_PUT()]]
-== OBJECT_PUT(`object`, `attr_key`, `attr_value`)
-
-=== Description
+== OBJECT_PUT
 
 This function adds new or updates existing attributes and values to a given object.
 
-=== Arguments
+=== Syntax
+
+....
+OBJECT_PUT(object, attr_key, attr_value)
+....
+
+==== Arguments
 
 object:: An expression representing an object.
 
@@ -1644,7 +1658,7 @@ The updated object.
 * If `attr_key` is MISSING, it returns a MISSING value.
 * If `attr_key` is not an object, it returns a NULL value.
 
-=== Examples
+=== Example
 
 include::ROOT:partial$query-context.adoc[tag=section]
 
@@ -1680,13 +1694,17 @@ LIMIT 1;
 ====
 
 [[fn-obj-rename,OBJECT_RENAME()]]
-== OBJECT_RENAME(`input_obj`, `old_field`, `new_field`)
-
-=== Description
+== OBJECT_RENAME
 
 Renames the attribute `old_field` to `new_field` in the JSON input object `input_obj`.
 
-=== Arguments
+=== Syntax
+
+....
+OBJECT_RENAME(input_obj, old_field, new_field)
+....
+
+==== Arguments
 
 input_obj:: Any JSON object, or {sqlpp} expression that can evaluate to a JSON object, representing the search object.
 
@@ -1699,7 +1717,7 @@ new_field:: A string, or any valid xref:n1ql-language-reference/index.adoc[expre
 The input object with the new attribute name.
 Note that if the new attribute name already exists in the input object, the original attribute with that name is replaced.
 
-=== Examples
+=== Example
 
 include::ROOT:partial$query-context.adoc[tag=section]
 
@@ -1744,13 +1762,17 @@ LIMIT 1;
 ====
 
 [[fn-obj-remove,OBJECT_REMOVE()]]
-== OBJECT_REMOVE(`object`, `attr_key`)
-
-=== Description
+== OBJECT_REMOVE
 
 This function removes the specified attribute and corresponding values from the given object.
 
-=== Attributes
+=== Syntax
+
+....
+OBJECT_REMOVE(object, attr_key)
+....
+
+==== Arguments
 
 object:: An expression representing an object.
 
@@ -1820,13 +1842,17 @@ SELECT OBJECT_REMOVE({"abc": 1, "def": 2, "ghi": 3}, "def");
 ====
 
 [[fn-obj-replace,OBJECT_REPLACE()]]
-== OBJECT_REPLACE(`input_obj`, `old_value`, `new_value`)
-
-=== Description
+== OBJECT_REPLACE
 
 Replaces all occurrences of the value `value_old` to `value_new` in the JSON input object `input_obj`.
 
-=== Arguments
+=== Syntax
+
+...
+OBJECT_REPLACE(input_obj, old_value, new_value)
+...
+
+==== Arguments
 
 input_obj:: Any JSON object, or {sqlpp} expression that can evaluate to a JSON object, representing the search object.
 
@@ -1838,7 +1864,7 @@ new_value:: A string, or any valid xref:n1ql-language-reference/index.adoc[expre
 
 The JSON object `input_obj` with replaced values.
 
-=== Examples
+=== Example
 
 include::ROOT:partial$query-context.adoc[tag=section]
 
@@ -1883,11 +1909,15 @@ LIMIT 1;
 ====
 
 [[fn-obj-type,OBJECT_TYPES()]]
-== OBJECT_TYPES(`expression`)
-
-=== Description
+== OBJECT_TYPES
 
 This function returns the data type of every field in the supplied object, as reported by the xref:n1ql-language-reference/typefun.adoc#fn-type-type[TYPE()] function.
+
+=== Syntax
+
+...
+OBJECT_TYPES(expression)
+...
 
 === Arguments
 
@@ -1928,14 +1958,18 @@ SELECT OBJECT_TYPES({"flight": "AI444",
 ====
 
 [[fn-obj-types-nested,OBJECT_TYPES_NESTED()]]
-== OBJECT_TYPES_NESTED(`expression`)
-
-=== Description
+== OBJECT_TYPES_NESTED
 
 This function returns the data type of every non-composite field in the supplied object, as reported by the xref:n1ql-language-reference/typefun.adoc#fn-type-type[TYPE()] function.
 Additionally, all composite type fields (ARRAYs and OBJECTs) are recursively processed in the same way, returning the data types of all nested values. 
 
-=== Arguments
+=== Syntax
+
+...
+OBJECT_TYPES_NESTED(expression)
+...
+
+==== Arguments
 
 expression:: An expression representing an object.
 
@@ -1985,13 +2019,17 @@ SELECT OBJECT_TYPES_NESTED({"flight":"AI444",
 
 
 [[fn-obj-unwrap,OBJECT_UNWRAP()]]
-== OBJECT_UNWRAP(`expression`)
-
-=== Description
+== OBJECT_UNWRAP
 
 This function enables you to unwrap an object without knowing the name of the attribute.
 
-=== Arguments
+=== Syntax
+
+...
+OBJECT_UNWRAP(expression)
+...
+
+==== Arguments
 
 expression:: An expression representing an object.
 
@@ -2001,7 +2039,7 @@ If the argument is an object with exactly one attribute, this function returns t
 If the argument is MISSING, it returns MISSING.
 For all other cases, it returns NULL.
 
-=== Examples
+=== Example
 
 [[obj-unwrap-ex,OBJECT_UNWRAP() Example]]
 ====
@@ -2029,11 +2067,7 @@ SELECT OBJECT_UNWRAP({"name": "value"}) AS single,
 ====
 
 [[fn-obj-values,OBJECT_VALUES()]]
-== OBJECT_VALUES(`expression`)
-
-_Alias_: *OBJECT_OUTER_VALUES(`expression`)*
-
-=== Description
+== OBJECT_VALUES
 
 This function returns an array, containing the values of each attribute in the input object.
 It is particularly useful when iterating over multiple objects in an array, as it collates the values from similarly-named attributes into a single nested array.
@@ -2041,7 +2075,15 @@ It is particularly useful when iterating over multiple objects in an array, as i
 In this case, the function returns a null entry from any object which does not contain the shared attribute name, rather like an OUTER JOIN.
 For an illustration, refer to the examples below.
 
-=== Arguments
+This function has an alias `OBJECT_OUTER_VALUES`.
+
+=== Syntax
+
+...
+OBJECT_VALUES(expression)
+...
+
+==== Arguments
 
 expression:: An expression representing an object.
 
@@ -2122,3 +2164,8 @@ SELECT OBJECT_VALUES(special_flights[*]) AS outer_values;
 ]
 ----
 ====
+
+== Aliases
+
+* `OBJECT_OUTER_PAIRS` is an alias for <<fn-obj-pairs,OBJECT_PAIRS>>.
+* `OBJECT_OUTER_VALUES` is an alias for <<fn-obj-values,OBJECT_VALUES>>.

--- a/modules/n1ql/pages/n1ql-language-reference/objectfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/objectfun.adoc
@@ -19,9 +19,9 @@ OBJECT_ADD(object, new_attr_key, new_attr_value)
 
 ==== Arguments
 
-object:: An expression representing the object to update.
-new_attr_key:: The name of the attribute to add to the object.
-new_attr_value:: The value to assign to the new attribute.
+object:: [Required] An expression representing the object to update.
+new_attr_key:: [Required] The name of the attribute to add to the object.
+new_attr_value:: [Required] The value to assign to the new attribute.
 
 === Return Value
 
@@ -39,15 +39,9 @@ The updated object.
 .Query
 [source,sqlpp]
 ----
-WITH route AS ([{
-  "id": "R1",
-  "schedule": [
-    {"day": 0, "flight": "AF198", "utc": "10:13:00"},
-    {"day": 2, "flight": "AF200", "utc": "15:30:00"}
-  ]
-}])
-SELECT route[0].schedule[0] AS original,
-       OBJECT_ADD(route[0].schedule[0], "day_new", 1) AS output;
+SELECT 
+OBJECT_ADD({"day": 0, "flight": "AF198", "utc": "10:13:00"}, 
+      "day_new", 1) AS output;
 ----
 
 .Result
@@ -55,11 +49,6 @@ SELECT route[0].schedule[0] AS original,
 ----
 [
   {
-    "original": {
-      "day": 0,
-      "flight": "AF198",
-      "utc": "10:13:00"
-    },
     "output": {
       "day": 0,
       "day_new": 1,
@@ -87,7 +76,7 @@ OBJECT_CONCAT(expr1, expr2, ...)
 
 ==== Arguments
 
-expr1, expr2, ...:: Expressions representing the objects to concatenate.
+expr1, expr2, ...:: [Required] Expressions representing the objects to concatenate.
 You must provide at least two expressions. 
 All input objects must be plain objects and cannot be arrays of objects.
 
@@ -98,7 +87,7 @@ An object constructed by concatenating all the input objects.
 If multiple input objects contain the same attribute name, the function copies the attribute from the last relevant object in the argument list to the output object. 
 The same-named attributes from earlier objects in the list are ignored.
 
-=== Examples
+=== Example
 
 [[obj-concat-ex,OBJECT_CONCAT() Example]]
 ====
@@ -146,7 +135,7 @@ OBJECT_CONCAT2(expr1, expr2, ...)
 
 ==== Arguments
 
-expr1, expr2, ...:: Expressions representing the objects to concatenate.
+expr1, expr2, ...:: [Required] Expressions representing the objects to concatenate.
 You must provide at least two expressions.
 These can be plain objects or arrays of objects, but the first argument must be a plain object and cannot be an array. 
 
@@ -204,9 +193,9 @@ OBJECT_FIELD(expr, field)
 
 ==== Arguments
 
-expr:: An expression representing the object to query.
+expr:: [Required] An expression representing the object to query.
 
-field:: A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the path to a field within the object.
+field:: [Required] A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the path to a field within the object.
 +
 You can use xref:n1ql-language-reference/nestedops.adoc[nested operators] to specify the path to a nested attribute or element.
 If any attribute names within the field path contain special characters, they must be escaped using backticks (`{backtick}{backtick}`).
@@ -339,7 +328,7 @@ OBJECT_FILTER(expression [, options])
 ....
 
 ==== Arguments
-expression:: An expression representing an object.
+expression:: [Required] An expression representing an object.
 
 options:: [Optional] A JSON object specifying options for the function.
 
@@ -511,13 +500,13 @@ For an illustration, refer to the examples below.
 
 === Syntax
 
-...
+....
 OBJECT_INNER_PAIRS(expr)
-...
+....
 
 ==== Arguments
 
-expr:: An expression representing an object.
+expr:: [Required] An expression representing an object.
 
 === Return Value
 
@@ -635,7 +624,7 @@ OBJECT_INNER_VALUES(expr)
 
 ==== Arguments
 
-expr:: An expression representing an object.
+expr:: [Required] An expression representing an object.
 
 === Return Value
 
@@ -726,7 +715,7 @@ OBJECT_LENGTH(expr)
 
 ==== Arguments
 
-expr:: An expression representing an object.
+expr:: [Required] An expression representing an object.
 
 === Return Value
 
@@ -742,16 +731,21 @@ If the input expression is `MISSING`, the function returns `MISSING`.
 .Query
 [source,sqlpp]
 ----
-SELECT OBJECT_LENGTH({"abc": 1, "def": 2, "ghi": {"uvw": 3, "xyz": 4}});
+SELECT OBJECT_LENGTH(
+    {"flight": "AI444", 
+    "airline": "Air France", 
+    "departure": {"airport": "CDG", "time": "10:13:00"}
+  }) 
+AS length;
 ----
 
 .Result
 [source,json]
 ----
 [
-    {
-        "$1": 3
-    }
+  {
+    "length": 3
+  }
 ]
 ----
 ====
@@ -770,7 +764,7 @@ OBJECT_NAMES(expr)
 
 ==== Arguments
 
-expr:: An expression representing an object.
+expr:: [Required] An expression representing an object.
 
 === Return Value
 
@@ -841,8 +835,6 @@ It also provides an option to return attribute types instead of values.
 The function is particularly useful when iterating over multiple objects in an array, as it collates the values from similarly-named attributes into a single nested array. 
 However, if an object does not contain a shared attribute name, it returns a null entry, similar to an OUTER JOIN.
 
-For an illustration, refer to the examples below.
-
 This function has an alias `OBJECT_OUTER_PAIRS`. 
 
 === Syntax
@@ -853,7 +845,7 @@ OBJECT_PAIRS(expression [, options])
 
 ==== Arguments
 
-expression:: An expression representing an object.
+expression:: [Required] An expression representing an object.
 
 options:: [Optional]
 A JSON object specifying options for the function.
@@ -898,7 +890,7 @@ An array of objects, each containing the following attributes:
 | String
 |===
 
-NOTE: Each returned object will have either **val** or **type** (depending on the specified options), and not both. 
+NOTE: Each returned object will have either `val` or `type` (depending on the specified options), and not both. 
 Also, the objects in the array are sorted by attribute name, in {sqlpp} collation order.
 
 === Examples
@@ -1040,8 +1032,6 @@ A field in this context may be any attribute or element, nested at any level wit
 This function may be useful when iterating over multiple objects in an array, as it collates and unnests the values from similarly-named fields across all objects in the input array.
 However, if an object does not contain a shared field name, it returns a null entry, similar to an OUTER JOIN.
 
-For an illustration, refer to the examples below.
-
 === Syntax
 
 ....
@@ -1050,7 +1040,7 @@ OBJECT_PAIRS_NESTED(object [, options])
 
 ==== Arguments
 
-object:: An expression representing an object.
+object:: [Required] An expression representing an object.
 
 options:: [Optional] A JSON object specifying options for the function. 
 
@@ -1171,7 +1161,7 @@ If any attribute names within a field path contain special characters, they are 
 | String
 |===
 
-NOTE: Each returned object will have either **val** or **type** (depending on the specified options), and not both. 
+NOTE: Each returned object will have either `val` or `type` (depending on the specified options), and not both. 
 Also, the objects in the array are sorted by field name, in {sqlpp} collation order.
 
 === Examples
@@ -1191,7 +1181,7 @@ SELECT OBJECT_PAIRS_NESTED(input) AS nested_pairs,
        OBJECT_PAIRS_NESTED(input, {"types": true}) AS nested_pairs_types,
        OBJECT_PAIRS_NESTED(input, {"pattern": "number", "patternspace":"field"}) AS filtered_fields,
        OBJECT_PAIRS_NESTED(input, {"pattern": "-name$", "patternspace":"field", "regex":true}) 
-                                   AS filtered_fields_regex;
+       AS filtered_fields_regex;
 ----
 
 .Result
@@ -1365,7 +1355,7 @@ SELECT OBJECT_PAIRS_NESTED(special_flights[*], {"composites": true}) AS nested_p
 ]
 ----
 
-Compare this example with <<obj-pairs-ex3>>.
+Compare this example with the <<obj-pairs-ex3, OBJECT_PAIRS() example>>.
 ====
 
 [[fn-obj-paths,OBJECT_PATHS()]]
@@ -1382,7 +1372,7 @@ OBJECT_PATHS(object [, options])
 
 ==== Arguments
 
-object:: An expression representing an object.
+object:: [Required] An expression representing an object.
 
 options:: [Optional] An object containing the following possible parameters. 
 
@@ -1648,11 +1638,11 @@ OBJECT_PUT(object, attr_key, attr_value)
 
 ==== Arguments
 
-object:: An expression representing an object.
+object:: [Required] An expression representing an object.
 
-attr_key:: The name of the attribute to insert or update.
+attr_key:: [Required] The name of the attribute to insert or update.
 
-attr_value:: The value of the attribute.
+attr_value:: [Required] The value of the attribute.
 
 === Return Value
 
@@ -1665,17 +1655,16 @@ The updated object.
 
 === Example
 
-include::ROOT:partial$query-context.adoc[tag=section]
-
 [[obj-put-ex,OBJECT_PUT() Example]]
 ====
 .Query
 [source,sqlpp]
 ----
-SELECT schedule[0] AS original,
-       OBJECT_PUT(schedule[0], "day", 1) AS output
-FROM route
-LIMIT 1;
+SELECT OBJECT_PUT(
+          {"day": 0,
+           "flight": "AF198",
+           "utc": "10:13:00"}, "day", 3) 
+AS updated;
 ----
 
 .Result
@@ -1683,13 +1672,8 @@ LIMIT 1;
 ----
 [
   {
-    "original": {
-      "day": 0,
-      "flight": "AF198",
-      "utc": "10:13:00"
-    },
-    "output": {
-      "day": 1,
+    "updated": {
+      "day": 3,
       "flight": "AF198",
       "utc": "10:13:00"
     }
@@ -1711,11 +1695,11 @@ OBJECT_RENAME(input_obj, old_field, new_field)
 
 ==== Arguments
 
-input_obj:: Any JSON object, or {sqlpp} expression that can evaluate to a JSON object, representing the search object.
+input_obj:: [Required] Any JSON object, or {sqlpp} expression that can evaluate to a JSON object, representing the search object.
 
-old_field:: A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the old (original) attribute name inside the JSON object `input_obj`.
+old_field:: [Required] A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the old (original) attribute name inside the JSON object `input_obj`.
 
-new_field:: A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the new attribute name to replace `old_field` inside the JSON object `input_obj`.
+new_field:: [Required] A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the new attribute name to replace `old_field` inside the JSON object `input_obj`.
 
 === Return Value
 
@@ -1724,18 +1708,15 @@ Note that if the new attribute name already exists in the input object, the orig
 
 === Example
 
-include::ROOT:partial$query-context.adoc[tag=section]
-
 [[obj-rename-ex,OBJECT_RENAME() Example]]
 .Changing a field name
 ====
 .Query
 [source,sqlpp]
 ----
-SELECT t AS original,
-       OBJECT_RENAME(t, "name", "new_name") AS output
-FROM airline AS t
-LIMIT 1;
+WITH input AS ({"flight-name": "AI444", "flight-number": 737})
+SELECT input AS original,
+        OBJECT_RENAME(input, "flight-name", "flight") AS renamed;
 ----
 
 .Result
@@ -1744,22 +1725,12 @@ LIMIT 1;
 [
   {
     "original": {
-      "callsign": "MILE-AIR",
-      "country": "United States",
-      "iata": "Q5",
-      "icao": "MLA",
-      "id": 10,
-      "name": "40-Mile Air",
-      "type": "airline"
+      "flight-name": "AI444",
+      "flight-number": 737
     },
-    "output": {
-      "callsign": "MILE-AIR",
-      "country": "United States",
-      "iata": "Q5",
-      "icao": "MLA",
-      "id": 10,
-      "new_name": "40-Mile Air",
-      "type": "airline"
+    "renamed": {
+      "flight": "AI444",
+      "flight-number": 737
     }
   }
 ]
@@ -1779,9 +1750,9 @@ OBJECT_REMOVE(object, attr_key)
 
 ==== Arguments
 
-object:: An expression representing an object.
+object:: [Required] An expression representing an object.
 
-attr_key:: The name of the attribute to remove.
+attr_key:: [Required] The name of the attribute to remove.
 
 === Return Value
 
@@ -1794,15 +1765,13 @@ The input object without the removed attribute.
 
 [[obj-remove-ex1,OBJECT_REMOVE() Example 1]]
 ====
-include::ROOT:partial$query-context.adoc[tag=example]
 
 .Query
 [source,sqlpp]
 ----
-SELECT schedule[0] AS original,
-       OBJECT_REMOVE(schedule[0], "day") AS output
-FROM route
-LIMIT 1;
+WITH input AS ({"flight-name": "AI444", "flight-number": 737})
+SELECT input AS original,
+       OBJECT_REMOVE(input, "flight-number") AS output;
 ----
 
 .Result
@@ -1811,35 +1780,11 @@ LIMIT 1;
 [
   {
     "original": {
-      "day": 0,
-      "flight": "AF198",
-      "utc": "10:13:00"
+      "flight-name": "AI444",
+      "flight-number": 737
     },
     "output": {
-      "flight": "AF198",
-      "utc": "10:13:00"
-    }
-  }
-]
-----
-====
-
-[[obj-remove-ex2,OBJECT_REMOVE() Example 2]]
-====
-.Query
-[source,sqlpp]
-----
-SELECT OBJECT_REMOVE({"abc": 1, "def": 2, "ghi": 3}, "def");
-----
-
-.Result
-[source,json]
-----
-[
-  {
-    "$1": {
-      "abc": 1,
-      "ghi": 3
+      "flight-name": "AI444"
     }
   }
 ]
@@ -1849,21 +1794,21 @@ SELECT OBJECT_REMOVE({"abc": 1, "def": 2, "ghi": 3}, "def");
 [[fn-obj-replace,OBJECT_REPLACE()]]
 == OBJECT_REPLACE
 
-Replaces all occurrences of the value `value_old` to `value_new` in the JSON input object `input_obj`.
+Replaces all occurrences of a specified value with another value in the given JSON object.
 
 === Syntax
 
-...
+....
 OBJECT_REPLACE(input_obj, old_value, new_value)
-...
+....
 
 ==== Arguments
 
-input_obj:: Any JSON object, or {sqlpp} expression that can evaluate to a JSON object, representing the search object.
+input_obj:: [Required] Any JSON object, or {sqlpp} expression that can evaluate to a JSON object, representing the search object.
 
-old_value:: A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the old (original) value name inside the JSON object `input_obj`.
+old_value:: [Required] A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the old (original) value name inside the JSON object `input_obj`.
 
-new_value:: A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the new value name to replace `old_value` inside the JSON object `input_obj`.
+new_value:: [Required] A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the new value name to replace `old_value` inside the JSON object `input_obj`.
 
 === Return Value
 
@@ -1871,18 +1816,15 @@ The JSON object `input_obj` with replaced values.
 
 === Example
 
-include::ROOT:partial$query-context.adoc[tag=section]
-
 [[obj-replace-ex,OBJECT_REPLACE() Example]]
 .Replace any occurrences of "airline" with "airplane"
 ====
 .Query
 [source,sqlpp]
 ----
-SELECT t AS original,
-       OBJECT_REPLACE(t, "airline", "airplane") AS output
-FROM airline AS t
-LIMIT 1;
+WITH input AS ({"flight-name": "AI444", "flight-number": 737})
+SELECT input AS original,
+       OBJECT_REPLACE(input, "AI444", "FO123") AS output;
 ----
 
 .Result
@@ -1891,22 +1833,12 @@ LIMIT 1;
 [
   {
     "original": {
-      "callsign": "MILE-AIR",
-      "country": "United States",
-      "iata": "Q5",
-      "icao": "MLA",
-      "id": 10,
-      "name": "40-Mile Air",
-      "type": "airline"
+      "flight-name": "AI444",
+      "flight-number": 737
     },
     "output": {
-      "callsign": "MILE-AIR",
-      "country": "United States",
-      "iata": "Q5",
-      "icao": "MLA",
-      "id": 10,
-      "name": "40-Mile Air",
-      "type": "airplane"
+      "flight-name": "FO123",
+      "flight-number": 737
     }
   }
 ]
@@ -1920,13 +1852,13 @@ Returns the data type of every field in the supplied object, as reported by the 
 
 === Syntax
 
-...
+....
 OBJECT_TYPES(expression)
-...
+....
 
-=== Arguments
+==== Arguments
 
-expression:: An expression representing an object.
+expression:: [Required] An expression representing an object.
 
 === Return Value
 
@@ -1943,7 +1875,7 @@ SELECT OBJECT_TYPES({"flight": "AI444",
                      "duration": 180,
                      "gate": NULL,
                      "aircraft": {"model": "Boeing 737"}}) 
-    AS object_types;
+AS object_types;
 ----
 
 .Result
@@ -1970,13 +1902,13 @@ Additionally, all composite type fields (ARRAYs and OBJECTs) are recursively pro
 
 === Syntax
 
-...
+....
 OBJECT_TYPES_NESTED(expression)
-...
+....
 
 ==== Arguments
 
-expression:: An expression representing an object.
+expression:: [Required] An expression representing an object.
 
 === Return Value
 
@@ -1989,14 +1921,17 @@ An object with the same fields as the input object, but with all values replaced
 .Query
 [source,sqlpp]
 ----
-SELECT OBJECT_TYPES_NESTED({"flight":"AI444",
-                            "crewMembers": ["Alice Bobson",
-                                            "John Flo",
-                                            true],
-                            "gate": NULL,
-                            "aircraft": {"model": "Boeing 737",
-                                         "capacity":200}}) 
-    AS object_types_nested;
+SELECT 
+OBJECT_TYPES_NESTED(
+    {"flight":"AI444",
+     "crewMembers": ["Alice Bobson",
+                     "John Flo",
+                      true],
+      "gate": NULL,
+      "aircraft": {"model": "Boeing 737", "capacity":200}
+      }
+    ) 
+AS object_types_nested;
 ----
 
 .Result
@@ -2030,19 +1965,19 @@ Enables you to unwrap an object without knowing the name of the attribute.
 
 === Syntax
 
-...
+....
 OBJECT_UNWRAP(expression)
-...
+....
 
 ==== Arguments
 
-expression:: An expression representing an object.
+expression:: [Required] An expression representing an object.
 
 === Return Value
 
 If the argument is an object with exactly one attribute, this function returns the value in the attribute.
-If the argument is MISSING, it returns MISSING.
-For all other cases, it returns NULL.
+If the argument is `MISSING`, it returns `MISSING`.
+For all other cases, it returns `NULL`.
 
 === Example
 
@@ -2084,13 +2019,13 @@ This function has an alias `OBJECT_OUTER_VALUES`.
 
 === Syntax
 
-...
+....
 OBJECT_VALUES(expression)
-...
+....
 
 ==== Arguments
 
-expression:: An expression representing an object.
+expression:: [Required] An expression representing an object.
 
 === Return Value
 


### PR DESCRIPTION
Changes:
- Updated function titles to display only the function name.
- Removed the **Description** heading for all functions. 
- Added a new **Syntax** section to each function, containing the full function definition (name + arguments).
- Moved the existing **Arguments** section to be a sub-section within **Syntax**.
- Replaced all examples to use ready-to-use code samples. (All samples locally tested and verified).

Previews:

- [Number Functions](https://preview.docs-test.couchbase.com/docs-devex-DOC-14261-update-object-number-functions/server/current/n1ql/n1ql-language-reference/numericfun.html)
- [Object Functions](https://preview.docs-test.couchbase.com/docs-devex-DOC-14261-update-object-number-functions/server/current/n1ql/n1ql-language-reference/objectfun.html)