### PR TITLE
[DOC-14244] Encryption at Rest for Query Service

### DIFF
--- a/modules/n1ql/pages/n1ql-manage/index.adoc
+++ b/modules/n1ql/pages/n1ql-manage/index.adoc
@@ -45,4 +45,5 @@ You can monitor and manage primary and secondary indexes using the Couchbase Web
 You can configure the Query service using cluster-level query settings, node-level query settings, and request-level query parameters.
 
 * xref:n1ql:n1ql-manage/query-settings.adoc[]
+* xref:n1ql:n1ql-manage/query-encryption-at-rest.adoc[]
 

--- a/modules/n1ql/pages/n1ql-manage/monitoring-n1ql-query.adoc
+++ b/modules/n1ql/pages/n1ql-manage/monitoring-n1ql-query.adoc
@@ -882,8 +882,8 @@ Couchbase Server tries to manage and retain archive files such that the total di
 When the specified limit is reached, older files are removed as necessary to make space for newly finalized files.
 When a file is removed, it's not guaranteed that only the oldest requests are evicted, given that Couchbase Server writes to multiple archive files in parallel.
 
-NOTE: From Couchbase Server 8.1 and later, you can encrypt the archived request files saved on disk.
-For more information, see xref:link[]. 
+NOTE: In the next major release of Couchbase Server and later, you can encrypt the archived request files saved on disk.
+For more information, see xref:n1ql-manage/query-encryption-at-rest[Encryption at Rest for Query Service]. 
 
 //TODO: Add the doc link. 
 
@@ -929,7 +929,8 @@ In such cases, reading the files directly using the CLI is more efficient.
 
 ==== View Encrypted Request Files
 
-NOTE: Encryption of archived completed request files is only available in Couchbase Server 8.1 and later. 
+NOTE: Encryption of archived completed request files is only available starting from the next major release of Couchbase Server and later.
+For more information, see xref:n1ql-manage/query-encryption-at-rest.adoc[Encryption at Rest for Query Service].
 
 To view encrypted archived requests, use the xref:cli:cbcat.adoc[cbcat] CLI tool.
 

--- a/modules/n1ql/pages/n1ql-manage/monitoring-n1ql-query.adoc
+++ b/modules/n1ql/pages/n1ql-manage/monitoring-n1ql-query.adoc
@@ -930,14 +930,7 @@ In such cases, reading the files directly using the CLI is more efficient.
 NOTE: Encryption of archived completed request files is only available starting from the next major release of Couchbase Server and later.
 For more information, see xref:n1ql-manage/query-encryption-at-rest.adoc[Encryption at Rest for Query Service].
 
