### PR TITLE
[DOC-12458] Add a note about `completed_requests`

### DIFF
--- a/modules/n1ql/pages/n1ql-manage/monitoring-n1ql-query.adoc
+++ b/modules/n1ql/pages/n1ql-manage/monitoring-n1ql-query.adoc
@@ -494,6 +494,9 @@ By default, the `system:completed_requests` catalog maintains a list of the most
 For each completed request, this catalog maintains information such as requestId, statement text, prepared name (if prepared statement), request time, service time, and so on.
 This information provides a general insight into the health and performance of the query node and the cluster.
 
+NOTE: The `system:completed_requests` catalog automatically captures named and positional parameters for qualified requests, regardless of the `controls` setting. 
+For more information about this setting, see xref:n1ql-manage/query-settings.adoc#section_nnj_sjk_k1b[Request-Level Parameters].
+
 [[sys-completed-get]]
 === Get Completed Requests
 


### PR DESCRIPTION
Added a note mentioning that the `system:completed_requests` catalog automatically captures named and positional parameters for qualified requests, regardless of the `controls` setting. 

> [!NOTE]
> DO NOT MERGE this PR until the corresponding API docs are updated. 