### PR TITLE
[DOC-13813] Encryption at Rest - Search Service Updates

### DIFF
--- a/modules/search/pages/search-index-architecture.adoc
+++ b/modules/search/pages/search-index-architecture.adoc
@@ -68,6 +68,38 @@ The persister and merger interact to continuously flush and merge new in-memory 
 Segments are marked as stale when they're replaced by a new merged segment created by the merger. 
 Stale segments are deleted when they're no longer used by any new queries. 
 
+[#encryption]
+== Search Index Encryption
+
+[.status]#Couchbase Server 8.1#
+
+From Couchbase Server version 8.1 and later, if you xref:[enable encryption at rest] on your cluster, the Search Service encrypts any files related to your Search indexes that contain indirect or direct references to user data. 
+// Fill in link!
+These references to user data include: 
+
+* Any document field names.
+* Any stored data from document fields.
+* Any terms derived from field data. 
+* Term frequencies and locations.
+
+Any files that contain these references are encrypted.
+These files can include: 
+
+* Log files
+* Recovery plan files
+* Index definition files
+* Index metadata files
+* Index segment files
+
+NOTE: For a Search query, data is always held in-memory and not written to disk.
+The Search Service does not encrypt the contents of a query, and only decrypts data as needed to return search results.
+
+During a rebalance, encrypted data remains encrypted.
+The key files necessary to decrypt Search data are copied into a temporary directory until the rebalance completes.
+
+For more information about encryption at rest in Couchbase Server, see xref:[].
+// Fill in link!
+
 == Search Request Processing 
 
 The Search Service uses a scatter-gather process for running all Search queries, when there are multiple nodes in the cluster running the Search Service.

--- a/modules/search/pages/search-index-architecture.adoc
+++ b/modules/search/pages/search-index-architecture.adoc
@@ -73,8 +73,7 @@ Stale segments are deleted when they're no longer used by any new queries.
 
 // [.status]#Couchbase Server 8.1#
 
-From the next major release of Couchbase Server and later, if you xref:[enable encryption at rest] on your cluster, the Search Service encrypts any files related to your Search indexes that contain indirect or direct references to user data. 
-// Fill in link!
+From the next major release of Couchbase Server and later, if you xref:manage:manage-security/encrypt-data-at-rest.adoc[enable encryption at rest] on your cluster, the Search Service encrypts any files related to your Search indexes that contain indirect or direct references to user data. 
 These references to user data include: 
 
 * Any document field names.
@@ -97,8 +96,7 @@ The Search Service does not encrypt the contents of a query, and only decrypts d
 During a rebalance, encrypted data remains encrypted.
 The key files necessary to decrypt Search data are copied into a temporary directory until the rebalance completes.
 
-For more information about encryption at rest in Couchbase Server, see xref:[].
-// Fill in link!
+For more information about encryption at rest in Couchbase Server, see xref:learn:security:native-encryption-at-rest-overview.adoc[].
 
 == Search Request Processing 
 

--- a/modules/search/pages/search-index-architecture.adoc
+++ b/modules/search/pages/search-index-architecture.adoc
@@ -71,9 +71,9 @@ Stale segments are deleted when they're no longer used by any new queries.
 [#encryption]
 == Search Index Encryption
 
-[.status]#Couchbase Server 8.1#
+// [.status]#Couchbase Server 8.1#
 
-From Couchbase Server version 8.1 and later, if you xref:[enable encryption at rest] on your cluster, the Search Service encrypts any files related to your Search indexes that contain indirect or direct references to user data. 
+From the next major release of Couchbase Server and later, if you xref:[enable encryption at rest] on your cluster, the Search Service encrypts any files related to your Search indexes that contain indirect or direct references to user data. 
 // Fill in link!
 These references to user data include: 
 

--- a/modules/search/pages/search-index-architecture.adoc
+++ b/modules/search/pages/search-index-architecture.adoc
@@ -73,7 +73,7 @@ Stale segments are deleted when they're no longer used by any new queries.
 
 // [.status]#Couchbase Server 8.1#
 
-From the next major release of Couchbase Server and later, if you xref:manage:manage-security/encrypt-data-at-rest.adoc[enable encryption at rest] on your cluster, the Search Service encrypts any files related to your Search indexes that contain indirect or direct references to user data. 
+From the next major release of Couchbase Server, if you xref:manage:manage-security/encrypt-data-at-rest.adoc[enable encryption at rest] on your cluster, the Search Service encrypts any files related to your Search indexes that contain indirect or direct references to user data. 
 These references to user data include: 
 
 * Any document field names.

--- a/modules/search/pages/search.adoc
+++ b/modules/search/pages/search.adoc
@@ -51,6 +51,9 @@ You can create a Search index:
 As of Couchbase Server version 8.0, you can also add synonym collections to your cluster and Search index to run synonym searches on text fields.
 For more information about synonym searches, see xref:synonyms/synonyms-search.adoc[].
 
+If your cluster is running Couchbase Server version 8.1 or later, the Search Service encrypts all direct or indirect references to your data in Search index files, using an AES-256-GCM encryption algorithm.
+For more information about encryption in Search, see xref:search-index-architecture.adoc#encryption[Search Index Encryption] or xref:vector-search-index-architecture.adoc#encryption[Search Vector Index Encryption].
+
 [#queries]
 == Search Queries 
 

--- a/modules/search/pages/search.adoc
+++ b/modules/search/pages/search.adoc
@@ -51,7 +51,7 @@ You can create a Search index:
 As of Couchbase Server version 8.0, you can also add synonym collections to your cluster and Search index to run synonym searches on text fields.
 For more information about synonym searches, see xref:synonyms/synonyms-search.adoc[].
 
-If your cluster is running Couchbase Server version 8.1 or later, the Search Service encrypts all direct or indirect references to your data in Search index files, using an AES-256-GCM encryption algorithm.
+If your cluster is running the next major release of Couchbase Server or later, the Search Service encrypts all direct or indirect references to your data in Search index files, using an AES-256-GCM encryption algorithm.
 For more information about encryption in Search, see xref:search-index-architecture.adoc#encryption[Search Index Encryption] or xref:vector-search-index-architecture.adoc#encryption[Search Vector Index Encryption].
 
 [#queries]

--- a/modules/vector-search/pages/vector-search-index-architecture.adoc
+++ b/modules/vector-search/pages/vector-search-index-architecture.adoc
@@ -151,14 +151,12 @@ Vector Search uses both 8bit and 4bit scalar quantization for indexes, based on 
 
 //[.status]#Couchbase Server 8.1#
 
-From the next major release of Couchbase Server and later, if you xref:[enable encryption at rest] on your cluster, the Search Service encrypts any files related to your Search Vector indexes that contain indirect or direct references to user data. 
-// Fill in link!
+From the next major release of Couchbase Server and later, if you xref:manage:manage-security/encrypt-data-at-rest.adoc[enable encryption at rest] on your cluster, the Search Service encrypts any files related to your Search Vector indexes that contain indirect or direct references to user data. 
 
 The Search Service encrypts the same data and files for Search Vector indexes as xref:search:search-index-architecture.adoc#encryption[Search indexes].
 For Search Vector indexes, the entire FAISS index and your vector to document mappings are encrypted.
 
-For more information about encryption at rest in Couchbase Server, see xref:[].
-// Fill in link!
+For more information about encryption at rest in Couchbase Server, see xref:learn:security:native-encryption-at-rest-overview.adoc[].
 
 == Search Request Processing 
 

--- a/modules/vector-search/pages/vector-search-index-architecture.adoc
+++ b/modules/vector-search/pages/vector-search-index-architecture.adoc
@@ -146,6 +146,20 @@ Scalar quantization in Vector Search does not have a significant effect on the r
 
 Vector Search uses both 8bit and 4bit scalar quantization for indexes, based on your xref:search:child-field-options-reference.adoc#optimized[Optimized For] setting.
 
+[#encryption]
+== Search Vector Index Encryption
+
+[.status]#Couchbase Server 8.1#
+
+From Couchbase Server version 8.1 and later, if you xref:[enable encryption at rest] on your cluster, the Search Service encrypts any files related to your Search Vector indexes that contain indirect or direct references to user data. 
+// Fill in link!
+
+The Search Service encrypts the same data and files for Search Vector indexes as xref:search:search-index-architecture.adoc#encryption[Search indexes].
+For Search Vector indexes, the entire FAISS index and your vector to document mappings are encrypted.
+
+For more information about encryption at rest in Couchbase Server, see xref:[].
+// Fill in link!
+
 == Search Request Processing 
 
 The Search Service uses a scatter-gather process for running all Search queries, when there are multiple nodes in the cluster running the Search Service.

--- a/modules/vector-search/pages/vector-search-index-architecture.adoc
+++ b/modules/vector-search/pages/vector-search-index-architecture.adoc
@@ -151,7 +151,7 @@ Vector Search uses both 8bit and 4bit scalar quantization for indexes, based on 
 
 //[.status]#Couchbase Server 8.1#
 
-From the next major release of Couchbase Server and later, if you xref:manage:manage-security/encrypt-data-at-rest.adoc[enable encryption at rest] on your cluster, the Search Service encrypts any files related to your Search Vector indexes that contain indirect or direct references to user data. 
+From the next major release of Couchbase Server, if you xref:manage:manage-security/encrypt-data-at-rest.adoc[enable encryption at rest] on your cluster, the Search Service encrypts any files related to your Search Vector indexes that contain indirect or direct references to user data. 
 
 The Search Service encrypts the same data and files for Search Vector indexes as xref:search:search-index-architecture.adoc#encryption[Search indexes].
 For Search Vector indexes, the entire FAISS index and your vector to document mappings are encrypted.

--- a/modules/vector-search/pages/vector-search-index-architecture.adoc
+++ b/modules/vector-search/pages/vector-search-index-architecture.adoc
@@ -149,9 +149,9 @@ Vector Search uses both 8bit and 4bit scalar quantization for indexes, based on 
 [#encryption]
 == Search Vector Index Encryption
 
-[.status]#Couchbase Server 8.1#
+//[.status]#Couchbase Server 8.1#
 
-From Couchbase Server version 8.1 and later, if you xref:[enable encryption at rest] on your cluster, the Search Service encrypts any files related to your Search Vector indexes that contain indirect or direct references to user data. 
+From the next major release of Couchbase Server and later, if you xref:[enable encryption at rest] on your cluster, the Search Service encrypts any files related to your Search Vector indexes that contain indirect or direct references to user data. 
 // Fill in link!
 
 The Search Service encrypts the same data and files for Search Vector indexes as xref:search:search-index-architecture.adoc#encryption[Search indexes].


### PR DESCRIPTION
Making some updates to the Search documentation to add in info about encryption at rest for the early release. 

Version number still needs to be finalized, so that's why some stuff is just commented out. 

Preview links: 

* https://preview.docs-test.couchbase.com/docs-devex-DOC-13813-fts-encryption-at-rest/server/current/search/search.html#indexes 

* https://preview.docs-test.couchbase.com/docs-devex-DOC-13813-fts-encryption-at-rest/server/current/search/search-index-architecture.html#encryption

* https://preview.docs-test.couchbase.com/docs-devex-DOC-13813-fts-encryption-at-rest/server/current/vector-search/vector-search-index-architecture.html#encryption

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.