### PR TITLE
DOC-14492: PlantUML diagrams have CSS warnings

### DIFF
--- a/modules/indexes/partials/diagrams/query-execution.puml
+++ b/modules/indexes/partials/diagrams/query-execution.puml
@@ -1,10 +1,18 @@
 @startuml query_execution
 
+<style>
+  /* Specific styles for a sequence diagram */
+  sequenceDiagram {
+    participant {
+      Padding: 10;
+    }
+  }
+</style>
+
 skinparam maxMessageSize 125
 skinparam roundcorner 5
 skinparam responseMessageBelowArrow true
 skinparam sequenceMessageAlign right
-skinparam ParticipantPadding 10
 skinparam BoxPadding 60
 skinparam box {
 BackgroundColor PaleGreen

--- a/modules/vector-index/partials/composite-vector-app-workflow.puml
+++ b/modules/vector-index/partials/composite-vector-app-workflow.puml
@@ -1,5 +1,19 @@
 @startuml ai-app-workflow
 
+<style>
+  /* Global style applied to all elements */
+  element {
+    Padding: 2;
+  }
+
+  /* Specific styles for a sequence diagram */
+  sequenceDiagram {
+    participant {
+      Padding: 10;
+    }
+  }
+</style>
+
 sprite Couchbase <svg width="98" height="98" viewBox="0 0 98 98">
 <path fill="#EC1218"
    d="m 82.1,57.6 c 0,2.9 -1.7,5.5 -5,6.1 -5.8,1 -17.9,1.6 -28.1,1.6 -10.2,0 -22.3,-0.7 -28.1,-1.6 -3.3,-0.6 -5,-3.2 -5,-6.1 V 38.4 c 0,-2.9 2.3,-5.7 5,-6.1 1.7,-0.3 5.6,-0.6 8.8,-0.6 1.2,0 2.2,0.9 2.2,2.3 V 47.3 C 37.8,47.3 43,47 49,47 c 6,0 11.2,0.3 17.2,0.3 V 34.1 c 0,-1.4 1,-2.3 2.2,-2.3 3.2,0 7.1,0.3 8.8,0.6 2.7,0.4 5,3.2 5,6.1 z M 49,0 C 21.9,0 0,21.9 0,49 0,76.1 21.9,98 49,98 76.1,98 98,76.1 98,49 98,21.9 76.1,0 49,0 Z" />
@@ -9,8 +23,6 @@ skinparam maxMessageSize 60
 skinparam roundcorner 5
 skinparam responseMessageBelowArrow true
 skinparam sequenceMessageAlign left
-skinparam ParticipantPadding 10
-skinparam Padding 2
 skinparam BoxPadding 20
 
 box Your Application #FloralWhite

--- a/modules/vector-index/partials/fts-vector-app-workflow.puml
+++ b/modules/vector-index/partials/fts-vector-app-workflow.puml
@@ -1,5 +1,19 @@
 @startuml ai-app-workflow
 
+<style>
+  /* Global style applied to all elements */
+  element {
+    Padding: 2;
+  }
+
+  /* Specific styles for a sequence diagram */
+  sequenceDiagram {
+    participant {
+      Padding: 10;
+    }
+  }
+</style>
+
 sprite Couchbase <svg width="98" height="98" viewBox="0 0 98 98">
 <path fill="#EC1218"
    d="m 82.1,57.6 c 0,2.9 -1.7,5.5 -5,6.1 -5.8,1 -17.9,1.6 -28.1,1.6 -10.2,0 -22.3,-0.7 -28.1,-1.6 -3.3,-0.6 -5,-3.2 -5,-6.1 V 38.4 c 0,-2.9 2.3,-5.7 5,-6.1 1.7,-0.3 5.6,-0.6 8.8,-0.6 1.2,0 2.2,0.9 2.2,2.3 V 47.3 C 37.8,47.3 43,47 49,47 c 6,0 11.2,0.3 17.2,0.3 V 34.1 c 0,-1.4 1,-2.3 2.2,-2.3 3.2,0 7.1,0.3 8.8,0.6 2.7,0.4 5,3.2 5,6.1 z M 49,0 C 21.9,0 0,21.9 0,49 0,76.1 21.9,98 49,98 76.1,98 98,76.1 98,49 98,21.9 76.1,0 49,0 Z" />
@@ -9,8 +23,6 @@ skinparam maxMessageSize 60
 skinparam roundcorner 5
 skinparam responseMessageBelowArrow true
 skinparam sequenceMessageAlign left
-skinparam ParticipantPadding 10
-skinparam Padding 2
 skinparam BoxPadding 50
 
 box Your Application #FloralWhite

--- a/modules/vector-index/partials/hyperscale-vector-app-workflow.puml
+++ b/modules/vector-index/partials/hyperscale-vector-app-workflow.puml
@@ -1,5 +1,19 @@
 @startuml ai-app-workflow
 
+<style>
+  /* Global style applied to all elements */
+  element {
+    Padding: 2;
+  }
+
+  /* Specific styles for a sequence diagram */
+  sequenceDiagram {
+    participant {
+      Padding: 10;
+    }
+  }
+</style>
+
 sprite Couchbase <svg width="98" height="98" viewBox="0 0 98 98">
 <path fill="#EC1218"
    d="m 82.1,57.6 c 0,2.9 -1.7,5.5 -5,6.1 -5.8,1 -17.9,1.6 -28.1,1.6 -10.2,0 -22.3,-0.7 -28.1,-1.6 -3.3,-0.6 -5,-3.2 -5,-6.1 V 38.4 c 0,-2.9 2.3,-5.7 5,-6.1 1.7,-0.3 5.6,-0.6 8.8,-0.6 1.2,0 2.2,0.9 2.2,2.3 V 47.3 C 37.8,47.3 43,47 49,47 c 6,0 11.2,0.3 17.2,0.3 V 34.1 c 0,-1.4 1,-2.3 2.2,-2.3 3.2,0 7.1,0.3 8.8,0.6 2.7,0.4 5,3.2 5,6.1 z M 49,0 C 21.9,0 0,21.9 0,49 0,76.1 21.9,98 49,98 76.1,98 98,76.1 98,49 98,21.9 76.1,0 49,0 Z" />
@@ -9,8 +23,6 @@ skinparam maxMessageSize 50
 skinparam roundcorner 5
 skinparam responseMessageBelowArrow true
 skinparam sequenceMessageAlign left
-skinparam ParticipantPadding 10
-skinparam Padding 2
 skinparam BoxPadding 20
 
 box Your Application #FloralWhite


### PR DESCRIPTION
Jira ticket: DOC-14492

PlantUML diagrams which included the `padding` and `participantPadding` skinparams are currently generated with a big  warning message, stating that these skinparams are deprecated.

This PR replaces the skinparams with CSS-like styling rules, as specified by [CSS Styles in PlantUML](https://plantuml.com/style). The style rules don't actually work, but at least they get rid of the warning message 🙄 

Preview docs:
- [SELECT › SELECT Statement processing](https://preview.docs-test.couchbase.com/docs-devex-DOC-14492-plantuml-css/server/current/n1ql/n1ql-language-reference/selectintro.html#select-statement-processing)
- [Choose the Right Vector Index](https://preview.docs-test.couchbase.com/docs-devex-DOC-14492-plantuml-css/server/current/vector-index/use-vector-indexes.html) — three diagrams on this page

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.