### PR TITLE
DOC-10322: Index Order Performance

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
@@ -244,6 +244,16 @@ The index key is sorted in descending order.
 
 This clause is optional; if omitted, the default is `ASC`.
 
+[TIP]
+====
+If any queries that use this index include an ordering term on the same field as this index key, the sort order of the ordering term should match the sort order of the index key to ensure the best performance.
+
+For example, if the index uses a descending sort order, then the query should also use a descending sort order.
+If the query uses the opposite sort order to the index, you may experience reduced performance.
+
+If necessary, you could create two indexes that are identical except for opposite sort orders, and then use an index hint in the query to select the appropriate index.
+====
+
 [[include-missing]]
 ==== INCLUDE MISSING Clause
 

--- a/modules/n1ql/pages/n1ql-language-reference/orderby.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/orderby.adoc
@@ -48,6 +48,16 @@ The collation clause determines the order of the search.
 
 If the collation clause is missing, the default is `ASC`.
 
+[TIP]
+====
+If this query uses an index which includes an index key on the same field as this ordering term, the sort order of the ordering term should match the sort order of the index key to ensure the best performance.
+
+For example, if the index uses a descending sort order, then the query should also use a descending sort order.
+If the query uses the opposite sort order to the index, you may experience reduced performance.
+
+If necessary, you could create two indexes that are identical except for opposite sort orders, and then use an index hint in the query to select the appropriate index.
+====
+
 [[nulls-ordering]]
 === Nulls Ordering
 


### PR DESCRIPTION
Jira ticket: DOC-10322

Backlog reduction. Added tip to state that the sort order (`ASC` or `DESC`) of ordering term in the query should match the sort order of index key in the index. I don't know if this restriction still applies in more recent versions?

Preview docs:
- [CREATE INDEX › Index Order](https://preview.docs-test.couchbase.com/docs-devex-DOC-10322-index-order/server/current/n1ql/n1ql-language-reference/createindex.html#index-order)
- [ORDER BY › Collation](https://preview.docs-test.couchbase.com/docs-devex-DOC-10322-index-order/server/current/n1ql/n1ql-language-reference/orderby.html#collation)

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.