-To view encrypted archived requests, use the xref:cli:cbcat.adoc[cbcat] CLI tool.
-
-[source,sh]
-----
-cbcat <add an example>
-----
-
-// TODO: Link to the `cbcat` CLI reference page and include a usage example. 
+To decrypt and view archived request files, use the xref:cli:cbcat.adoc[cbcat] command line tool.
 
 [#query-monitoring-settings]
 == Query Profiling

--- a/modules/n1ql/pages/n1ql-manage/monitoring-n1ql-query.adoc
+++ b/modules/n1ql/pages/n1ql-manage/monitoring-n1ql-query.adoc
@@ -888,49 +888,47 @@ For more information, see xref:n1ql-manage/query-encryption-at-rest.adoc[Encrypt
 [#sys-history-view]
 === View Archived Requests
 
-You can view archived completed requests by using the command line or by running a {sqlpp} query. 
-The method you use depends on whether the files are encrypted or unencrypted.
+You can view archived completed requests by using either the command line or a {sqlpp} query.
 
-==== View Unencrypted Request Files
+==== Using the Command Line
 
-To view unencrypted archived requests, use https://www.gnu.org/software/gzip[gzip] and https://jqlang.github.io/jq[jq] on the command line, or a {sqlpp} query.
+To view archived requests files using the command line, use a tool that matches the encryption state of the files.
 
-[tabs,sync-group-id="REST API|{sqlpp}"]
-====
-Command Line::
+* *Unencrypted files*: Use https://www.gnu.org/software/gzip/[gzip^] and https://jqlang.org/[jq^] on the command line. 
 +
---
-To view all archived completed requests in `$FILE`:
-
+For example, to view archived requests in `$FILE`, use:
++
 [source,sh]
 ----
 gzip -qdc $FILE | jq .
 ----
---
 
-{sqlpp}::
+* *Encrypted files*: Use the xref:cli:cbcat.adoc[cbcat] command line tool.
 +
---
-To get a list of archived completed requests using {sqlpp}:
+For example, to decrypt and view archived requests in `$FILE` encrypted with the master password `$MASTER`, use:
++
+[source,sh]
+----
+cbcat --password $MASTER $FILE
+----
++
+NOTE: Encryption of archived request files is only available in the next major release of Couchbase Server and later. 
+For more information, see xref:n1ql-manage/query-encryption-at-rest.adoc[Encryption at Rest for Query Service].
+
+==== Using a {sqlpp} Query
+
+To view archived requests using a {sqlpp} query, use the `system:completed_requests_history` keyspace.
+This keyspace provides access to both encrypted and unencrypted files.
+
+For example, to get all archived requests, use: 
 
 [source,sqlpp]
 ----
 SELECT * FROM system:completed_requests_history;
 ----
---
-====
 
-NOTE: The `system:completed_requests_history` keyspace provides {sqlpp} access to archived files. 
-Because these files are external GZIP archives, query performance is limited, 
-particularly when querying large histories on multi-node clusters. 
-In such cases, reading the files directly using the CLI is more efficient. 
-
-==== View Encrypted Request Files
-
-NOTE: Encryption of archived completed request files is only available starting from the next major release of Couchbase Server and later.
-For more information, see xref:n1ql-manage/query-encryption-at-rest.adoc[Encryption at Rest for Query Service].
-
-To decrypt and view archived request files, use the xref:cli:cbcat.adoc[cbcat] command line tool.
+NOTE: Because these files are external GZIP archives, query performance is limited, particularly when querying large histories on multi-node clusters.
+In such cases, reading the files directly using the command line is more efficient.
 
 [#query-monitoring-settings]
 == Query Profiling

--- a/modules/n1ql/pages/n1ql-manage/monitoring-n1ql-query.adoc
+++ b/modules/n1ql/pages/n1ql-manage/monitoring-n1ql-query.adoc
@@ -882,10 +882,20 @@ Couchbase Server tries to manage and retain archive files such that the total di
 When the specified limit is reached, older files are removed as necessary to make space for newly finalized files.
 When a file is removed, it's not guaranteed that only the oldest requests are evicted, given that Couchbase Server writes to multiple archive files in parallel.
 
+NOTE: From Couchbase Server 8.1 and later, you can encrypt the archived request files saved on disk.
+For more information, see xref:link[]. 
+
+//TODO: Add the doc link. 
+
 [#sys-history-view]
 === View Archived Requests
 
-To view archived completed requests, use https://www.gnu.org/software/gzip[gzip] and https://jqlang.github.io/jq[jq] on the command line, or a {sqlpp} query.
+You can view archived completed requests by using the command line or by running a {sqlpp} query. 
+The method you use depends on whether the files are encrypted or unencrypted.
+
+==== View Unencrypted Request Files
+
+To view unencrypted archived requests, use https://www.gnu.org/software/gzip[gzip] and https://jqlang.github.io/jq[jq] on the command line, or a {sqlpp} query.
 
 [tabs,sync-group-id="REST API|{sqlpp}"]
 ====
@@ -912,8 +922,18 @@ SELECT * FROM system:completed_requests_history;
 --
 ====
 
-The `system:completed_requests_history` keyspace is provided for {sqlpp} access to the archived files, but as they're external GZIP archives performance is restricted, particularly with large histories on clusters with multiple Query Service nodes.
-Directly reading the files may be more useful in some cases.
+The `system:completed_requests_history` keyspace provides {sqlpp} access to the archived files. 
+However, because these files are external GZIP archives, query performance is limited - 
+particularly for large histories on clusters with multiple Query Service nodes.
+In such cases, directly reading files using the CLI can be more efficient than querying this keyspace. 
+
+==== View Encrypted Request Files
+
+NOTE: Encryption of archived completed request files is only available in Couchbase Server 8.1 and later. 
+
+To view encrypted archived requests, use the xref:cli:cbcat.adoc[cbcat] CLI tool. 
+
+// TODO: Add a link to the `cbcat` CLI reference page and include a usage example. 
 
 [#query-monitoring-settings]
 == Query Profiling

--- a/modules/n1ql/pages/n1ql-manage/monitoring-n1ql-query.adoc
+++ b/modules/n1ql/pages/n1ql-manage/monitoring-n1ql-query.adoc
@@ -885,8 +885,6 @@ When a file is removed, it's not guaranteed that only the oldest requests are ev
 NOTE: In the next major release of Couchbase Server and later, you can encrypt the archived request files saved on disk.
 For more information, see xref:n1ql-manage/query-encryption-at-rest[Encryption at Rest for Query Service]. 
 
-//TODO: Add the doc link. 
-
 [#sys-history-view]
 === View Archived Requests
 
@@ -922,9 +920,9 @@ SELECT * FROM system:completed_requests_history;
 --
 ====
 
-NOTE: The `system:completed_requests_history` keyspace provides {sqlpp} access to the archived files. 
-However, because these files are external GZIP archives, query performance is limited;
-especially when querying large histories on multi-node clusters. 
+NOTE: The `system:completed_requests_history` keyspace provides {sqlpp} access to archived files. 
+Because these files are external GZIP archives, query performance is limited, 
+particularly when querying large histories on multi-node clusters. 
 In such cases, reading the files directly using the CLI is more efficient. 
 
 ==== View Encrypted Request Files

--- a/modules/n1ql/pages/n1ql-manage/monitoring-n1ql-query.adoc
+++ b/modules/n1ql/pages/n1ql-manage/monitoring-n1ql-query.adoc
@@ -922,18 +922,25 @@ SELECT * FROM system:completed_requests_history;
 --
 ====
 
-The `system:completed_requests_history` keyspace provides {sqlpp} access to the archived files. 
+NOTE: Because the Query Service stores archived requests in GZIP files, 
+
+NOTE: The `system:completed_requests_history` keyspace provides {sqlpp} access to the archived files. 
 However, because these files are external GZIP archives, query performance is limited - 
-particularly for large histories on clusters with multiple Query Service nodes.
-In such cases, directly reading files using the CLI can be more efficient than querying this keyspace. 
+especially when querying large histories on multi-node clusters. 
+In such cases, reading the files directly using the CLI is more efficient. 
 
 ==== View Encrypted Request Files
 
 NOTE: Encryption of archived completed request files is only available in Couchbase Server 8.1 and later. 
 
-To view encrypted archived requests, use the xref:cli:cbcat.adoc[cbcat] CLI tool. 
+To view encrypted archived requests, use the xref:cli:cbcat.adoc[cbcat] CLI tool.
 
-// TODO: Add a link to the `cbcat` CLI reference page and include a usage example. 
+[source,sh]
+----
+cbcat <add an example>
+----
+
+// TODO: Link to the `cbcat` CLI reference page and include a usage example. 
 
 [#query-monitoring-settings]
 == Query Profiling

--- a/modules/n1ql/pages/n1ql-manage/monitoring-n1ql-query.adoc
+++ b/modules/n1ql/pages/n1ql-manage/monitoring-n1ql-query.adoc
@@ -883,7 +883,7 @@ When the specified limit is reached, older files are removed as necessary to mak
 When a file is removed, it's not guaranteed that only the oldest requests are evicted, given that Couchbase Server writes to multiple archive files in parallel.
 
 NOTE: In the next major release of Couchbase Server and later, you can encrypt archived request files saved on disk.
-For more information, see xref:n1ql-manage/query-encryption-at-rest.adoc[Encryption at Rest for Query Service]. 
+For more information, see xref:n1ql-manage/query-encryption-at-rest.adoc[]. 
 
 [#sys-history-view]
 === View Archived Requests
@@ -913,7 +913,7 @@ cbcat --password $MASTER $FILE
 ----
 +
 NOTE: Encryption of archived request files is only available in the next major release of Couchbase Server and later. 
-For more information, see xref:n1ql-manage/query-encryption-at-rest.adoc[Encryption at Rest for Query Service].
+For more information, see xref:n1ql-manage/query-encryption-at-rest.adoc[].
 
 ==== Using a {sqlpp} Query
 

--- a/modules/n1ql/pages/n1ql-manage/monitoring-n1ql-query.adoc
+++ b/modules/n1ql/pages/n1ql-manage/monitoring-n1ql-query.adoc
@@ -882,8 +882,8 @@ Couchbase Server tries to manage and retain archive files such that the total di
 When the specified limit is reached, older files are removed as necessary to make space for newly finalized files.
 When a file is removed, it's not guaranteed that only the oldest requests are evicted, given that Couchbase Server writes to multiple archive files in parallel.
 
-NOTE: In the next major release of Couchbase Server and later, you can encrypt the archived request files saved on disk.
-For more information, see xref:n1ql-manage/query-encryption-at-rest[Encryption at Rest for Query Service]. 
+NOTE: In the next major release of Couchbase Server and later, you can encrypt archived request files saved on disk.
+For more information, see xref:n1ql-manage/query-encryption-at-rest.adoc[Encryption at Rest for Query Service]. 
 
 [#sys-history-view]
 === View Archived Requests

--- a/modules/n1ql/pages/n1ql-manage/monitoring-n1ql-query.adoc
+++ b/modules/n1ql/pages/n1ql-manage/monitoring-n1ql-query.adoc
@@ -922,10 +922,8 @@ SELECT * FROM system:completed_requests_history;
 --
 ====
 
-NOTE: Because the Query Service stores archived requests in GZIP files, 
-
 NOTE: The `system:completed_requests_history` keyspace provides {sqlpp} access to the archived files. 
-However, because these files are external GZIP archives, query performance is limited - 
+However, because these files are external GZIP archives, query performance is limited;
 especially when querying large histories on multi-node clusters. 
 In such cases, reading the files directly using the CLI is more efficient. 
 

--- a/modules/n1ql/pages/n1ql-manage/query-encryption-at-rest.adoc
+++ b/modules/n1ql/pages/n1ql-manage/query-encryption-at-rest.adoc
@@ -10,7 +10,7 @@
 == Overview
 
 In the next major release of Couchbase Server and later, the Query Service provides xref:learn:security/native-encryption-at-rest-overview.adoc[Encryption at Rest] to protect data written to disk.
-This includes data such as temporary spill files, First Failure Data Capture (FFDC) files, and archived request files.
+This includes temporary spill files, First Failure Data Capture (FFDC) files, and archived request files.
 
 By default, encryption at rest is turned off. 
 To use this feature, you must explicitly enable it in your cluster settings and select the encryption types you want to apply.
@@ -29,19 +29,19 @@ The following table describes the supported encryption types and the data they p
 
 [cols="1,2,3", options="header"]
 |===
-| Encryption Type | Query Service Data | Description
+| Encryption Type | Data | Description
 
 .2+| Log Encryption 
 
 | First Failure Data Capture (FFDC) files
 | Encrypts diagnostic files that the Query Service creates when it detects incidents or potential failures. 
-This includes files containing information about xref:n1ql:n1ql-manage:monitoring-n1ql-query.adoc#sys-active-examples[active requests], xref:n1ql:n1ql-manage:monitoring-n1ql-query.adoc#sys-completed-get[completed requests], and xref:n1ql:1ql-manage:monitoring-n1ql-query.adoc#sys-vital-examples[system vitals].
+This includes files containing information about xref:monitoring-n1ql-query.adoc#sys-active-examples[active requests], xref:monitoring-n1ql-query.adoc#sys-completed-get[completed requests], and xref:monitoring-n1ql-query.adoc#sys-vital-examples[system vitals].
 
 | Archived Request Files
 | Encrypts files that store completed requests.
 The Query Service creates these files only when streaming of completed requests is enabled.
 
-For more information, see xref:n1ql:n1ql-manage:monitoring-n1ql-query.adoc#sys-history[Streaming Completed Requests].
+For more information, see xref:monitoring-n1ql-query.adoc#sys-history[Streaming Completed Requests].
 
 .2+| Bucket Encryption
 | Index scan backfill files
@@ -69,7 +69,21 @@ For more information about the various encryption types, see xref:learn:security
 To check the encryption status on the Query Service, use the xref:n1ql-rest-admin:index.adoc#get_encryption_at_rest[Encryption-at-Rest REST API].
 The API returns an object that lists the data encryption keys (DEKs) currently in use to encrypt data. 
 
-== Decrypt Encrypted Files
+For example, to get the encryption status, use:
 
-To decrypt First Failure Data Capture (FFDC) files and archived request files, use the xref:cli:cbcat.adoc[cbcat] command line tool.
+[source,sh]
+----
+curl -u $USER:$PASSWORD $BASE_URL/admin/encryption_at_rest
+----
+
+== Decrypt and View Encrypted Files
+
+To decrypt and view First Failure Data Capture (FFDC) files and archived request files, use the xref:cli:cbcat.adoc[cbcat] command line tool.
+
+For example, to get the archived requests in `$FILE` encrypted with the master password `$MASTER`, use:
+
+[source,sh]
+----
+cbcat --password $MASTER $FILE
+----
 

--- a/modules/n1ql/pages/n1ql-manage/query-encryption-at-rest.adoc
+++ b/modules/n1ql/pages/n1ql-manage/query-encryption-at-rest.adoc
@@ -1,4 +1,5 @@
 = Encryption at Rest for Query Service
+:navtitle: Encryption at Rest
 :description: Learn how the Query Service encrypts data at rest and the types of data it can encrypt.
 :page-topic-type: concept
 :page-edition: Enterprise Edition
@@ -87,3 +88,5 @@ For example, to get the archived requests in `$FILE` encrypted with the master p
 cbcat --password $MASTER $FILE
 ----
 
+TIP: You can find FFDC and archived request files in the Couchbase Server `logs` directory.
+For the directory path, see xref:manage:manage-logging/manage-logging.adoc[].

--- a/modules/n1ql/pages/n1ql-manage/query-encryption-at-rest.adoc
+++ b/modules/n1ql/pages/n1ql-manage/query-encryption-at-rest.adoc
@@ -35,26 +35,26 @@ The following table describes the supported encryption types and the data they p
 
 | First Failure Data Capture (FFDC) files
 | Encrypts diagnostic files that the Query Service creates when it detects incidents or potential failures. 
-This includes files containing information about xref:monitoring-n1ql-query.adoc#sys-active-examples[active requests], xref:monitoring-n1ql-query.adoc#sys-completed-get[completed requests], and xref:monitoring-n1ql-query.adoc#sys-vital-examples[system vitals].
+This includes files containing information about xref:n1ql:n1ql-manage/monitoring-n1ql-query.adoc#sys-active-examples[active requests], xref:n1ql:n1ql-manage/monitoring-n1ql-query.adoc#sys-completed-get[completed requests], and xref:n1ql:n1ql-manage/monitoring-n1ql-query.adoc#sys-vital-examples[system vitals].
 
 | Archived Request Files
 | Encrypts files that store completed requests.
 The Query Service creates these files only when streaming of completed requests is enabled.
 
-For more information, see xref:monitoring-n1ql-query.adoc#sys-history[Streaming Completed Requests].
+For more information, see xref:n1ql:n1ql-manage/monitoring-n1ql-query.adoc#sys-history[Streaming Completed Requests].
 
 .2+| Bucket Encryption
 | Index scan backfill files
 | Encrypts temporary files created during index scans on a bucket. 
 The Query Service creates these files when scan results exceed the capacity of the buffered channel between the Index Service client and the Query Service.
 
-For more information, see xref:indexes:storage-modes.html#encryption-at-rest[Encryption at Rest for GSI].
+For more information, see xref:indexes:storage-modes.adoc#encryption-at-rest[Encryption at Rest for GSI].
 
 
 | Sequential Scan Files
 | Encrypts temporary files that the Query Service creates during sequential scans on a bucket.
 
-For more information, see xref:indexes:storage-modes.html#encryption-at-rest[Encryption at Rest for GSI].
+For more information, see xref:indexes:storage-modes.adoc#encryption-at-rest[Encryption at Rest for GSI].
 
 
 | Other Encryption
@@ -66,7 +66,7 @@ For more information about the various encryption types, see xref:learn:security
 
 == Get Encryption Status
 
-To check the encryption status on the Query Service, use the xref:n1ql-rest-admin:index.adoc#get_encryption_at_rest[Encryption-at-Rest REST API].
+To check the encryption status on the Query Service, use the xref:n1ql-rest-admin:index.adoc#get_encryption_at_rest[Retrieve Encryption-At-Rest Information] endpoint from the Query Admin REST API.
 The API returns an object that lists the data encryption keys (DEKs) currently in use to encrypt data. 
 
 For example, to get the encryption status, use:

--- a/modules/n1ql/pages/n1ql-manage/query-encryption-at-rest.adoc
+++ b/modules/n1ql/pages/n1ql-manage/query-encryption-at-rest.adoc
@@ -18,7 +18,7 @@ For more information about how to enable encryption, see the xref:link[Enabling 
 // TODO: Add a link to the relevant doc. 
 
 When enabled, the Query Service generates a unique Data Encryption Key (DEK) for each data type and uses it to encrypt that data before writing it to disk.
-For more information about DEKs, see the xref:link[Data Encryption Key].
+For more information about DEKs, see xref:link[Data Encryption Key].
 
 // TODO: Add a link to the relevant doc.
 
@@ -37,7 +37,6 @@ The following table describes the supported encryption types and the data they p
 | First Failure Data Capture (FFDC) files
 | Encrypts diagnostic files that the Query Service creates when it detects incidents or potential failures. 
 This includes files containing information about xref:n1ql-manage:monitoring-n1ql-query.adoc#sys-active-examples[active requests], xref:n1ql-manage:monitoring-n1ql-query.adoc#sys-completed-get[completed requests], and xref:n1ql-manage:monitoring-n1ql-query.adoc#sys-vital-examples[system vitals].
-
 
 | Archived Request Files
 | Encrypts files that store completed requests.

--- a/modules/n1ql/pages/n1ql-manage/query-encryption-at-rest.adoc
+++ b/modules/n1ql/pages/n1ql-manage/query-encryption-at-rest.adoc
@@ -1,26 +1,25 @@
 = Encryption at Rest for Query Service
 :description: Learn how the Query Service protects data using encryption at rest and the types of data it can encrypt.
 :page-topic-type: concept
+:page-edition: Enterprise Edition
+// :page-status: Couchbase Server <version>
 
 [abstract]
 {description}
 
 == Overview
 
-In Couchbase Server 8.1 and later, the Query Service provides xref:link[Encryption at Rest] to protect data written to disk.
+In the next major release of Couchbase Server and later, the Query Service provides xref:learn:security/native-encryption-at-rest-overview.adoc[Encryption at Rest] to protect data written to disk.
 This includes temporary spill files, First Failure Data Capture (FFDC) files, and archived request files.
 
-To use encryption, you must explicitly enable it in your cluster configuration and select the encryption types you want to apply.
-By default, this feature is turned off. 
-You can enable it through the Couchbase Server Web Console or REST API.
-For more information about how to enable encryption, see the xref:link[Enabling Encryption].
+By default, encryption at rest is turned off. 
+To use this feature, you must explicitly enable it in your cluster settings and select the encryption types you want to apply.
+You can enable encryption through the Couchbase Server Web Console or REST API.
+For more information, see xref:manage:manage-security/encrypt-data-at-rest.adoc[Enable Encryption].
 
-// TODO: Add a link to the relevant doc. 
-
-When enabled, the Query Service generates a unique Data Encryption Key (DEK) for each data type and uses it to encrypt that data before writing it to disk.
-For more information about DEKs, see xref:link[Data Encryption Key].
-
-// TODO: Add a link to the relevant doc.
+NOTE: The Query Service uses data encryption keys (DEKs) to encrypt data.
+Therefore, before enabling encryption, you must configure a Key Encryption Key (KEK) or Key Management System (KMS) to manage the DEKs.
+For more information, see xref:learn:security/encryption-at-rest-keys.adoc[Encryption at Rest Keys].
 
 == Supported Encryption Types
 
@@ -45,18 +44,21 @@ For more information, see xref:n1ql-manage:monitoring-n1ql-query.adoc#sys-histor
 
 .2+| Bucket Encryption
 | Index scan backfill files
-| Encrypts temporary files created during index scans associated with a bucket. 
-These files are created when scan results exceed the capacity of the buffered channel between the Index Service client and the Query Service.
+| Encrypts temporary files created during index scans on a bucket. 
+The Query Service creates these files when scan results exceed the capacity of the buffered channel between the Index Service client and the Query Service.
 For more information, see xref:link[Encryption at Rest for GSI].
 
+// TODO: Add link
+
 | Sequential Scan Files
-| Encrypts temporary files created during sequential scans over a bucket.
+| Encrypts temporary files that the Query Service creates during sequential scans on a bucket.
 
 | Other Encryption
 | Transient query files
-| Encrypts temporary spill files used to store transient data during query processing.
-For example, files created for spilled sorting operation. 
+| Encrypts temporary spill files used to store transient data during query processing, such as files created for spilled sorting operation. 
 |===
+
+For more information about the various encryption types, see xref:learn:security/native-encryption-at-rest-overview.adoc[Encryption at Rest Overview].
 
 == View Encryption Status
 
@@ -74,8 +76,11 @@ The DEK list indicates the encryption state:
 
 == Decrypt Encrypted Files
 
-You can decrypt encrypted FFDC and archived request files using the `cbcat` CLI tool.
+You can decrypt encrypted FFDC and archived request files using the xref:link[cbcat CLI tool].
 
-For more information, see the xref:cli:cbcat.adoc[cbcat CLI reference page].
+[source,sh]
+----
+cbcat <add an example>
+----
 
-//TODO: Add a link to the cbcat tool. Also include a few lines about the possible options. 
+//TODO: Add a link to the cbcat tool and a few lines about the tool usage. 

--- a/modules/n1ql/pages/n1ql-manage/query-encryption-at-rest.adoc
+++ b/modules/n1ql/pages/n1ql-manage/query-encryption-at-rest.adoc
@@ -35,13 +35,13 @@ The following table describes the supported encryption types and the data they p
 
 | First Failure Data Capture (FFDC) files
 | Encrypts diagnostic files that the Query Service creates when it detects incidents or potential failures. 
-This includes files containing information about xref:n1ql-manage:monitoring-n1ql-query.adoc#sys-active-examples[active requests], xref:n1ql-manage:monitoring-n1ql-query.adoc#sys-completed-get[completed requests], and xref:n1ql-manage:monitoring-n1ql-query.adoc#sys-vital-examples[system vitals].
+This includes files containing information about xref:n1ql:n1ql-manage:monitoring-n1ql-query.adoc#sys-active-examples[active requests], xref:n1ql:n1ql-manage:monitoring-n1ql-query.adoc#sys-completed-get[completed requests], and xref:n1ql:1ql-manage:monitoring-n1ql-query.adoc#sys-vital-examples[system vitals].
 
 | Archived Request Files
 | Encrypts files that store completed requests.
 The Query Service creates these files only when streaming of completed requests is enabled.
 
-For more information, see xref:n1ql-manage:monitoring-n1ql-query.adoc#sys-history[Streaming Completed Requests].
+For more information, see xref:n1ql:n1ql-manage:monitoring-n1ql-query.adoc#sys-history[Streaming Completed Requests].
 
 .2+| Bucket Encryption
 | Index scan backfill files

--- a/modules/n1ql/pages/n1ql-manage/query-encryption-at-rest.adoc
+++ b/modules/n1ql/pages/n1ql-manage/query-encryption-at-rest.adoc
@@ -1,0 +1,33 @@
+= Encryption at Rest for Query Service
+:description: Encryption at Rest for Query Service
+:page-topic-type: concept
+
+
+[abstract]
+{description}
+
+== Overview
+
+== Types of Encryption 
+
+== View Encryption Status
+
+You can use the xref:link[Query Admin REST API] to check the encryption status of a Query Service node. 
+
+The API returns an object that lists the data encryption keys (DEKs) currently in use to encrypt data. 
+Each DEK is identified by a unique DEK ID. 
+
+The DEK list indicates the encryption state:
+
+* Encryption enabled: The list includes one or more non-empty DEK IDs. 
+* Unencrypted files present: The list includes the special key ID `""` (an empty string).
+
+//TODO: Add a link to the Query Admin REST API endpoint and include an example here.
+
+== Decrypt Encrypted Files
+
+You can decrypt encrypted FFDC and archived request files using the `cbcat` CLI tool.
+
+For more information, see the xref:cli:cbcat.adoc[cbcat CLI reference page].
+
+//TODO: Add a link to the cbcat tool and also include a few lines the possible options and how to use them to decrypt files.

--- a/modules/n1ql/pages/n1ql-manage/query-encryption-at-rest.adoc
+++ b/modules/n1ql/pages/n1ql-manage/query-encryption-at-rest.adoc
@@ -1,5 +1,5 @@
 = Encryption at Rest for Query Service
-:description: Learn how the Query Service protects data using encryption at rest and the types of data it can encrypt.
+:description: Learn how the Query Service encrypts data at rest and the types of data it can encrypt.
 :page-topic-type: concept
 :page-edition: Enterprise Edition
 // :page-status: Couchbase Server <version>
@@ -15,11 +15,11 @@ This includes data such as temporary spill files, First Failure Data Capture (FF
 By default, encryption at rest is turned off. 
 To use this feature, you must explicitly enable it in your cluster settings and select the encryption types you want to apply.
 You can enable encryption through the Couchbase Server Web Console or REST API.
-For more information, see xref:manage:manage-security/encrypt-data-at-rest.adoc[Enable Encryption].
+For more information, see xref:manage:manage-security/encrypt-data-at-rest.adoc[Encrypt Data at Rest].
 
 NOTE: The Query Service uses data encryption keys (DEKs) to encrypt data.
 Therefore, before enabling encryption, you must configure a Key Encryption Key (KEK) or Key Management System (KMS) to manage the DEKs.
-For more information, see xref:learn:security/encryption-at-rest-keys.adoc[Encryption at Rest Keys].
+For more information, see xref:learn:security/encryption-at-rest-keys.adoc[Encryption-at-Rest Keys].
 
 == Supported Encryption Types
 
@@ -40,47 +40,35 @@ This includes files containing information about xref:n1ql-manage:monitoring-n1q
 | Archived Request Files
 | Encrypts files that store completed requests.
 The Query Service creates these files only when streaming of completed requests is enabled.
+
 For more information, see xref:n1ql-manage:monitoring-n1ql-query.adoc#sys-history[Streaming Completed Requests].
 
 .2+| Bucket Encryption
 | Index scan backfill files
 | Encrypts temporary files created during index scans on a bucket. 
 The Query Service creates these files when scan results exceed the capacity of the buffered channel between the Index Service client and the Query Service.
-For more information, see xref:link[Encryption at Rest for GSI].
 
-// TODO: Add link
+For more information, see xref:indexes:storage-modes.html#encryption-at-rest[Encryption at Rest for GSI].
+
 
 | Sequential Scan Files
 | Encrypts temporary files that the Query Service creates during sequential scans on a bucket.
+
+For more information, see xref:indexes:storage-modes.html#encryption-at-rest[Encryption at Rest for GSI].
+
 
 | Other Encryption
 | Transient query files
 | Encrypts temporary spill files that store transient data during query processing, such as files created for spilled sorting operations. 
 |===
 
-For more information about the various encryption types, see xref:learn:security/native-encryption-at-rest-overview.adoc[Encryption at Rest Overview].
+For more information about the various encryption types, see xref:learn:security/native-encryption-at-rest-overview.adoc#what-encryption-at-rest-protects[What Encryption at Rest Protects].
 
-== View Encryption Status
+== Get Encryption Status
 
-You can use the xref:link[Query Admin REST API] to check the encryption status of a Query Service node. 
-
+To check the encryption status on the Query Service, use the xref:n1ql-rest-admin:index.adoc#encryption_at_rest[Encryption-at-Rest REST API].
 The API returns an object that lists the data encryption keys (DEKs) currently in use to encrypt data. 
-Each DEK is identified by a unique DEK ID. 
-
-The DEK list indicates the encryption state:
-
-* Encryption enabled: The list includes one or more non-empty DEK IDs. 
-* Unencrypted files present: The list includes the special key ID `""` (an empty string).
-
-//TODO: Add a link to the Query Admin REST API endpoint and include an example here.
 
 == Decrypt Encrypted Files
 
-You can decrypt encrypted FFDC and archived request files using the xref:link[cbcat CLI tool].
-
-[source,sh]
-----
-cbcat <add an example>
-----
-
-//TODO: Add a link to the cbcat tool and a few lines about the tool usage. 
+To decrypt First Failure Data Capture (FFDC) files and archived request files, use the xref:cli:cbcat.adoc[cbcat] command line tool.

--- a/modules/n1ql/pages/n1ql-manage/query-encryption-at-rest.adoc
+++ b/modules/n1ql/pages/n1ql-manage/query-encryption-at-rest.adoc
@@ -1,14 +1,63 @@
 = Encryption at Rest for Query Service
-:description: Encryption at Rest for Query Service
+:description: Learn how the Query Service protects data using encryption at rest and the types of data it can encrypt.
 :page-topic-type: concept
-
 
 [abstract]
 {description}
 
 == Overview
 
-== Types of Encryption 
+In Couchbase Server 8.1 and later, the Query Service provides xref:link[Encryption at Rest] to protect data written to disk.
+This includes temporary spill files, First Failure Data Capture (FFDC) files, and archived request files.
+
+To use encryption, you must explicitly enable it in your cluster configuration and select the encryption types you want to apply.
+By default, this feature is turned off. 
+You can enable it through the Couchbase Server Web Console or REST API.
+For more information about how to enable encryption, see the xref:link[Enabling Encryption].
+
+// TODO: Add a link to the relevant doc. 
+
+When enabled, the Query Service generates a unique Data Encryption Key (DEK) for each data type and uses it to encrypt that data before writing it to disk.
+For more information about DEKs, see the xref:link[Data Encryption Key].
+
+// TODO: Add a link to the relevant doc.
+
+== Supported Encryption Types
+
+Depending on the encryption types you enable, the Query Service encrypts different types of data. 
+
+The following table describes the supported encryption types and the data they protect:
+
+[cols="1,2,3", options="header"]
+|===
+| Encryption Type | Query Service Data | Description
+
+.2+| Log Encryption 
+
+| First Failure Data Capture (FFDC) files
+| Encrypts diagnostic files that the Query Service creates when it detects incidents or potential failures. 
+This includes files containing information about xref:n1ql-manage:monitoring-n1ql-query.adoc#sys-active-examples[active requests], xref:n1ql-manage:monitoring-n1ql-query.adoc#sys-completed-get[completed requests], and xref:n1ql-manage:monitoring-n1ql-query.adoc#sys-vital-examples[system vitals].
+
+
+| Archived Request Files
+| Encrypts files that store completed requests.
+The Query Service creates these files only when streaming of completed requests is enabled.
+For more information, see xref:n1ql-manage:monitoring-n1ql-query.adoc#sys-history[Streaming Completed Requests].
+
+.2+| Bucket Encryption
+| Index scan backfill files
+| Encrypts temporary files created during index scans associated with a bucket. 
+These files are created when scan results exceed the capacity of the buffered channel between the Index Service client and the Query Service.
+For more information, see xref:link[Encryption at Rest for GSI].
+
+| Sequential Scan Files
+| Encrypts temporary files created during sequential scans over a bucket.
+
+| Other Encryption
+| Transient query files
+| Encrypts temporary spill files used to store transient data during query processing.
+For example, files created for spilled sorting operation. 
+|===
 
 == View Encryption Status
 
@@ -30,4 +79,4 @@ You can decrypt encrypted FFDC and archived request files using the `cbcat` CLI 
 
 For more information, see the xref:cli:cbcat.adoc[cbcat CLI reference page].
 
-//TODO: Add a link to the cbcat tool and also include a few lines the possible options and how to use them to decrypt files.
+//TODO: Add a link to the cbcat tool. Also include a few lines about the possible options. 

--- a/modules/n1ql/pages/n1ql-manage/query-encryption-at-rest.adoc
+++ b/modules/n1ql/pages/n1ql-manage/query-encryption-at-rest.adoc
@@ -66,9 +66,10 @@ For more information about the various encryption types, see xref:learn:security
 
 == Get Encryption Status
 
-To check the encryption status on the Query Service, use the xref:n1ql-rest-admin:index.adoc#encryption_at_rest[Encryption-at-Rest REST API].
+To check the encryption status on the Query Service, use the xref:n1ql-rest-admin:index.adoc#get_encryption_at_rest[Encryption-at-Rest REST API].
 The API returns an object that lists the data encryption keys (DEKs) currently in use to encrypt data. 
 
 == Decrypt Encrypted Files
 
 To decrypt First Failure Data Capture (FFDC) files and archived request files, use the xref:cli:cbcat.adoc[cbcat] command line tool.
+

--- a/modules/n1ql/pages/n1ql-manage/query-encryption-at-rest.adoc
+++ b/modules/n1ql/pages/n1ql-manage/query-encryption-at-rest.adoc
@@ -10,7 +10,7 @@
 == Overview
 
 In the next major release of Couchbase Server and later, the Query Service provides xref:learn:security/native-encryption-at-rest-overview.adoc[Encryption at Rest] to protect data written to disk.
-This includes temporary spill files, First Failure Data Capture (FFDC) files, and archived request files.
+This includes data such as temporary spill files, First Failure Data Capture (FFDC) files, and archived request files.
 
 By default, encryption at rest is turned off. 
 To use this feature, you must explicitly enable it in your cluster settings and select the encryption types you want to apply.
@@ -55,7 +55,7 @@ For more information, see xref:link[Encryption at Rest for GSI].
 
 | Other Encryption
 | Transient query files
-| Encrypts temporary spill files used to store transient data during query processing, such as files created for spilled sorting operation. 
+| Encrypts temporary spill files that store transient data during query processing, such as files created for spilled sorting operations. 
 |===
 
 For more information about the various encryption types, see xref:learn:security/native-encryption-at-rest-overview.adoc[Encryption at Rest Overview].

--- a/modules/n1ql/partials/nav.adoc
+++ b/modules/n1ql/partials/nav.adoc
@@ -41,7 +41,7 @@
     *** xref:manage:monitor/monitoring-indexes.adoc[]
     *** xref:manage:manage-indexes/manage-indexes.adoc[]
     *** xref:n1ql:n1ql-manage/query-settings.adoc[]
-    *** xref:n1ql:n1ql-manage/query-encryption-at-rest.adoc[Encryption at Rest]
+    *** xref:n1ql:n1ql-manage/query-encryption-at-rest.adoc[]
   ** xref:n1ql:n1ql-language-reference/index.adoc[]
     *** xref:n1ql:n1ql-language-reference/conventions.adoc[]
     *** xref:n1ql:n1ql-language-reference/reservedwords.adoc[]

--- a/modules/n1ql/partials/nav.adoc
+++ b/modules/n1ql/partials/nav.adoc
@@ -41,6 +41,7 @@
     *** xref:manage:monitor/monitoring-indexes.adoc[]
     *** xref:manage:manage-indexes/manage-indexes.adoc[]
     *** xref:n1ql:n1ql-manage/query-settings.adoc[]
+    *** xref:n1ql:n1ql-manage/query-encryption-at-rest.adoc[Encryption at Rest]
   ** xref:n1ql:n1ql-language-reference/index.adoc[]
     *** xref:n1ql:n1ql-language-reference/conventions.adoc[]
     *** xref:n1ql:n1ql-language-reference/reservedwords.adoc[]


### PR DESCRIPTION
Jira: DOC-14244

Doc updates for Encryption at Rest for Query Service. 

Docs Preview: 

- [Encryption at Rest for Query Service](https://preview.docs-test.couchbase.com/docs-devex-DOC-14244-query-encryption-at-rest/server/current/n1ql/n1ql-manage/query-encryption-at-rest.html)
- [Stream Completed Requests > Archived Request Files](https://preview.docs-test.couchbase.com/docs-devex-DOC-14244-query-encryption-at-rest/server/current/n1ql/n1ql-manage/monitoring-n1ql-query.html#sys-history-files)

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.

> [!NOTE]
> The links may not resolve to the correct sections at the moment. Will review and verify the links during the next round of reviews on the main [DOC-13938-encryption-at-rest](https://github.com/couchbaselabs/docs-devex/tree/DOC-13938-encryption-at-rest) feature branch. 